### PR TITLE
Add Dockerfile for API documentation generation and serving

### DIFF
--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
 WORKDIR /app
 
 # Get Flutter version from .fvmrc and download Flutter SDK
-COPY ../.fvmrc .
+COPY .fvmrc .
 RUN FLUTTER_VERSION=$(jq -r .flutter .fvmrc) && \
     mkdir -p /flutter && \
     curl -fsSL "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" | \
@@ -25,7 +25,7 @@ COPY ../pubspec.* ./
 RUN flutter pub get
 
 # Copy app source code
-COPY ../ ./
+COPY . .
 
 # Generate documentation
 RUN dart doc


### PR DESCRIPTION
This PR adds a Docker-based workflow for generating and serving Dart API documentation:

- Multi-stage Dockerfile that generates docs using `dart doc` and serves them via Caddy
- Uses Flutter version from `.fvmrc` for consistency with project setup
- Debian-based builder stage (required for Flutter SDK glibc dependency)
- Lightweight Alpine-based Caddy server for serving generated docs
- Located in `doc/` directory to avoid confusion with application Dockerfile