### PR TITLE
fix: account for multi-period span in course table period checks

### DIFF
--- a/lib/repositories/course_repository.dart
+++ b/lib/repositories/course_repository.dart
@@ -55,11 +55,18 @@ typedef CourseTableEntry =
     MapEntry<({DayOfWeek day, Period period}), CourseTableCell>;
 
 extension on CourseTableEntry {
-  /// All [Period]s this entry occupies, accounting for [CourseTableCell.span].
-  Iterable<Period> get periods => List.generate(
-    value.span,
-    (i) => Period.values[key.period.index + i],
-  );
+  /// All [Period]s this entry occupies, accounting for [CourseTableCell.span]
+  /// and skipping noon when [CourseTableCell.crossesNoon] is true.
+  Iterable<Period> get periods {
+    final noonIndex = Period.nPeriod.index;
+    final start = key.period.index;
+    return List.generate(value.span, (i) {
+      final raw = start + i;
+      return Period.values[raw >= noonIndex && value.crossesNoon
+          ? raw + 1
+          : raw];
+    });
+  }
 }
 
 /// Derived layout metadata computed from [CourseTableData] keys.
@@ -97,9 +104,9 @@ extension CourseTableMeta on CourseTableData {
   /// Latest period that has a course (accounting for span), or null if empty.
   Period? get latestPeriod => isEmpty
       ? null
-      : Period.values[entries
-            .map((e) => e.key.period.index + e.value.span - 1)
-            .reduce(max)];
+      : entries
+            .expand((e) => e.periods)
+            .reduce((a, b) => a.index > b.index ? a : b);
 
   /// Unique courses by number, for aggregation.
   Iterable<CourseTableCell> get _uniqueCourses {


### PR DESCRIPTION
## Summary

- Period-category getters (`hasAMCourse`, `hasPMCourse`, `hasNoonCourse`, `hasEveningCourse`) only checked the start period, ignoring multi-period spans — e.g. a course starting at period 4 with span 2 covers period N, but `hasNoonCourse` missed it
- Extract `CourseTableEntry` typedef and `periods` getter to expand spans, and use it in all period-category checks

In this screenshot, "物聯網智慧應用" is cut off because `hasEveningCourse` didn't account for periods 9 and A of the course. Therefore, this fix is needed.

<img src="https://github.com/user-attachments/assets/f4813fb8-fa6a-4a4e-813e-420c75bc224b" width="400">

## Test plan

- [ ] Verify course table UI correctly shows/hides period rows for courses that span across period categories
