### PR TITLE
test: add unit tests for localized and fetchWithTtl utilities

### DIFF
--- a/test/utils/fetch_with_ttl_test.dart
+++ b/test/utils/fetch_with_ttl_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tattoo/utils/fetch_with_ttl.dart';
+
+void main() {
+  const cached = 'cached';
+  const fresh = 'fresh';
+  final now = DateTime.now();
+
+  Future<String> fetchFromNetwork() async => fresh;
+
+  group('fetchWithTtl', () {
+    test('fetches from network when no cached data', () async {
+      final result = await fetchWithTtl(
+        cached: null,
+        getFetchedAt: (_) => now,
+        fetchFromNetwork: fetchFromNetwork,
+      );
+      expect(result, fresh);
+    });
+
+    test('returns cached data when fresh', () async {
+      final result = await fetchWithTtl(
+        cached: cached,
+        getFetchedAt: (_) => now.subtract(const Duration(hours: 1)),
+        fetchFromNetwork: fetchFromNetwork,
+      );
+      expect(result, cached);
+    });
+
+    test('fetches from network when stale', () async {
+      final result = await fetchWithTtl(
+        cached: cached,
+        getFetchedAt: (_) => now.subtract(const Duration(days: 30)),
+        fetchFromNetwork: fetchFromNetwork,
+      );
+      expect(result, fresh);
+    });
+
+    test('fetches from network when refresh is true', () async {
+      final result = await fetchWithTtl(
+        cached: cached,
+        getFetchedAt: (_) => now.subtract(const Duration(hours: 1)),
+        fetchFromNetwork: fetchFromNetwork,
+        refresh: true,
+      );
+      expect(result, fresh);
+    });
+
+    test('fetches from network when fetchedAt is null', () async {
+      final result = await fetchWithTtl(
+        cached: cached,
+        getFetchedAt: (_) => null,
+        fetchFromNetwork: fetchFromNetwork,
+      );
+      expect(result, fresh);
+    });
+
+    test('respects custom ttl', () async {
+      final result = await fetchWithTtl(
+        cached: cached,
+        getFetchedAt: (_) => now.subtract(const Duration(hours: 2)),
+        fetchFromNetwork: fetchFromNetwork,
+        ttl: const Duration(hours: 1),
+      );
+      expect(result, fresh);
+    });
+  });
+}

--- a/test/utils/localized_test.dart
+++ b/test/utils/localized_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tattoo/i18n/strings.g.dart';
+import 'package:tattoo/utils/localized.dart';
+
+void main() {
+  group('localized', () {
+    group('when locale is zhTw', () {
+      setUp(() async => LocaleSettings.setLocale(AppLocale.zhTw));
+
+      test('returns zh when both provided', () {
+        expect(localized('中文', 'English'), '中文');
+      });
+
+      test('falls back to en when zh is null', () {
+        expect(localized(null, 'English'), 'English');
+      });
+
+      test('returns empty string when both null', () {
+        expect(localized(null, null), '');
+      });
+    });
+
+    group('when locale is en', () {
+      setUp(() async => LocaleSettings.setLocale(AppLocale.en));
+
+      test('returns en when both provided', () {
+        expect(localized('中文', 'English'), 'English');
+      });
+
+      test('falls back to zh when en is null', () {
+        expect(localized('中文', null), '中文');
+      });
+
+      test('returns empty string when both null', () {
+        expect(localized(null, null), '');
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add unit tests for `localized()` helper (6 tests): locale preference, fallbacks, both-null case
- Add unit tests for `fetchWithTtl()` (6 tests): no cache, fresh cache, stale cache, forced refresh, null fetchedAt, custom TTL

So Copilot would shut up about having no tests.

## Test plan
- `flutter test test/utils/` — all 12 tests pass