### PR TITLE
fix: share profile providers with course table header

### DIFF
--- a/lib/screens/main/course_table/course_table_providers.dart
+++ b/lib/screens/main/course_table/course_table_providers.dart
@@ -1,7 +1,0 @@
-import 'package:tattoo/screens/main/profile/profile_providers.dart';
-
-/// Alias of [userProfileProvider] so course table and profile share the same state.
-final courseTableUserProfileProvider = userProfileProvider;
-
-/// Alias of [userAvatarProvider] so course table and profile share the same state.
-final courseTableUserAvatarProvider = userAvatarProvider;

--- a/lib/screens/main/course_table/course_table_providers.dart
+++ b/lib/screens/main/course_table/course_table_providers.dart
@@ -1,19 +1,7 @@
-import 'dart:io';
+import 'package:tattoo/screens/main/profile/profile_providers.dart';
 
-import 'package:riverpod/riverpod.dart';
-import 'package:tattoo/database/database.dart';
-import 'package:tattoo/repositories/auth_repository.dart';
+/// Alias of [userProfileProvider] so course table and profile share the same state.
+final courseTableUserProfileProvider = userProfileProvider;
 
-/// Provides the current user's basic profile for course table header.
-///
-/// Returns `null` if not logged in. Automatically fetches full profile if stale.
-final courseTableUserProfileProvider = FutureProvider.autoDispose<User?>((ref) {
-  return ref.watch(authRepositoryProvider).getUser();
-});
-
-/// Provides the current user's avatar file for course table header.
-///
-/// Returns `null` if user has no avatar or not logged in.
-final courseTableUserAvatarProvider = FutureProvider.autoDispose<File?>((ref) {
-  return ref.watch(authRepositoryProvider).getAvatar();
-});
+/// Alias of [userAvatarProvider] so course table and profile share the same state.
+final courseTableUserAvatarProvider = userAvatarProvider;

--- a/lib/screens/main/course_table/course_table_screen.dart
+++ b/lib/screens/main/course_table/course_table_screen.dart
@@ -4,7 +4,7 @@ import 'package:tattoo/components/app_skeleton.dart';
 import 'package:tattoo/components/chip_tab_switcher.dart';
 import 'package:tattoo/database/database.dart';
 import 'package:tattoo/i18n/strings.g.dart';
-import 'package:tattoo/screens/main/course_table/course_table_providers.dart';
+import 'package:tattoo/screens/main/user_providers.dart';
 
 // TODO: Import mock data from demo mode when implemented
 const _placeholderOwnerName = '載入中';
@@ -102,8 +102,8 @@ class _TableOwnerIndicator extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final profileAsync = ref.watch(courseTableUserProfileProvider);
-    final avatarAsync = ref.watch(courseTableUserAvatarProvider);
+    final profileAsync = ref.watch(userProfileProvider);
+    final avatarAsync = ref.watch(userAvatarProvider);
     final profile = profileAsync.asData?.value;
     final avatarFile = avatarAsync.asData?.value;
     final isLoading = profileAsync is AsyncLoading<User?> && profile == null;

--- a/lib/screens/main/course_table/course_table_screen.dart
+++ b/lib/screens/main/course_table/course_table_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tattoo/components/app_skeleton.dart';
@@ -12,7 +10,7 @@ import 'package:tattoo/screens/main/course_table/course_table_providers.dart';
 const _placeholderOwnerName = '載入中';
 const _placeholderAvatarInitial = '載';
 
