### PR TITLE
feat: add typed preference keys with get/set access

### DIFF
--- a/lib/repositories/preferences_repository.dart
+++ b/lib/repositories/preferences_repository.dart
@@ -8,6 +8,7 @@ enum PrefType { boolean, integer, double, string, stringList }
 // dart format off
 /// Typed preference keys with defaults.
 enum PrefKey<T> {
+  /// Whether to use mock data instead of live NTUT services.
   demoMode<bool>(PrefType.boolean, false);
 
   const PrefKey(this.type, this.defaultValue);


### PR DESCRIPTION
## Summary

- Add `PrefKey<T>` enum with `PrefType` for type-safe preference access with compile-time defaults
- Implement `get()` and `set()` methods on `PreferencesRepository`
- First key: `demoMode` (bool, default false)

Split from #100 — this is the non-sync foundation that cloud sync will build on.