### PR TITLE
fix: refresh course table localization on locale change

### DIFF
--- a/lib/screens/main/course_table/course_table_grid.dart
+++ b/lib/screens/main/course_table/course_table_grid.dart
@@ -109,6 +109,8 @@ class CourseTableGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = context.t;
+    
     return CustomScrollView(
       slivers: [
         // table header with weekday labels, pinned to top when scrolling
@@ -122,7 +124,7 @@ class CourseTableGrid extends StatelessWidget {
           scrolledUnderElevation: 0,
           elevation: 0,
           titleSpacing: 0,
-          title: _buildHeader(_visibleDaysOfWeek),
+          title: _buildHeader(t, _visibleDaysOfWeek),
         ),
 
         // table body with period labels and course cells
@@ -251,7 +253,7 @@ class CourseTableGrid extends StatelessWidget {
     );
   }
 
-  Widget _buildHeader(List<DayOfWeek> visibleDaysOfWeek) {
+  Widget _buildHeader(Translations t, List<DayOfWeek> visibleDaysOfWeek) {
     return Row(
       children: [
         SizedBox(width: _stubWidth),

--- a/lib/screens/main/course_table/course_table_providers.dart
+++ b/lib/screens/main/course_table/course_table_providers.dart
@@ -1,8 +1,14 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tattoo/database/database.dart';
+import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/auth_repository.dart';
 import 'package:tattoo/repositories/course_repository.dart';
 import 'package:tattoo/screens/main/user_providers.dart';
+
+/// Tracks app locale changes so localized course-table data can rebuild.
+final courseTableLocaleProvider = StreamProvider.autoDispose<AppLocale>((ref) {
+  return LocaleSettings.getLocaleStream();
+});
 
 /// Provides the available semesters for the current user.
 ///
@@ -28,6 +34,8 @@ final courseTableProvider = FutureProvider.autoDispose
       ref,
       semester,
     ) async {
+      ref.watch(courseTableLocaleProvider);
+
       final user = await ref.watch(userProfileProvider.future);
       if (user == null) return CourseTableData();
 

--- a/lib/screens/main/course_table/course_table_screen.dart
+++ b/lib/screens/main/course_table/course_table_screen.dart
@@ -21,12 +21,13 @@ class CourseTableScreen extends ConsumerWidget {
 
   void _showDemoTap(BuildContext context) {
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(t.general.notImplemented)),
+      SnackBar(content: Text(context.t.general.notImplemented)),
     );
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final t = context.t;
     final profileAsync = ref.watch(userProfileProvider);
     final semestersAsync = ref.watch(courseTableSemestersProvider);
     final displayedSemesterTabLabels = switch (semestersAsync) {
@@ -197,6 +198,7 @@ class _TableOwnerIndicator extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final t = context.t;
     final profileAsync = ref.watch(userProfileProvider);
     final avatarAsync = ref.watch(userAvatarProvider);
     final profile = profileAsync.asData?.value;

--- a/lib/screens/main/home_screen.dart
+++ b/lib/screens/main/home_screen.dart
@@ -26,6 +26,8 @@ class HomeScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final t = context.t;
+    
     return Scaffold(
       body: navigationShell,
       bottomNavigationBar: NavigationBar(


### PR DESCRIPTION
## Summary
Fix delayed language updates after changing the Android system language.

The issue had two parts:
- UI text in the preserved home/course table shell was using translations that did not subscribe to locale changes.
- Course table cell titles/classroom names were localized inside the repository, so they stayed stale until the provider rebuilt for some unrelated reason.

This PR updates the course table flow to refresh immediately when the app locale changes by:
- switching course table UI labels to locale-aware `context.t` usage
- making `courseTableProvider` depend on the locale stream so cached course-table data is rebuilt with the new language
- keeping preserved tab content in sync without requiring extra taps or scrolling

<img src="https://github.com/user-attachments/assets/fbeb49b2-9844-464b-8f82-6d271a18e7d3" width=300px>

## Test Plan

![Works on my machine](https://img.shields.io/badge/works_on-my_machine-green)
- [x] on Android device
- [ ] on iPhone