### PR TITLE
fix(ci): explicitly set target SHA for daily release

### DIFF
--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -135,6 +135,7 @@ jobs:
           gh release create daily \
             --title "Daily Build $(TZ='Asia/Taipei' date +'%Y-%m-%d')" \
             --notes "$BODY" \
+            --target $(git rev-parse HEAD) \
             --prerelease
 
   android:


### PR DESCRIPTION
This fixes the issue where the daily release CI triggers every day because the target commitish defaulted to the branch name instead of the specific SHA, causing the 'Check for changes' comparison to fail.