-class CourseTableScreen extends ConsumerWidget {
+class CourseTableScreen extends StatelessWidget {
   const CourseTableScreen({super.key});
 
   void _showDemoTap(BuildContext context) {
@@ -22,10 +20,7 @@ class CourseTableScreen extends ConsumerWidget {
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final profileAsync = ref.watch(courseTableUserProfileProvider);
-    final avatarAsync = ref.watch(courseTableUserAvatarProvider);
-
+  Widget build(BuildContext context) {
     return DefaultTabController(
       length: _courseTableTabs.length,
       child: Scaffold(
@@ -47,11 +42,7 @@ class CourseTableScreen extends ConsumerWidget {
                     child: Row(
                       crossAxisAlignment: CrossAxisAlignment.end,
                       children: [
-                        _TableOwnerIndicator(
-                          context: context,
-                          profileAsync: profileAsync,
-                          avatarAsync: avatarAsync,
-                        ),
+                        const _TableOwnerIndicator(),
                         const Spacer(),
                         Row(
                           mainAxisSize: MainAxisSize.min,
@@ -104,21 +95,15 @@ class CourseTableScreen extends ConsumerWidget {
   }
 }
 
-class _TableOwnerIndicator extends StatelessWidget {
-  const _TableOwnerIndicator({
-    required this.context,
-    required this.profileAsync,
-    required this.avatarAsync,
-  });
+class _TableOwnerIndicator extends ConsumerWidget {
+  const _TableOwnerIndicator();
 
   static const double _height = 36;
 
-  final BuildContext context;
-  final AsyncValue<User?> profileAsync;
-  final AsyncValue<File?> avatarAsync;
-
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profileAsync = ref.watch(courseTableUserProfileProvider);
+    final avatarAsync = ref.watch(courseTableUserAvatarProvider);
     final profile = profileAsync.asData?.value;
     final avatarFile = avatarAsync.asData?.value;
     final isLoading = profileAsync is AsyncLoading<User?> && profile == null;

--- a/lib/screens/main/profile/profile_card.dart
+++ b/lib/screens/main/profile/profile_card.dart
@@ -9,6 +9,7 @@ import 'package:tattoo/database/database.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/models/user.dart';
 import 'package:tattoo/screens/main/profile/profile_providers.dart';
+import 'package:tattoo/screens/main/user_providers.dart';
 
 const _placeholderProfile = User(
   id: 0,

--- a/lib/screens/main/profile/profile_providers.dart
+++ b/lib/screens/main/profile/profile_providers.dart
@@ -1,25 +1,10 @@
-import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tattoo/database/database.dart';
-import 'package:tattoo/repositories/auth_repository.dart';
-
 import 'package:tattoo/i18n/strings.g.dart';
-
-/// Provides the current user's profile.
-///
-/// Returns `null` if not logged in. Automatically fetches full profile if stale.
-final userProfileProvider = FutureProvider.autoDispose<User?>((ref) {
-  return ref.watch(authRepositoryProvider).getUser();
-});
-
-/// Provides the current user's avatar file.
-///
-/// Returns `null` if user has no avatar or not logged in.
-final userAvatarProvider = FutureProvider.autoDispose<File?>((ref) {
-  return ref.watch(authRepositoryProvider).getAvatar();
-});
+import 'package:tattoo/repositories/auth_repository.dart';
+import 'package:tattoo/screens/main/user_providers.dart';
 
 /// Provides the user's active registration (current class and semester).
 ///

--- a/lib/screens/main/profile/profile_screen.dart
+++ b/lib/screens/main/profile/profile_screen.dart
@@ -18,6 +18,7 @@ import 'package:tattoo/utils/launch_url.dart';
 import 'package:tattoo/screens/main/profile/profile_card.dart';
 import 'package:tattoo/screens/main/profile/profile_danger_zone.dart';
 import 'package:tattoo/screens/main/profile/profile_providers.dart';
+import 'package:tattoo/screens/main/user_providers.dart';
 
 class ProfileScreen extends ConsumerWidget {
   const ProfileScreen({super.key});

--- a/lib/screens/main/user_providers.dart
+++ b/lib/screens/main/user_providers.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tattoo/database/database.dart';
+import 'package:tattoo/repositories/auth_repository.dart';
+
+/// Provides the current user's profile.
+///
+/// Returns `null` if not logged in. Automatically fetches full profile if stale.
+final userProfileProvider = FutureProvider.autoDispose<User?>((ref) {
+  return ref.watch(authRepositoryProvider).getUser();
+});
+
+/// Provides the current user's avatar file.
+///
+/// Returns `null` if user has no avatar or not logged in.
+final userAvatarProvider = FutureProvider.autoDispose<File?>((ref) {
+  return ref.watch(authRepositoryProvider).getAvatar();
+});


### PR DESCRIPTION
## Summary

- reuse `userProfileProvider` and `userAvatarProvider` for the course table header
- move Riverpod `watch` calls into `_TableOwnerIndicator` to match `ProfileCard`
- remove duplicated course table provider implementations so both screens share the same provider state
- fix crash in #167 

## Why

The course table screen previously used separate provider definitions and passed `AsyncValue` down from the parent widget.
This could drift from the profile screen's behavior and make profile/avatar state updates inconsistent between the two screens.

## Test Plan

![Works on my machine](https://img.shields.io/badge/works_on-my_machine-green)
- [x] Android 16 physical device in debug mode
- [x] Android 16 physical device in release mode
- [x] iPhone