### PR TITLE
Configure Dart formatter to preserve trailing commas

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,3 +3,6 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   plugins:
     - custom_lint
+
+formatter:
+  trailing_commas: preserve


### PR DESCRIPTION
Adds formatter configuration to preserve trailing commas in Dart code.

This change updates `analysis_options.yaml` to include a formatter section that preserves trailing commas, which improves code readability and reduces diff noise when adding new parameters or list items.