### PR TITLE
docs: remove FVM references from VS Code setup

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -5,19 +5,6 @@ This project uses specific VS Code configurations for consistent development exp
 ## Quick Start
 
 1. Install recommended extensions (VS Code will prompt you, or search `@recommended` in the Extensions panel)
-2. Create a `settings.json` file in the `.vscode/` directory with the configuration below
-
-## Required Configuration
-
-### `settings.json`
-
-This ensures everyone uses the same Flutter version via FVM:
-
-```json
-{
-  "dart.flutterSdkPath": ".fvm/versions/3.35.7"
-}
-```
 
 ## Optional Configuration
 


### PR DESCRIPTION
The project uses mise for Flutter SDK management, which activates via the shell and doesn't require VS Code `settings.json` configuration. Remove the outdated FVM `dart.flutterSdkPath` setup instructions.