### PR TITLE
fix: better cell layout handling in course table

### DIFF
--- a/lib/screens/main/course_table/course_table_cell.dart
+++ b/lib/screens/main/course_table/course_table_cell.dart
@@ -67,37 +67,46 @@ class CourseTableCell extends StatelessWidget {
           child: InkWell(
             onTap: onTap,
             borderRadius: borderRadius,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 2),
-              child: Column(
-                mainAxisAlignment: .center,
-                children: [
-                  AutoSizeText(
-                    courseTitle,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      fontSize: 12,
-                      fontWeight: .w700,
-                    ),
-                    maxLines: 2,
-                    minFontSize: 8,
-                    overflow: .ellipsis,
-                    textAlign: .center,
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final titleMaxLines = constraints.maxHeight > 100 ? 3 : 2;
+
+                return Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 2,
+                    vertical: 2,
                   ),
-                  if (classroomName case final classroomName?
-                      when classroomName.isNotEmpty)
-                    AutoSizeText(
-                      classroomName,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        fontSize: 8,
-                        fontWeight: .w400,
+                  child: Column(
+                    mainAxisAlignment: .center,
+                    children: [
+                      AutoSizeText(
+                        courseTitle,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontSize: 12,
+                          fontWeight: .w700,
+                        ),
+                        maxLines: titleMaxLines,
+                        minFontSize: 8,
+                        overflow: .ellipsis,
+                        textAlign: .center,
                       ),
-                      maxLines: 1,
-                      minFontSize: 6,
-                      overflow: .ellipsis,
-                      textAlign: .center,
-                    ),
-                ],
-              ),
+                      if (classroomName case final classroomName?
+                          when classroomName.isNotEmpty)
+                        AutoSizeText(
+                          classroomName,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            fontSize: 8,
+                            fontWeight: .w400,
+                          ),
+                          maxLines: 1,
+                          minFontSize: 6,
+                          overflow: .ellipsis,
+                          textAlign: .center,
+                        ),
+                    ],
+                  ),
+                );
+              },
             ),
           ),
         ),


### PR DESCRIPTION
# 課表表格內容排版調整

Follow-up form #135 

<table>
<tr>
 <td> before
 <td> after
<tr>
 <td><img src="https://github.com/user-attachments/assets/6a812f4e-1ed3-49da-8e9b-6f8a7bba0b16" width=250px/>
 <td><img src="https://github.com/user-attachments/assets/82dd33be-a37e-4c2e-970d-0c9273edd34a" width=250px/>
<tr>
 <td><img src="https://github.com/user-attachments/assets/47264ed1-540e-43fe-a709-7be942b8c327" width=250px/>
 <td><img src="https://github.com/user-attachments/assets/3df51388-b52b-4f53-8f8d-c3c5f13c5fa0" width=250px/>
</table>

## Summary

因應英文課程名稱普遍較長問題，作了以下改動：

* 恢復自動調整大小的最小限制 -- 那在我某次測試時不小心改掉了
* 放寬最小字體，現在課程名稱最小可以到 8pt，以更好地應對英文課名
* 於空間足夠 ( >=2 節 ) 時，允許三行而非兩行，以更好地應對較窄的顯示畫面(尤其在六日都有課時)，和超長的英文課名。

## Test Plan

![Works on my machine](https://img.shields.io/badge/works_on-my_machine-green)
- [x] on Android device
- [x] on iPhone