### PR TITLE
feat: implement CourseRepository.getCourse with TTL caching

### DIFF
--- a/lib/repositories/course_repository.dart
+++ b/lib/repositories/course_repository.dart
@@ -254,26 +254,18 @@ class CourseRepository {
         final courseId = dto.course?.id;
         final courseNameZh = dto.course?.nameZh;
         if (courseId == null || courseNameZh == null) {
-          _firebaseService.crashlytics?.recordError(
-            Exception(
-              'Skipped offering with incomplete course data: '
-              'number=${dto.number}, courseId=$courseId, '
-              'courseNameZh=$courseNameZh',
-            ),
-            StackTrace.current,
-            fatal: false,
+          _firebaseService.recordNonFatal(
+            'Skipped offering with incomplete course data: '
+            'number=${dto.number}, courseId=$courseId, '
+            'courseNameZh=$courseNameZh',
           );
           continue;
         }
 
         if (dto.credits == null || dto.hours == null) {
-          _firebaseService.crashlytics?.recordError(
-            Exception(
-              'Course $courseId missing credits/hours: '
-              'credits=${dto.credits}, hours=${dto.hours}',
-            ),
-            StackTrace.current,
-            fatal: false,
+          _firebaseService.recordNonFatal(
+            'Course $courseId missing credits/hours: '
+            'credits=${dto.credits}, hours=${dto.hours}',
           );
         }
 
@@ -489,13 +481,9 @@ class CourseRepository {
     );
 
     if (dto.nameZh == null || dto.credits == null || dto.hours == null) {
-      _firebaseService.crashlytics?.recordError(
-        Exception(
-          'Incomplete course data for $code: '
-          'nameZh=${dto.nameZh}, credits=${dto.credits}, hours=${dto.hours}',
-        ),
-        StackTrace.current,
-        fatal: false,
+      _firebaseService.recordNonFatal(
+        'Incomplete course data for $code: '
+        'nameZh=${dto.nameZh}, credits=${dto.credits}, hours=${dto.hours}',
       );
     }
 

--- a/lib/services/firebase_service.dart
+++ b/lib/services/firebase_service.dart
@@ -23,12 +23,17 @@ final firebaseServiceProvider = Provider<FirebaseService>((ref) {
 ///
 /// ```dart
 /// ref.read(firebaseServiceProvider).analytics?.logAppOpen();
-/// ref.read(firebaseServiceProvider).crashlytics?.recordError(e, stack);
+/// ref.read(firebaseServiceProvider).recordNonFatal('...');
 /// ```
 class FirebaseService {
   /// The [FirebaseAnalytics] instance, or `null` if Firebase is disabled.
   FirebaseAnalytics? get analytics =>
       useFirebase ? FirebaseAnalytics.instance : null;
+
+  /// Returns a [FirebaseAnalyticsObserver] for use with navigation observers, or
+  /// `null` if Firebase is disabled.
+  FirebaseAnalyticsObserver? get analyticsObserver =>
+      useFirebase ? FirebaseAnalyticsObserver(analytics: analytics!) : null;
 
   /// The [FirebaseCrashlytics] instance, or `null` if Firebase is disabled.
   FirebaseCrashlytics? get crashlytics =>
@@ -42,8 +47,12 @@ class FirebaseService {
     crashlytics?.log(message);
   }
 
-  /// Returns a [FirebaseAnalyticsObserver] for use with navigation observers, or
-  /// `null` if Firebase is disabled.
-  FirebaseAnalyticsObserver? get analyticsObserver =>
-      useFirebase ? FirebaseAnalyticsObserver(analytics: analytics!) : null;
+  /// Records a non-fatal error to Firebase Crashlytics if enabled.
+  void recordNonFatal(String message) {
+    crashlytics?.recordError(
+      Exception(message),
+      StackTrace.current,
+      fatal: false,
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- Implement `CourseRepository.getCourse()` — resolves a course code to a `Course` DB row, fetching from `CourseService.getCourse()` if missing or stale
- Follows existing `fetchWithTtl` pattern with `Fetchable.fetchedAt` for cache invalidation
- Persists course name, credits, hours, and descriptions
- Log Crashlytics non-fatals when nullable DTO fields fall back to defaults (`credits ?? 0`, `hours ?? 0`, `nameZh ?? code`) in both `_fetchCourseFromNetwork` and `_fetchCourseTableFromNetwork`
- Add `FirebaseService` dependency to `CourseRepository`

## Test plan

- [ ] Verify `getCourse` returns cached data within TTL and fetches from network when stale
- [ ] Verify Crashlytics non-fatal is recorded when course data has null fields