### PR TITLE
chore: update recommended VS Code extensions

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -5,6 +5,10 @@ This project uses specific VS Code configurations for consistent development exp
 ## Quick Start
 
 1. Install recommended extensions (VS Code will prompt you, or search `@recommended` in the Extensions panel)
+   - **Dart** (`dart-code.dart-code`) — Dart language support: analysis, debugging, code completion
+   - **Flutter** (`dart-code.flutter`) — Flutter development tools: hot reload, device management, widget inspector
+   - **Mise** (`hverlin.mise-vscode`) — Integration with [mise](https://mise.jdx.dev/) for tool version management (`mise.toml`)
+   - **YAML** (`redhat.vscode-yaml`) — YAML language support with schema validation (`pubspec.yaml`, slang i18n files)
 
 ## Optional Configuration
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,8 @@
 {
   "recommendations": [
-    "google.arb-editor",
-    "dart-code.flutter",
     "dart-code.dart-code",
-    "hverlin.mise-vscode"
+    "dart-code.flutter",
+    "hverlin.mise-vscode",
+    "redhat.vscode-yaml"
   ]
 }


### PR DESCRIPTION
- Add redhat.vscode-yaml for pubspec.yaml and slang i18n files
- Remove google.arb-editor (unused since migrating to slang)
- Sort extensions alphabetically
- Document each extension with description and project context in README