### PR TITLE
chore: preserve caret ranges for pub major updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,8 @@
     {
       "matchManagers": ["pub"],
       "groupName": "Flutter dependencies",
-      "groupSlug": "flutter"
+      "groupSlug": "flutter",
+      "rangeStrategy": "replace"
     },
     {
       "matchManagers": ["mise"],


### PR DESCRIPTION
## Summary
- Adds `rangeStrategy: "replace"` to the pub package rule in Renovate config
- Prevents Renovate from pinning exact versions on major updates (e.g., `^6.3.0` → `8.0.1`), which would cause all future minor/patch updates to also require PRs
- Major updates will now keep caret ranges (e.g., `^6.3.0` → `^8.0.1`)

## Test plan
- [ ] Rebase PR #73 after merging to verify Renovate produces `^8.0.1` instead of `8.0.1`