### PR TITLE
ci: verify generated files are up-to-date in analyze workflow

### DIFF
--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -16,6 +16,11 @@ jobs:
       - name: Setup project
         uses: ./.github/actions/setup-project
 
+      - name: Verify generated files are up-to-date
+        run: |
+          dart run build_runner build --delete-conflicting-outputs
+          git diff --exit-code
+
       - name: Verify formatting
         run: dart format --output none --set-exit-if-changed .
 


### PR DESCRIPTION
Adds a step to the analyze workflow that runs `build_runner` and checks for uncommitted changes. This catches cases where someone modifies the Drift schema but forgets to regenerate the `.g.dart` files.