### PR TITLE
feat(android): add per-app language support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
     <application
         android:label="tattoo"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:localeConfig="@xml/locales_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/locales_config.xml
+++ b/android/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="zh-TW" />
+    <locale android:name="en" />
+</locale-config>


### PR DESCRIPTION
## Summary

- Add `locales_config.xml` declaring `zh-TW` and `en` locales
- Reference locale config in `AndroidManifest.xml` via `android:localeConfig`

This enables the native per-app language picker on Android 13+ (Settings > Apps > Tattoo > Language), matching the iOS behavior already provided by `CFBundleLocalizations` in Info.plist.

**Trade-offs:** Android 12 and below (6.68% of users) won't see the per-app picker — they fall back to the system locale. Since most users in that group already use zh-TW as their system language, this is acceptable over building and maintaining a custom in-app locale setting.

## Test plan

- [x] Verify per-app language picker appears on Android 13+ device (screenshot attached)
- [x] Verify switching language updates the app UI
- [x] Verify iOS per-app language still works (already configured)

<img width="399" height="465" alt="qemu-system-aarch64 2026-02-25 at 17 42 37@2x" src="https://github.com/user-attachments/assets/dc7a7c97-aeaf-4226-bb3f-e962e0cb7d24" />