### PR TITLE
Add pull-to-refresh on profile screen

### DIFF
--- a/lib/screens/main/profile/profile_screen.dart
+++ b/lib/screens/main/profile/profile_screen.dart
@@ -15,9 +15,11 @@ class ProfileScreen extends ConsumerWidget {
 
   Future<void> _refresh(WidgetRef ref) async {
     await ref.read(authRepositoryProvider).getUser(refresh: true);
-    ref.invalidate(userProfileProvider);
-    ref.invalidate(userAvatarProvider);
-    ref.invalidate(activeRegistrationProvider);
+    await Future.wait([
+      ref.refresh(userProfileProvider.future),
+      ref.refresh(userAvatarProvider.future),
+      ref.refresh(activeRegistrationProvider.future),
+    ]);
   }
 
   Future<void> _logout(BuildContext context, WidgetRef ref) async {


### PR DESCRIPTION
Wraps the profile screen's CustomScrollView with a RefreshIndicator. On pull-to-refresh, forces a network fetch via `getUser(refresh: true)` then invalidates the three profile providers so they re-read the fresh DB data.