### PR TITLE
fix: catch SFSafariViewController PlatformException crashes

### DIFF
--- a/lib/screens/main/profile/about_screen.dart
+++ b/lib/screens/main/profile/about_screen.dart
@@ -9,7 +9,7 @@ import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/preferences_repository.dart';
 import 'package:tattoo/screens/main/profile/profile_providers.dart';
 import 'package:tattoo/services/github_service.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:tattoo/utils/launch_url.dart';
 
 final packageInfoProvider = FutureProvider.autoDispose<String>((ref) async {
   final packageInfo = await PackageInfo.fromPlatform();

--- a/lib/screens/main/profile/profile_screen.dart
+++ b/lib/screens/main/profile/profile_screen.dart
@@ -13,7 +13,7 @@ import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/auth_repository.dart';
 import 'package:tattoo/router/app_router.dart';
 import 'package:tattoo/services/portal_service.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:tattoo/utils/launch_url.dart';
 import 'package:tattoo/screens/main/profile/profile_card.dart';
 import 'package:tattoo/screens/main/profile/profile_danger_zone.dart';
 import 'package:tattoo/screens/main/profile/profile_providers.dart';
@@ -104,14 +104,11 @@ class ProfileScreen extends ConsumerWidget {
           .withAuth(
             () => ref.read(portalServiceProvider).getSsoUrl(serviceCode),
           );
-      final launched = await launchUrl(
-        url,
-        // iOS doesn't preserve the in-app browser's session, so we have to open externally to maintain login state.
-        mode: Platform.isIOS ? .externalApplication : .platformDefault,
-      );
-      if (!launched) throw Exception('Could not open browser');
-    } catch (e) {
-      if (context.mounted) _showMessage(context, 'Failed to open: $e');
+      // iOS doesn't preserve the in-app browser's session, so we have to
+      // open externally to maintain login state.
+      await launchUrl(url, inExternalApplication: Platform.isIOS);
+    } on DioException {
+      if (context.mounted) _showMessage(context, t.errors.connectionFailed);
     }
   }
 

--- a/lib/screens/welcome/login_screen.dart
+++ b/lib/screens/welcome/login_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:tattoo/utils/launch_url.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/auth_repository.dart';
 import 'package:tattoo/router/app_router.dart';

--- a/lib/utils/launch_url.dart
+++ b/lib/utils/launch_url.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart' as ul;
+
+export 'package:url_launcher/url_launcher.dart' hide launchUrl;
+
+/// Launches a URL, catching [PlatformException]s that would otherwise be fatal.
+///
+/// Set [inExternalApplication] to open in the system browser instead of an
+/// in-app browser (e.g. to preserve login session cookies).
+///
+/// When using the default in-app mode, falls back to the external browser if
+/// the in-app browser fails (e.g. SFSafariViewController on some iOS versions).
+Future<void> launchUrl(Uri url, {bool inExternalApplication = false}) async {
+  if (inExternalApplication) {
+    await ul.launchUrl(url, mode: .externalApplication);
+    return;
+  }
+  try {
+    await ul.launchUrl(url);
+  } on PlatformException {
+    await ul.launchUrl(url, mode: .externalApplication);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `launchUrl` wrapper (`lib/utils/launch_url.dart`) that catches `PlatformException` from `url_launcher` and falls back to the system browser, preventing fatal crashes from `SFSafariViewController` failures on iOS 26
- Re-exports `url_launcher` (hiding its `launchUrl`) so callers only need one import
- Replace all direct `url_launcher` imports in profile, about, and login screens

Fixes Firebase Crashlytics [`191da13681395b983b0abb58423586e7`](https://console.firebase.google.com/u/0/project/npc-tattoo/crashlytics/app/ios:club.ntut.tattoo/issues/191da13681395b983b0abb58423586e7)

## Test plan
- [x] Open privacy policy link on iOS — should open in-app, or fall back to Safari if SFSafariViewController fails
- [x] Open NPC club / GitHub / Crowdin links on about screen
- [x] Open portal link on login screen
- [x] Open SSO service (學生查詢專區) on profile — should open in external browser on iOS