### PR TITLE
feat: add localized() helper for service strings

### DIFF
--- a/lib/utils/localized.dart
+++ b/lib/utils/localized.dart
@@ -1,0 +1,12 @@
+import '../i18n/strings.g.dart';
+
+/// Picks the appropriate localized string based on the current app locale.
+///
+/// NTUT services return Chinese (always) and English (sometimes). For Chinese
+/// locales, prefers [zh]; all other locales prefer [en], falling back to [zh].
+String localized(String? zh, String? en) {
+  if (LocaleSettings.currentLocale == AppLocale.zhTw) {
+    return zh ?? en ?? '';
+  }
+  return en ?? zh ?? '';
+}


### PR DESCRIPTION
## Summary
- Add `localized(zh, en)` utility that picks the appropriate string based on the current app locale
- Chinese locale prefers `zh` with `en` fallback; all other locales prefer `en` with `zh` fallback
- Designed for NTUT service DTOs that return paired Zh/En fields (e.g., `departmentZh`/`departmentEn`)

## Usage

```dart
import "package:tattoo/utils/localized.dart";

// In UI code:
Text(localized(profile.departmentZh, profile.departmentEn))
Text(localized(course.nameZh, course.nameEn))
```

## Test plan
- `flutter analyze` passes with no issues