### PR TITLE
fix: use center text alignment in ClearNotice

### DIFF
--- a/lib/components/notices.dart
+++ b/lib/components/notices.dart
@@ -53,7 +53,6 @@ class ClearNotice extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.center,
         spacing: 8,
@@ -65,7 +64,7 @@ class ClearNotice extends StatelessWidget {
           Flexible(
             child: Text(
               text,
-              textAlign: TextAlign.justify,
+              textAlign: TextAlign.center,
               style:
                   textStyle?.copyWith(color: resolvedColor) ??
                   TextStyle(color: resolvedColor),


### PR DESCRIPTION
Replace `TextAlign.justify` with `TextAlign.center` and remove redundant `mainAxisAlignment` on the Row.

`justify` caused wide letter-spacing with short English text. `center` reads better for both short and wrapped lines. Trade-off: the leading icon stays left-aligned in the Row rather than flowing inline with centered text, but this keeps the icon vertically centered when text wraps.

Single-line text (unchanged):
<img width="800" height="70" alt="qemu-system-aarch64 2026-02-22 at 21 07 51@2x" src="https://github.com/user-attachments/assets/bf518eb7-59f7-4b8c-b442-dc99c29acfd9" />

Wrapped text(before):
<img width="796" height="102" alt="qemu-system-aarch64 2026-02-22 at 21 11 48@2x" src="https://github.com/user-attachments/assets/0a29734e-ad20-4e14-bfc3-5c4e2fb8f92c" />

Wrapped text(after):
<img width="798" height="102" alt="qemu-system-aarch64 2026-02-22 at 21 07 03@2x" src="https://github.com/user-attachments/assets/63eefb1d-fed1-49bc-ba75-348ec621ed3e" />
