### PR TITLE
fix: handle schema version mismatch with destructive fallback

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -58,7 +58,8 @@ class AppDatabase extends _$AppDatabase {
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
-    beforeOpen: (details) async {
+    onUpgrade: destructiveFallback.onUpgrade,
+    beforeOpen: (_) async {
       await customStatement('PRAGMA foreign_keys = ON');
     },
   );


### PR DESCRIPTION
## Summary

- Add Drift's `destructiveFallback` as the `onUpgrade` handler so the database is dropped and recreated when the schema version changes

## Context

The `0305-demo` branch bumped `schemaVersion` to 2 (build 512), but `main` still has `schemaVersion: 1`. When a tester upgraded from build 512 to build 514 (from `main`), Drift detected a version mismatch and crashed on startup — no `onUpgrade` handler was defined.

Crashlytics: [`481761e`](https://console.firebase.google.com/project/npc-tattoo/crashlytics/app/ios:club.ntut.tattoo/issues/481761e7eb6a48b47c720fd070398fde) (2 events, iPhone 17, iOS 26.3.0)

## Test plan

- [ ] Bump `schemaVersion` to 2, run on a device with existing data — app starts fresh without crashing
- [ ] Revert to 1, run again — downgrade also handled