### PR TITLE
Strip e化教室 marker from classroom names

### DIFF
--- a/lib/services/course/ntut_course_service.dart
+++ b/lib/services/course/ntut_course_service.dart
@@ -153,6 +153,7 @@ class NtutCourseService implements CourseService {
 
     // Build schedule map keyed by course name from the grid
     final periodRegex = RegExp(r'第 (\S) 節');
+    final eClassroomRegex = RegExp(r'\s*\(e\)$');
     final scheduleMap =
         <
           String,
@@ -190,7 +191,7 @@ class NtutCourseService implements CourseService {
         if (classroomRef?.name case final name?) {
           classroomRef = (
             id: classroomRef!.id,
-            name: name.replaceFirst(RegExp(r'\s*\(e\)$'), ''),
+            name: name.replaceFirst(eClassroomRegex, ''),
           );
         }
 


### PR DESCRIPTION
## Summary

- Strip the `(e)` suffix (with optional leading space) from classroom names parsed from the timetable grid
- The `(e)` marker indicates e化教室 (classrooms with PC and online recordings) and is not part of the actual classroom name
- Examples: `六教526(e)` → `六教526`, `先鋒501 (e)` → `先鋒501`

## Test plan

- [x] Course service integration tests pass