### PR TITLE
docs: add dependency pinning guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,21 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
 ## Branch Names
 
 Use kebab-case: `add-student-query-service`, `fix-login-crash`
+
+## Dependencies
+
+Pin exact versions (no caret `^` constraints). Renovate manages updates.
+
+```bash
+flutter pub add dio
+```
+
+Then edit `pubspec.yaml` to remove the caret:
+
+```yaml
+# Before
+dio: ^5.9.1
+
+# After
+dio: 5.9.1
+```


### PR DESCRIPTION
Document the workflow for adding dependencies with pinned versions:
- Run `flutter pub add` to get the latest version
- Edit `pubspec.yaml` to remove the caret constraint

This aligns with the Renovate configuration that uses `rangeStrategy: "pin"`.