### PR TITLE
fix: combine flutter pub get and dart doc into single cache mount step

### DIFF
--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -24,7 +24,6 @@ RUN --mount=type=cache,target=/mise/cache \
     mise install flutter
 
 # Resolve app dependencies and generate documentation
-COPY pubspec.* ./
 COPY . .
 RUN --mount=type=cache,target=/root/.pub-cache \
     flutter --disable-analytics && \


### PR DESCRIPTION
The `dart doc` build was failing with:

    fatal error: unable to locate the input directory at '/root/.pub-cache/hosted/pub.dev/meta-1.17.0/lib'

**Root cause:** BuildKit `--mount=type=cache` volumes are independent from Docker layer cache. When the pub-cache volume on the build server gets pruned (e.g. via `docker builder prune`), but the `flutter pub get` layer is still cached, pub get doesn't re-run — leaving the mount empty. The subsequent `dart doc` step then mounts the same empty volume and fails.

**Fix:** Combine `flutter pub get` and `dart doc` into a single `RUN` step sharing one cache mount invocation. If the mount is empty, pub get always runs first within the same step to repopulate it before dart doc needs it.