### PR TITLE
fix: prevent empty SET clause in teacher semester upsert

### DIFF
--- a/lib/database/actions.dart
+++ b/lib/database/actions.dart
@@ -109,6 +109,7 @@ extension DatabaseActions on AppDatabase {
         ),
         onConflict: DoUpdate(
           (old) => TeacherSemestersCompanion(
+            teacher: Value(teacher.id),
             email: Value.absentIfNull(email),
             department: Value.absentIfNull(departmentId),
             title: Value.absentIfNull(title),


### PR DESCRIPTION
## Summary

Fixes a regression from #197 where `upsertTeacherSemester` generates invalid SQL (`DO UPDATE SET RETURNING *`) when called without optional profile fields.

When all optional parameters (`email`, `department`, `title`, `teachingHours`, `officeHoursNote`, `fetchedAt`) are null, every `DoUpdate` field becomes `Value.absent()`, producing an empty SET clause. This happens in `CourseRepository._saveCourseTable` which only passes `code`, `semesterId`, `nameZh`, and `nameEn`.

The fix adds `teacher: Value(teacher.id)` as a guaranteed non-absent column in the SET clause.