### PR TITLE
feat:  Update Theme Color Scheme Seed

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,6 +87,8 @@ Future<void> main() async {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
+  static const themeColor = Color(0xFF4B709B);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp.router(
@@ -95,7 +97,7 @@ class MyApp extends StatelessWidget {
       supportedLocales: AppLocaleUtils.supportedLocales,
       localizationsDelegates: GlobalMaterialLocalizations.delegates,
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Color(0xFF4B709B)),
+        colorScheme: ColorScheme.fromSeed(seedColor: themeColor),
       ),
       routerConfig: appRouter,
     );


### PR DESCRIPTION
Currently, the project uses `Colors.purple` as the seed color in `main.dart`. This was an early design choice.

As the app has evolved, I would like to unify the overall visual identity. Therefore, this PR updates the theme seed color to match the background color used in the Student ID–style profile card.

This change aligns the overall color scheme more closely with NTUT’s visual style and improves consistency across the app.

<img width="200px" src="https://github.com/user-attachments/assets/409e253e-438b-4ca1-ad21-8aaab55928e0"/>

<img width="200px" src="https://github.com/user-attachments/assets/da9714ad-35cd-4c9a-af75-b9eca8e8e709"/>

<img width="200px" src="https://github.com/user-attachments/assets/5fdba62b-f85b-4a68-aa42-57ce05af5da1"/>