### PR TITLE
chore: drop version pinning and reorganize Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,24 +1,24 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:best-practices",
-    "group:allNonMajor",
-    "schedule:monthly"
-  ],
+  "extends": ["config:best-practices", "schedule:monthly"],
   "timezone": "Asia/Taipei",
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "packageRules": [
-    {
-      "matchPackageNames": ["*"],
-      "rangeStrategy": "pin"
-    },
     {
       "matchPackageNames": ["dart"],
       "enabled": false
     },
     {
+      "matchManagers": ["pub"],
+      "groupName": "Flutter dependencies",
+      "groupSlug": "flutter"
+    },
+    {
       "matchManagers": ["mise"],
       "groupName": "Development tools",
-      "groupSlug": "sdk"
+      "groupSlug": "dev-tools"
     },
     {
       "matchFileNames": ["android/**"],
@@ -29,6 +29,11 @@
       "matchFileNames": ["ios/**"],
       "groupName": "iOS dependencies",
       "groupSlug": "ios"
+    },
+    {
+      "matchFileNames": [".github/**", "Gemfile", "doc/Dockerfile"],
+      "groupName": "CI dependencies",
+      "groupSlug": "ci"
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,20 +21,3 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
 
 Use kebab-case: `add-student-query-service`, `fix-login-crash`
 
-## Dependencies
-
-Pin exact versions (no caret `^` constraints). Renovate manages updates.
-
-```bash
-flutter pub add dio
-```
-
-Then edit `pubspec.yaml` to remove the caret:
-
-```yaml
-# Before
-dio: ^5.9.1
-
-# After
-dio: 5.9.1
-```

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,33 +15,33 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  cupertino_icons: 1.0.8
-  dio: 5.9.1
-  cookie_jar: 4.0.8
-  dio_cookie_manager: 3.3.0
-  html: 0.15.6
-  dio_redirect_interceptor: 1.0.1
-  collection: 1.19.1
-  intl: 0.20.2
-  flutter_svg: 2.2.3
-  drift: 2.30.1
-  drift_flutter: 0.2.8
-  path_provider: 2.1.5
-  url_launcher: 6.3.2
-  riverpod: 3.1.0
-  flutter_riverpod: 3.1.0
-  go_router: 17.1.0
-  flutter_secure_storage: 10.0.0
-  skeletonizer: 2.1.2
-  animations: 2.0.11
+  cupertino_icons: ^1.0.8
+  dio: ^5.9.1
+  cookie_jar: ^4.0.8
+  dio_cookie_manager: ^3.3.0
+  html: ^0.15.6
+  dio_redirect_interceptor: ^1.0.1
+  collection: ^1.19.1
+  intl: ^0.20.2
+  flutter_svg: ^2.2.3
+  drift: ^2.30.1
+  drift_flutter: ^0.2.8
+  path_provider: ^2.1.5
+  url_launcher: ^6.3.2
+  riverpod: ^3.1.0
+  flutter_riverpod: ^3.1.0
+  go_router: ^17.1.0
+  flutter_secure_storage: ^10.0.0
+  skeletonizer: ^2.1.2
+  animations: ^2.0.11
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: 6.0.0
-  build_runner: 2.10.5
-  drift_dev: 2.30.1
+  flutter_lints: ^6.0.0
+  build_runner: ^2.10.5
+  drift_dev: ^2.30.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary

- Switch from exact version pinning to default caret (`^`) constraints in `pubspec.yaml` — the lock file + `--enforce-lockfile` in CI already ensures reproducible builds
- Disable lock file maintenance — Renovate resolves with a different Dart SDK than our pinned Flutter 3.38.9, producing incompatible transitive dependency versions (fixes failing CI on #68)
- Replace `group:allNonMajor` with per-platform groups: Flutter, Android, iOS, CI (including Gemfile/Dockerfile), and dev tools
- Remove dependency pinning instructions from CONTRIBUTING.md