### PR TITLE
fix: validate Content-Type in getAvatar to trigger re-auth on session timeout

### DIFF
--- a/lib/services/portal_service.dart
+++ b/lib/services/portal_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:html/parser.dart';
+import 'package:http_parser/http_parser.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:tattoo/utils/http.dart';
 
@@ -144,7 +145,8 @@ class PortalService {
     );
 
     final contentType = response.headers.value('content-type') ?? '';
-    if (!contentType.startsWith('image/')) {
+    final mediaType = MediaType.parse(contentType);
+    if (mediaType.type != 'image') {
       throw FormatException(
         'Expected image response, got Content-Type: $contentType',
       );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -462,7 +462,7 @@ packages:
     source: hosted
     version: "3.2.2"
   http_parser:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http_parser
       sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   skeletonizer: ^2.1.2
   animations: ^2.0.11
   google_fonts: ^8.0.1
+  http_parser: ^4.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
When the portal session expires, `photoView.do` returns HTTP 200 with `Content-Type: text/html` and a JSON error body instead of image bytes. Since `getAvatar` used `ResponseType.bytes`, it returned the JSON as if it were image data without throwing, so `withAuth` never triggered re-authentication.

Add a Content-Type check in `PortalService.getAvatar()` that throws `FormatException` when the response isn't `image/*`. This lets `withAuth` catch the error, re-login, and retry successfully.