### PR TITLE
feat: Add floating action bar in course table screen

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -235,9 +235,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Firebase: 065f2bb395062046623036d8e6dc857bc2521d56
-  firebase_analytics: 42693ebf35c4d330b74abcb46ca80351703644e0
-  firebase_core: 98bcc1bd1a097bcb8b1ed6e091de3039802527c4
-  firebase_crashlytics: 2fd6c030ca2f91e8d3b13d2e6e9a08a282c9d259
+  firebase_analytics: 8288e2480a2b2a5eb2cc3c474e4a4327e8dc520b
+  firebase_core: 8e6f58412ca227827c366b92e7cee047a2148c60
+  firebase_crashlytics: c399f9682c474beb06a89c11dfab04db537f3cd2
   FirebaseAnalytics: cd7d01d352f3c237c9a0e31552c257cd0b0c0352
   FirebaseCore: 428912f751178b06bef0a1793effeb4a5e09a9b8
   FirebaseCoreExtension: e911052d59cd0da237a45d706fc0f81654f035c1
@@ -247,24 +247,24 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 765ee19cd2bfa8e54937c8dae901eb634ad6787d
   FirebaseSessions: a2d06fd980431fda934c7a543901aca05fc4edcc
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
-  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
+  flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
+  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   GoogleAdsOnDeviceConversion: d68c69dd9581a0f5da02617b6f377e5be483970f
   GoogleAppMeasurement: fce7c1c90640d2f9f5c56771f71deacb2ba3f98c
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
+  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
-  mobile_scanner: 77265f3dc8d580810e91849d4a0811a90467ed5e
+  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageWebPCoder: 0e06e365080397465cc73a7a9b472d8a3bd0f377
-  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
-  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 
 PODFILE CHECKSUM: ce2a4dd764e1c7aeed6a7cdc5e61d092b6dc6d32
 

--- a/lib/components/anchored_popup_menu.dart
+++ b/lib/components/anchored_popup_menu.dart
@@ -58,9 +58,9 @@ class AnchoredPopupMenuLayout {
     required EdgeInsets mediaPadding,
   }) {
     return switch (placement) {
-      AnchoredPopupMenuPlacement.above => AnchoredPopupMenuPlacement.above,
-      AnchoredPopupMenuPlacement.below => AnchoredPopupMenuPlacement.below,
-      AnchoredPopupMenuPlacement.auto =>
+      .above => .above,
+      .below => .below,
+      .auto =>
         _availableHeightAbove(
                   anchorRect: anchorRect,
                   mediaPadding: mediaPadding,
@@ -70,8 +70,8 @@ class AnchoredPopupMenuLayout {
                   overlaySize: overlaySize,
                   mediaPadding: mediaPadding,
                 )
-            ? AnchoredPopupMenuPlacement.above
-            : AnchoredPopupMenuPlacement.below,
+            ? .above
+            : .below,
     };
   }
 
@@ -114,14 +114,14 @@ class AnchoredPopupMenuLayout {
     return math.max(
       0.0,
       switch (placement) {
-        AnchoredPopupMenuPlacement.auto => throw StateError(
+        .auto => throw StateError(
           'AnchoredPopupMenuPlacement.auto must be resolved before layout.',
         ),
-        AnchoredPopupMenuPlacement.above => _availableHeightAbove(
+        .above => _availableHeightAbove(
           anchorRect: anchorRect,
           mediaPadding: mediaPadding,
         ),
-        AnchoredPopupMenuPlacement.below => _availableHeightBelow(
+        .below => _availableHeightBelow(
           anchorRect: anchorRect,
           overlaySize: overlaySize,
           mediaPadding: mediaPadding,

--- a/lib/components/anchored_popup_menu.dart
+++ b/lib/components/anchored_popup_menu.dart
@@ -1,7 +1,6 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart' show SemanticsRole;
 import 'package:flutter/widget_previews.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 
@@ -38,7 +37,7 @@ class AnchoredPopupMenuLayout {
     this.maxWidth = _anchoredPopupMenuMaxWidth,
     this.screenPadding = _anchoredPopupMenuScreenPadding,
     this.gap = _anchoredPopupMenuGap,
-    this.placement = AnchoredPopupMenuPlacement.auto,
+    this.placement = .auto,
   }) : assert(minWidth <= maxWidth),
        assert(screenPadding >= 0),
        assert(gap >= 0);
@@ -445,9 +444,9 @@ class _AnchoredPopupMenu<T> extends StatelessWidget {
     final shadowColor =
         style.shadowColor ?? theme.shadowColor.withValues(alpha: 0.08);
     final growAlignment = switch (placement) {
-      AnchoredPopupMenuPlacement.above => AlignmentDirectional.bottomEnd,
-      AnchoredPopupMenuPlacement.below => AlignmentDirectional.topEnd,
-      AnchoredPopupMenuPlacement.auto => AlignmentDirectional.bottomEnd,
+      .above => AlignmentDirectional.bottomEnd,
+      .below => AlignmentDirectional.topEnd,
+      .auto => AlignmentDirectional.bottomEnd,
     };
     final size = CurvedAnimation(
       parent: animation,
@@ -471,8 +470,8 @@ class _AnchoredPopupMenu<T> extends StatelessWidget {
             shadowColor: shadowColor,
             surfaceTintColor: style.surfaceTintColor,
             shape: style.shape,
-            clipBehavior: Clip.antiAlias,
-            type: MaterialType.card,
+            clipBehavior: .antiAlias,
+            type: .card,
             child: Align(
               alignment: growAlignment,
               widthFactor: 1,
@@ -487,7 +486,7 @@ class _AnchoredPopupMenu<T> extends StatelessWidget {
         child: IntrinsicWidth(
           stepWidth: 56,
           child: Semantics(
-            role: SemanticsRole.menu,
+            role: .menu,
             scopesRoute: true,
             namesRoute: true,
             explicitChildNodes: true,
@@ -528,10 +527,9 @@ class _AnchoredPopupMenuRouteLayout extends SingleChildLayoutDelegate {
   @override
   Offset getPositionForChild(Size size, Size childSize) {
     final y = switch (placement) {
-      AnchoredPopupMenuPlacement.above =>
-        anchorRect.top - layout.gap - childSize.height,
-      AnchoredPopupMenuPlacement.below => anchorRect.bottom + layout.gap,
-      AnchoredPopupMenuPlacement.auto => anchorRect.top - layout.gap,
+      .above => anchorRect.top - layout.gap - childSize.height,
+      .below => anchorRect.bottom + layout.gap,
+      .auto => anchorRect.top - layout.gap,
     };
 
     return Offset(
@@ -556,8 +554,8 @@ class _AnchoredPopupMenuRouteLayout extends SingleChildLayoutDelegate {
       > 0 => overlaySize.width - right - childSize.width,
       < 0 => left,
       _ => switch (textDirection) {
-        TextDirection.rtl => overlaySize.width - right - childSize.width,
-        TextDirection.ltr => left,
+        .rtl => overlaySize.width - right - childSize.width,
+        .ltr => left,
       },
     };
   }

--- a/lib/components/anchored_popup_menu.dart
+++ b/lib/components/anchored_popup_menu.dart
@@ -18,12 +18,17 @@ const _anchoredPopupMenuShape = RoundedRectangleBorder(
 
 /// Controls how an [AnchoredPopupMenuButton] is sized and positioned.
 enum AnchoredPopupMenuPlacement {
+  /// Choose the side with more available vertical space.
   auto,
+
+  /// Prefer showing the popup menu above the trigger.
   above,
+
+  /// Prefer showing the popup menu below the trigger.
   below,
 }
 
-/// Controls how an [AnchoredPopupMenuButton] is sized and positioned.
+/// Configures sizing and placement behavior for [AnchoredPopupMenuButton].
 @immutable
 class AnchoredPopupMenuLayout {
   /// Creates the layout configuration for an anchored popup menu.
@@ -52,6 +57,10 @@ class AnchoredPopupMenuLayout {
   /// Preferred vertical placement of the popup menu relative to its trigger.
   final AnchoredPopupMenuPlacement placement;
 
+  /// Resolves the final menu placement for the current overlay and anchor.
+  ///
+  /// When [placement] is [AnchoredPopupMenuPlacement.auto], the menu is placed
+  /// on the side with more available vertical space.
   AnchoredPopupMenuPlacement resolvePlacement({
     required Rect anchorRect,
     required Size overlaySize,
@@ -75,6 +84,10 @@ class AnchoredPopupMenuLayout {
     };
   }
 
+  /// Resolves popup menu constraints for the current anchor and viewport.
+  ///
+  /// Width is always constrained by [minWidth] and [maxWidth]. Height is
+  /// additionally constrained when there is vertical room on the chosen side.
   BoxConstraints resolveMenuConstraints({
     required Rect anchorRect,
     required Size overlaySize,

--- a/lib/components/anchored_popup_menu.dart
+++ b/lib/components/anchored_popup_menu.dart
@@ -1,0 +1,632 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart' show SemanticsRole;
+import 'package:flutter/widget_previews.dart';
+
+import 'widget_preview_frame.dart';
+
+const _anchoredPopupMenuMinWidth = 112.0;
+const _anchoredPopupMenuMaxWidth = 280.0;
+const _anchoredPopupMenuScreenPadding = 8.0;
+const _anchoredPopupMenuGap = 8.0;
+const _anchoredPopupMenuPadding = EdgeInsets.symmetric(vertical: 8.0);
+const _anchoredPopupMenuAnimationDuration = Duration(milliseconds: 220);
+const _anchoredPopupMenuShape = RoundedRectangleBorder(
+  borderRadius: BorderRadius.all(Radius.circular(16)),
+);
+
+/// Controls how an [AnchoredPopupMenuButton] is sized and positioned.
+enum AnchoredPopupMenuPlacement {
+  auto,
+  above,
+  below,
+}
+
+/// Controls how an [AnchoredPopupMenuButton] is sized and positioned.
+@immutable
+class AnchoredPopupMenuLayout {
+  /// Creates the layout configuration for an anchored popup menu.
+  const AnchoredPopupMenuLayout({
+    this.minWidth = _anchoredPopupMenuMinWidth,
+    this.maxWidth = _anchoredPopupMenuMaxWidth,
+    this.screenPadding = _anchoredPopupMenuScreenPadding,
+    this.gap = _anchoredPopupMenuGap,
+    this.placement = AnchoredPopupMenuPlacement.auto,
+  }) : assert(minWidth <= maxWidth),
+       assert(screenPadding >= 0),
+       assert(gap >= 0);
+
+  /// Minimum popup menu width.
+  final double minWidth;
+
+  /// Maximum popup menu width.
+  final double maxWidth;
+
+  /// Minimum distance between the popup menu and the viewport edge.
+  final double screenPadding;
+
+  /// Gap between the trigger and popup menu.
+  final double gap;
+
+  /// Preferred vertical placement of the popup menu relative to its trigger.
+  final AnchoredPopupMenuPlacement placement;
+
+  AnchoredPopupMenuPlacement resolvePlacement({
+    required Rect anchorRect,
+    required Size overlaySize,
+    required EdgeInsets mediaPadding,
+  }) {
+    return switch (placement) {
+      AnchoredPopupMenuPlacement.above => AnchoredPopupMenuPlacement.above,
+      AnchoredPopupMenuPlacement.below => AnchoredPopupMenuPlacement.below,
+      AnchoredPopupMenuPlacement.auto =>
+        _availableHeightAbove(
+                  anchorRect: anchorRect,
+                  mediaPadding: mediaPadding,
+                ) >=
+                _availableHeightBelow(
+                  anchorRect: anchorRect,
+                  overlaySize: overlaySize,
+                  mediaPadding: mediaPadding,
+                )
+            ? AnchoredPopupMenuPlacement.above
+            : AnchoredPopupMenuPlacement.below,
+    };
+  }
+
+  BoxConstraints resolveMenuConstraints({
+    required Rect anchorRect,
+    required Size overlaySize,
+    required EdgeInsets mediaPadding,
+  }) {
+    final availableHeight = _availableHeight(
+      anchorRect: anchorRect,
+      overlaySize: overlaySize,
+      mediaPadding: mediaPadding,
+      placement: resolvePlacement(
+        anchorRect: anchorRect,
+        overlaySize: overlaySize,
+        mediaPadding: mediaPadding,
+      ),
+    );
+
+    if (availableHeight <= 0) {
+      return BoxConstraints(
+        minWidth: minWidth,
+        maxWidth: maxWidth,
+      );
+    }
+
+    return BoxConstraints(
+      minWidth: minWidth,
+      maxWidth: maxWidth,
+      maxHeight: availableHeight,
+    );
+  }
+
+  double _availableHeight({
+    required Rect anchorRect,
+    required Size overlaySize,
+    required EdgeInsets mediaPadding,
+    required AnchoredPopupMenuPlacement placement,
+  }) {
+    return math.max(
+      0.0,
+      switch (placement) {
+        AnchoredPopupMenuPlacement.auto => throw StateError(
+          'AnchoredPopupMenuPlacement.auto must be resolved before layout.',
+        ),
+        AnchoredPopupMenuPlacement.above => _availableHeightAbove(
+          anchorRect: anchorRect,
+          mediaPadding: mediaPadding,
+        ),
+        AnchoredPopupMenuPlacement.below => _availableHeightBelow(
+          anchorRect: anchorRect,
+          overlaySize: overlaySize,
+          mediaPadding: mediaPadding,
+        ),
+      },
+    );
+  }
+
+  double _availableHeightAbove({
+    required Rect anchorRect,
+    required EdgeInsets mediaPadding,
+  }) {
+    return anchorRect.top - mediaPadding.top - screenPadding - gap;
+  }
+
+  double _availableHeightBelow({
+    required Rect anchorRect,
+    required Size overlaySize,
+    required EdgeInsets mediaPadding,
+  }) {
+    return overlaySize.height -
+        anchorRect.bottom -
+        mediaPadding.bottom -
+        screenPadding -
+        gap;
+  }
+}
+
+/// Controls the popup menu surface and transition styling.
+@immutable
+class AnchoredPopupMenuStyle {
+  /// Creates the visual styling for an anchored popup menu.
+  const AnchoredPopupMenuStyle({
+    this.padding = _anchoredPopupMenuPadding,
+    this.transitionDuration = _anchoredPopupMenuAnimationDuration,
+    this.elevation = 4,
+    this.color,
+    this.shadowColor,
+    this.surfaceTintColor = Colors.transparent,
+    this.shape = _anchoredPopupMenuShape,
+  }) : assert(elevation >= 0);
+
+  /// App-wide floating popup menu styling shared by floating controls.
+  static const floatingSurface = AnchoredPopupMenuStyle(
+    color: Color(0xF5FFFFFF),
+    shadowColor: Color(0x14000000),
+    surfaceTintColor: Colors.transparent,
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(16)),
+    ),
+  );
+
+  /// Padding applied around the popup menu content.
+  final EdgeInsetsGeometry padding;
+
+  /// Duration of the popup menu route transition.
+  final Duration transitionDuration;
+
+  /// Material elevation applied to the popup menu surface.
+  final double elevation;
+
+  /// Popup menu background color.
+  ///
+  /// Falls back to `Theme.of(context).colorScheme.surface` when null.
+  final Color? color;
+
+  /// Popup menu shadow color.
+  ///
+  /// Falls back to the current theme shadow color when null.
+  final Color? shadowColor;
+
+  /// Popup menu surface tint color.
+  final Color surfaceTintColor;
+
+  /// Popup menu shape.
+  final ShapeBorder shape;
+}
+
+/// A reusable popup menu trigger that opens a custom menu anchored to itself.
+///
+/// The public API is intentionally split into:
+/// 1. Core behavior: [items], [onSelected], [triggerBuilder]
+/// 2. Layout tweaks: [layout]
+/// 3. Visual styling: [style]
+///
+/// The menu resolves its vertical placement from [layout], then keeps itself
+/// inside the safe area and screen padding. Consumers provide the visual trigger
+/// through [triggerBuilder], keeping menu behavior reusable across different
+/// surfaces.
+///
+/// Example:
+/// ```dart
+/// AnchoredPopupMenuButton<String>(
+///   items: const [
+///     PopupMenuItem(
+///       value: 'refresh',
+///       child: Text('Refresh'),
+///     ),
+///   ],
+///   onSelected: print,
+///   style: const AnchoredPopupMenuStyle(
+///     shape: RoundedRectangleBorder(
+///       borderRadius: BorderRadius.all(Radius.circular(20)),
+///     ),
+///   ),
+///   triggerBuilder: (context, onPressed) {
+///     return FilledButton.icon(
+///       onPressed: onPressed,
+///       icon: const Icon(Icons.more_vert),
+///       label: const Text('Open menu'),
+///     );
+///   },
+/// )
+/// ```
+class AnchoredPopupMenuButton<T> extends StatelessWidget {
+  /// Creates an anchored popup menu trigger.
+  const AnchoredPopupMenuButton({
+    super.key,
+    required this.items,
+    required this.onSelected,
+    required this.triggerBuilder,
+    this.enabled = true,
+    this.tooltip,
+    this.layout = const AnchoredPopupMenuLayout(),
+    this.style = const AnchoredPopupMenuStyle(),
+  });
+
+  /// The popup menu entries shown when the trigger is pressed.
+  final List<PopupMenuEntry<T>> items;
+
+  /// Called with the selected value after the popup menu closes.
+  final ValueChanged<T> onSelected;
+
+  /// Builds the visual trigger.
+  ///
+  /// The callback is null when the menu is disabled and should be wired to the
+  /// trigger's tap handler.
+  final Widget Function(BuildContext context, VoidCallback? onPressed)
+  triggerBuilder;
+
+  /// Whether the trigger can open the popup menu.
+  final bool enabled;
+
+  /// Optional tooltip shown around the trigger.
+  final String? tooltip;
+
+  /// Sizing and positioning configuration for the popup menu.
+  final AnchoredPopupMenuLayout layout;
+
+  /// Surface and transition styling for the popup menu.
+  final AnchoredPopupMenuStyle style;
+
+  bool get _canOpen => enabled && items.isNotEmpty;
+
+  Rect? _resolveAnchorRect(BuildContext context, NavigatorState navigator) {
+    final button = context.findRenderObject() as RenderBox?;
+    final overlay = navigator.overlay?.context.findRenderObject() as RenderBox?;
+    if (button == null || overlay == null) {
+      return null;
+    }
+
+    return Rect.fromPoints(
+      button.localToGlobal(Offset.zero, ancestor: overlay),
+      button.localToGlobal(
+        button.size.bottomRight(Offset.zero),
+        ancestor: overlay,
+      ),
+    );
+  }
+
+  Future<void> _showPopupMenu(BuildContext context) async {
+    if (!_canOpen) {
+      return;
+    }
+
+    final navigator = Navigator.of(context);
+    final anchorRect = _resolveAnchorRect(context, navigator);
+    if (anchorRect == null) {
+      return;
+    }
+
+    final selected = await navigator.push<T>(
+      _AnchoredPopupMenuRoute<T>(
+        anchorRect: anchorRect,
+        items: items,
+        layout: layout,
+        style: style,
+        barrierLabelText: MaterialLocalizations.of(context).menuDismissLabel,
+        capturedThemes: InheritedTheme.capture(
+          from: context,
+          to: navigator.context,
+        ),
+      ),
+    );
+
+    if (selected case final selected?) {
+      onSelected(selected);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final trigger = Builder(
+      builder: (context) {
+        return triggerBuilder(
+          context,
+          _canOpen ? () => _showPopupMenu(context) : null,
+        );
+      },
+    );
+
+    if (tooltip case final tooltip?) {
+      return Tooltip(
+        message: tooltip,
+        child: trigger,
+      );
+    }
+
+    return trigger;
+  }
+}
+
+class _AnchoredPopupMenuRoute<T> extends PopupRoute<T> {
+  _AnchoredPopupMenuRoute({
+    required this.anchorRect,
+    required this.items,
+    required this.layout,
+    required this.style,
+    required this.barrierLabelText,
+    required this.capturedThemes,
+  });
+
+  final Rect anchorRect;
+  final List<PopupMenuEntry<T>> items;
+  final AnchoredPopupMenuLayout layout;
+  final AnchoredPopupMenuStyle style;
+  final String barrierLabelText;
+  final CapturedThemes capturedThemes;
+
+  @override
+  bool get barrierDismissible => true;
+
+  @override
+  Color? get barrierColor => null;
+
+  @override
+  String get barrierLabel => barrierLabelText;
+
+  @override
+  Duration get transitionDuration => style.transitionDuration;
+
+  @override
+  Widget buildPage(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+  ) {
+    final mediaQuery = MediaQuery.of(context);
+    final overlaySize = mediaQuery.size;
+    final placement = layout.resolvePlacement(
+      anchorRect: anchorRect,
+      overlaySize: overlaySize,
+      mediaPadding: mediaQuery.padding,
+    );
+
+    return MediaQuery.removePadding(
+      context: context,
+      removeTop: true,
+      removeBottom: true,
+      removeLeft: true,
+      removeRight: true,
+      child: CustomSingleChildLayout(
+        delegate: _AnchoredPopupMenuRouteLayout(
+          anchorRect: anchorRect,
+          textDirection: Directionality.of(context),
+          mediaPadding: mediaQuery.padding,
+          layout: layout,
+          placement: placement,
+        ),
+        child: capturedThemes.wrap(
+          _AnchoredPopupMenu<T>(
+            animation: animation,
+            items: items,
+            constraints: layout.resolveMenuConstraints(
+              anchorRect: anchorRect,
+              overlaySize: overlaySize,
+              mediaPadding: mediaQuery.padding,
+            ),
+            style: style,
+            placement: placement,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AnchoredPopupMenu<T> extends StatelessWidget {
+  const _AnchoredPopupMenu({
+    required this.animation,
+    required this.items,
+    required this.constraints,
+    required this.style,
+    required this.placement,
+  });
+
+  final Animation<double> animation;
+  final List<PopupMenuEntry<T>> items;
+  final BoxConstraints constraints;
+  final AnchoredPopupMenuStyle style;
+  final AnchoredPopupMenuPlacement placement;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = style.color ?? theme.colorScheme.surface;
+    final shadowColor =
+        style.shadowColor ?? theme.shadowColor.withValues(alpha: 0.08);
+    final growAlignment = switch (placement) {
+      AnchoredPopupMenuPlacement.above => AlignmentDirectional.bottomEnd,
+      AnchoredPopupMenuPlacement.below => AlignmentDirectional.topEnd,
+      AnchoredPopupMenuPlacement.auto => AlignmentDirectional.bottomEnd,
+    };
+    final size = CurvedAnimation(
+      parent: animation,
+      curve: Curves.easeOutCubic,
+      reverseCurve: Curves.easeInCubic,
+    );
+    final opacity = CurvedAnimation(
+      parent: animation,
+      curve: const Interval(0, 0.7, curve: Curves.easeOut),
+      reverseCurve: const Interval(0, 1, curve: Curves.easeIn),
+    );
+
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, child) {
+        return FadeTransition(
+          opacity: opacity,
+          child: Material(
+            color: color,
+            elevation: style.elevation,
+            shadowColor: shadowColor,
+            surfaceTintColor: style.surfaceTintColor,
+            shape: style.shape,
+            clipBehavior: Clip.antiAlias,
+            type: MaterialType.card,
+            child: Align(
+              alignment: growAlignment,
+              widthFactor: 1,
+              heightFactor: size.value,
+              child: child,
+            ),
+          ),
+        );
+      },
+      child: ConstrainedBox(
+        constraints: constraints,
+        child: IntrinsicWidth(
+          stepWidth: 56,
+          child: Semantics(
+            role: SemanticsRole.menu,
+            scopesRoute: true,
+            namesRoute: true,
+            explicitChildNodes: true,
+            label: MaterialLocalizations.of(context).popupMenuLabel,
+            child: SingleChildScrollView(
+              padding: style.padding,
+              child: ListBody(children: items),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AnchoredPopupMenuRouteLayout extends SingleChildLayoutDelegate {
+  _AnchoredPopupMenuRouteLayout({
+    required this.anchorRect,
+    required this.textDirection,
+    required this.mediaPadding,
+    required this.layout,
+    required this.placement,
+  });
+
+  final Rect anchorRect;
+  final TextDirection textDirection;
+  final EdgeInsets mediaPadding;
+  final AnchoredPopupMenuLayout layout;
+  final AnchoredPopupMenuPlacement placement;
+
+  @override
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
+    return BoxConstraints.loose(
+      constraints.biggest,
+    ).deflate(EdgeInsets.all(layout.screenPadding) + mediaPadding);
+  }
+
+  @override
+  Offset getPositionForChild(Size size, Size childSize) {
+    final y = switch (placement) {
+      AnchoredPopupMenuPlacement.above =>
+        anchorRect.top - layout.gap - childSize.height,
+      AnchoredPopupMenuPlacement.below => anchorRect.bottom + layout.gap,
+      AnchoredPopupMenuPlacement.auto => anchorRect.top - layout.gap,
+    };
+
+    return Offset(
+      _clampHorizontal(
+        overlaySize: size,
+        childSize: childSize,
+        x: _resolveHorizontalOffset(size, childSize),
+      ),
+      _clampVertical(
+        overlaySize: size,
+        childSize: childSize,
+        y: y,
+      ),
+    );
+  }
+
+  double _resolveHorizontalOffset(Size overlaySize, Size childSize) {
+    final left = anchorRect.left;
+    final right = overlaySize.width - anchorRect.right;
+
+    return switch (left.compareTo(right)) {
+      > 0 => overlaySize.width - right - childSize.width,
+      < 0 => left,
+      _ => switch (textDirection) {
+        TextDirection.rtl => overlaySize.width - right - childSize.width,
+        TextDirection.ltr => left,
+      },
+    };
+  }
+
+  double _clampHorizontal({
+    required Size overlaySize,
+    required Size childSize,
+    required double x,
+  }) {
+    final minX = layout.screenPadding + mediaPadding.left;
+    final maxX =
+        overlaySize.width -
+        childSize.width -
+        layout.screenPadding -
+        mediaPadding.right;
+
+    return x.clamp(minX, maxX);
+  }
+
+  double _clampVertical({
+    required Size overlaySize,
+    required Size childSize,
+    required double y,
+  }) {
+    final minY = layout.screenPadding + mediaPadding.top;
+    final maxY =
+        overlaySize.height -
+        childSize.height -
+        layout.screenPadding -
+        mediaPadding.bottom;
+
+    return y.clamp(minY, maxY);
+  }
+
+  @override
+  bool shouldRelayout(_AnchoredPopupMenuRouteLayout oldDelegate) {
+    return anchorRect != oldDelegate.anchorRect ||
+        textDirection != oldDelegate.textDirection ||
+        mediaPadding != oldDelegate.mediaPadding ||
+        placement != oldDelegate.placement ||
+        layout.gap != oldDelegate.layout.gap ||
+        layout.screenPadding != oldDelegate.layout.screenPadding;
+  }
+}
+
+@Preview(
+  name: 'AnchoredPopupMenuButton',
+  group: 'Popup Menu',
+  size: Size(420, 220),
+)
+Widget previewAnchoredPopupMenuButton() {
+  return WidgetPreviewFrame(
+    child: Center(
+      child: AnchoredPopupMenuButton<String>(
+        items: const [
+          PopupMenuItem(
+            value: 'refresh',
+            child: Text('Refresh'),
+          ),
+          PopupMenuItem(
+            value: 'display',
+            child: Text('Display options'),
+          ),
+        ],
+        onSelected: (_) {},
+        triggerBuilder: (context, onPressed) {
+          return FilledButton.icon(
+            onPressed: onPressed,
+            icon: const Icon(Icons.more_vert_outlined),
+            label: const Text('Open menu'),
+          );
+        },
+      ),
+    ),
+  );
+}

--- a/lib/components/anchored_popup_menu.dart
+++ b/lib/components/anchored_popup_menu.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart' show SemanticsRole;
 import 'package:flutter/widget_previews.dart';
+import 'package:tattoo/i18n/strings.g.dart';
 
 import 'widget_preview_frame.dart';
 
@@ -337,23 +338,13 @@ class AnchoredPopupMenuButton<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final trigger = Builder(
-      builder: (context) {
-        return triggerBuilder(
-          context,
-          _canOpen ? () => _showPopupMenu(context) : null,
-        );
-      },
+    return Tooltip(
+      message: tooltip ?? t.courseTable.actions.showMoreOptions,
+      child: triggerBuilder(
+        context,
+        _canOpen ? () => _showPopupMenu(context) : null,
+      ),
     );
-
-    if (tooltip case final tooltip?) {
-      return Tooltip(
-        message: tooltip,
-        child: trigger,
-      );
-    }
-
-    return trigger;
   }
 }
 

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -41,7 +41,10 @@ class ScrollAwareFloatingActionBar extends StatefulWidget {
 
 class _ScrollAwareFloatingActionBarState
     extends State<ScrollAwareFloatingActionBar> {
+  static const _dragHideThreshold = 12.0;
+
   bool _isVisible = true;
+  double _dragHideDelta = 0;
 
   bool _handleScrollNotification(ScrollNotification notification) {
     if (notification.metrics.axis != Axis.vertical) {
@@ -74,6 +77,31 @@ class _ScrollAwareFloatingActionBarState
     return false;
   }
 
+  void _handleVerticalDragStart(DragStartDetails details) {
+    _dragHideDelta = 0;
+  }
+
+  void _handleVerticalDragUpdate(DragUpdateDetails details) {
+    final delta = details.primaryDelta;
+    if (delta == null || delta <= 0) {
+      return;
+    }
+
+    _dragHideDelta += delta;
+    if (_dragHideDelta < _dragHideThreshold || !_isVisible) {
+      return;
+    }
+
+    setState(() {
+      _isVisible = false;
+    });
+    _dragHideDelta = 0;
+  }
+
+  void _handleVerticalDragEnd(DragEndDetails details) {
+    _dragHideDelta = 0;
+  }
+
   @override
   Widget build(BuildContext context) {
     final floatingActionBar = widget.floatingActionBarBuilder(
@@ -96,7 +124,16 @@ class _ScrollAwareFloatingActionBarState
               bottom: resolvedMargin.bottom,
               child: Align(
                 alignment: Alignment.bottomCenter,
-                child: floatingActionBar,
+                child: IgnorePointer(
+                  ignoring: !_isVisible,
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.translucent,
+                    onVerticalDragStart: _handleVerticalDragStart,
+                    onVerticalDragUpdate: _handleVerticalDragUpdate,
+                    onVerticalDragEnd: _handleVerticalDragEnd,
+                    child: floatingActionBar,
+                  ),
+                ),
               ),
             ),
         ],

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -72,7 +72,7 @@ class _ScrollAwareFloatingActionBarState
   double _dragHideDelta = 0;
 
   bool _handleScrollNotification(ScrollNotification notification) {
-    if (notification.metrics.axis == Axis.horizontal &&
+    if (notification.metrics.axis == .horizontal &&
         !_isVisible &&
         notification is ScrollUpdateNotification &&
         notification.dragDetails != null) {
@@ -82,7 +82,7 @@ class _ScrollAwareFloatingActionBarState
       return false;
     }
 
-    if (notification.metrics.axis != Axis.vertical) {
+    if (notification.metrics.axis != .vertical) {
       return false;
     }
 
@@ -159,10 +159,10 @@ class _ScrollAwareFloatingActionBarState
     return NotificationListener<ScrollNotification>(
       onNotification: _handleScrollNotification,
       child: Stack(
-        fit: StackFit.expand,
+        fit: .expand,
         children: [
           GestureDetector(
-            behavior: HitTestBehavior.translucent,
+            behavior: .translucent,
             onTap: _toggleFloatingActionBar,
             child: widget.child,
           ),
@@ -177,7 +177,7 @@ class _ScrollAwareFloatingActionBarState
                 child: IgnorePointer(
                   ignoring: !_isVisible,
                   child: GestureDetector(
-                    behavior: HitTestBehavior.translucent,
+                    behavior: .translucent,
                     onVerticalDragStart: _handleVerticalDragStart,
                     onVerticalDragUpdate: _handleVerticalDragUpdate,
                     onVerticalDragEnd: _handleVerticalDragEnd,
@@ -462,7 +462,7 @@ class _FloatingActionBarSurface extends StatelessWidget {
       shadowColor: Colors.black.withValues(alpha: 0.08),
       surfaceTintColor: Colors.transparent,
       shape: shape,
-      clipBehavior: Clip.antiAlias,
+      clipBehavior: .antiAlias,
       child: child,
     );
   }

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -102,6 +102,16 @@ class _ScrollAwareFloatingActionBarState
     _dragHideDelta = 0;
   }
 
+  void _showFloatingActionBar() {
+    if (_isVisible) {
+      return;
+    }
+
+    setState(() {
+      _isVisible = true;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final floatingActionBar = widget.floatingActionBarBuilder(
@@ -115,7 +125,11 @@ class _ScrollAwareFloatingActionBarState
       child: Stack(
         fit: StackFit.expand,
         children: [
-          widget.child,
+          GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: _showFloatingActionBar,
+            child: widget.child,
+          ),
           if (floatingActionBar case final floatingActionBar?)
             Positioned(
               left: resolvedMargin.left,

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -121,12 +121,8 @@ class _ScrollAwareFloatingActionBarState
   }
 
   void _showFloatingActionBar() {
-    if (_isVisible) {
-      return;
-    }
-
     setState(() {
-      _isVisible = true;
+      _isVisible = !_isVisible;
     });
   }
 

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -1,18 +1,32 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart' show SemanticsRole;
 import 'package:flutter/widget_previews.dart';
 import 'package:tattoo/components/chip_tab_switcher.dart';
 import 'package:tattoo/components/widget_preview_frame.dart';
 
+const _floatingActionBarPopupMenuMinWidth = 112.0;
+const _floatingActionBarPopupMenuMaxWidth = 280.0;
+const _floatingActionBarPopupMenuScreenPadding = 8.0;
+const _floatingActionBarPopupMenuGap = 8.0;
+const _floatingActionBarPopupMenuPadding = EdgeInsets.symmetric(vertical: 8.0);
+const _floatingActionBarPopupMenuAnimationDuration = Duration(
+  milliseconds: 220,
+);
+
 /// A layout helper that overlays a floating action bar above a scrollable body.
 ///
-/// The widget listens to descendant [ScrollNotification]s and uses vertical
-/// drag updates to drive the bar visibility:
+/// The widget keeps the bar visibility logic close to the layout instead of
+/// duplicating it in each screen:
 /// 1. Scrolling toward larger offsets hides the bar
 /// 2. Scrolling back toward the top shows the bar
 /// 3. Reaching the top always shows the bar
+/// 4. Tapping the body reveals the bar again when it is hidden
 ///
-/// This keeps scroll-aware visibility behavior close to the floating bar
-/// implementation instead of duplicating gesture logic in each screen.
+/// The [floatingActionBarBuilder] receives the resolved visibility state so the
+/// caller can decide whether to render a [FloatingActionBar] or omit the bar
+/// entirely for the current screen state.
 ///
 /// Example:
 /// ```dart
@@ -120,9 +134,13 @@ class _ScrollAwareFloatingActionBarState
     _dragHideDelta = 0;
   }
 
-  void _showFloatingActionBar() {
+  void _revealFloatingActionBar() {
+    if (_isVisible) {
+      return;
+    }
+
     setState(() {
-      _isVisible = !_isVisible;
+      _isVisible = true;
     });
   }
 
@@ -141,7 +159,7 @@ class _ScrollAwareFloatingActionBarState
         children: [
           GestureDetector(
             behavior: HitTestBehavior.translucent,
-            onTap: _showFloatingActionBar,
+            onTap: _revealFloatingActionBar,
             child: widget.child,
           ),
           if (floatingActionBar case final floatingActionBar?)
@@ -170,7 +188,8 @@ class _ScrollAwareFloatingActionBarState
   }
 }
 
-/// A bottom-floating action bar with one large pill surface and trailing actions.
+/// A bottom-floating action bar with one large pill surface and trailing
+/// circular actions.
 ///
 /// The bar renders:
 /// 1. A primary pill surface that hosts [child]
@@ -182,9 +201,16 @@ class _ScrollAwareFloatingActionBarState
 /// FloatingActionBar(
 ///   visible: isVisible,
 ///   actions: [
-///     FloatingActionBarActionButton(
+///     FloatingActionBarMenuButton<String>(
 ///       icon: Icons.more_vert_outlined,
-///       onTap: onMoreTap,
+///       items: const [
+///         FloatingActionBarMenuItem(
+///           value: 'refresh',
+///           label: 'Refresh',
+///           icon: Icons.refresh_outlined,
+///         ),
+///       ],
+///       onSelected: onMenuSelected,
 ///     ),
 ///   ],
 ///   child: ChipTabSwitcher(
@@ -216,8 +242,8 @@ class FloatingActionBar extends StatelessWidget {
 
   /// Trailing action widgets shown as separate floating surfaces.
   ///
-  /// Use [FloatingActionBarActionButton] for the built-in circular action
-  /// appearance.
+  /// Use [FloatingActionBarActionButton] for tap actions and
+  /// [FloatingActionBarMenuButton] for popup menus.
   final List<Widget> actions;
 
   /// Whether the bar is interactive and visible.
@@ -266,6 +292,9 @@ class FloatingActionBar extends StatelessWidget {
 }
 
 /// A circular trailing action button used by [FloatingActionBar].
+///
+/// Use this for a single tap action that should share the floating action bar's
+/// circular surface style.
 class FloatingActionBarActionButton extends StatelessWidget {
   /// Creates a circular floating action button surface.
   const FloatingActionBarActionButton({
@@ -282,31 +311,475 @@ class FloatingActionBarActionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    return _FloatingActionBarCircularActionSurface(
+      child: Material(
+        color: Colors.transparent,
+        shape: const CircleBorder(),
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          splashFactory: InkRipple.splashFactory,
+          splashColor: Colors.black12,
+          highlightColor: Colors.black12,
+          onTap: onTap,
+          child: _FloatingActionBarActionIcon(icon: icon),
+        ),
+      ),
+    );
+  }
+}
+
+/// A menu item definition used by [FloatingActionBarMenuButton].
+///
+/// Each item maps a displayed label and optional icon to a typed [value] that
+/// is returned to [FloatingActionBarMenuButton.onSelected].
+class FloatingActionBarMenuItem<T> {
+  /// Creates a floating action bar menu item.
+  const FloatingActionBarMenuItem({
+    required this.value,
+    required this.label,
+    this.icon,
+    this.enabled = true,
+  });
+
+  /// The value returned when the menu item is selected.
+  final T value;
+
+  /// The label shown in the popup menu.
+  final String label;
+
+  /// An optional leading icon shown next to the menu item label.
+  final IconData? icon;
+
+  /// Whether the item can be selected.
+  final bool enabled;
+}
+
+/// A circular trailing action that expands into a popup menu.
+///
+/// This is the menu counterpart to [FloatingActionBarActionButton]. It reuses
+/// the same circular surface style, but opens a popup menu built from [items]
+/// and reports the selected item's value through [onSelected].
+///
+/// Multiple action buttons and menu buttons can be mixed in
+/// [FloatingActionBar.actions].
+class FloatingActionBarMenuButton<T> extends StatelessWidget {
+  /// Creates a menu action button for [FloatingActionBar].
+  const FloatingActionBarMenuButton({
+    super.key,
+    required this.icon,
+    required this.items,
+    required this.onSelected,
+    this.tooltip,
+  });
+
+  /// The icon shown at the center of the button.
+  final IconData icon;
+
+  /// The menu items shown when the button is tapped.
+  ///
+  /// Add more entries here to extend the popup menu without changing the
+  /// button's public API.
+  final List<FloatingActionBarMenuItem<T>> items;
+
+  /// Called after the user selects a menu item.
+  final ValueChanged<T> onSelected;
+
+  /// Optional tooltip shown for long-press and accessibility affordances.
+  final String? tooltip;
+
+  bool get _enabled => items.any((item) => item.enabled);
+
+  List<PopupMenuEntry<T>> _buildPopupMenuEntries() {
+    return [
+      for (final item in items)
+        PopupMenuItem<T>(
+          value: item.value,
+          enabled: item.enabled,
+          child: Row(
+            spacing: 12,
+            children: [
+              if (item.icon case final icon?) Icon(icon, size: 20),
+              Flexible(
+                child: Text(
+                  item.label,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+    ];
+  }
+
+  Future<void> _showPopupMenu(BuildContext context) async {
+    if (!_enabled) {
+      return;
+    }
+
+    final navigator = Navigator.of(context);
+    final button = context.findRenderObject() as RenderBox?;
+    final overlay = navigator.overlay?.context.findRenderObject() as RenderBox?;
+    if (button == null || overlay == null) {
+      return;
+    }
+
+    final entries = _buildPopupMenuEntries();
+    final buttonRect = Rect.fromPoints(
+      button.localToGlobal(Offset.zero, ancestor: overlay),
+      button.localToGlobal(
+        button.size.bottomRight(Offset.zero),
+        ancestor: overlay,
+      ),
+    );
+    final mediaPadding = MediaQuery.paddingOf(context);
+    final availableHeightAbove = math.max(
+      0.0,
+      buttonRect.top -
+          mediaPadding.top -
+          _floatingActionBarPopupMenuScreenPadding -
+          _floatingActionBarPopupMenuGap,
+    );
+    final popupMenuConstraints = availableHeightAbove > 0
+        ? BoxConstraints(
+            minWidth: _floatingActionBarPopupMenuMinWidth,
+            maxWidth: _floatingActionBarPopupMenuMaxWidth,
+            maxHeight: availableHeightAbove,
+          )
+        : const BoxConstraints(
+            minWidth: _floatingActionBarPopupMenuMinWidth,
+            maxWidth: _floatingActionBarPopupMenuMaxWidth,
+          );
+
+    final selected = await navigator.push<T>(
+      _FloatingActionBarMenuRoute<T>(
+        anchorRect: buttonRect,
+        items: entries,
+        constraints: popupMenuConstraints,
+        menuPadding: _floatingActionBarPopupMenuPadding,
+        gap: _floatingActionBarPopupMenuGap,
+        barrierLabelText: MaterialLocalizations.of(context).menuDismissLabel,
+        capturedThemes: InheritedTheme.capture(
+          from: context,
+          to: navigator.context,
+        ),
+        elevation: 4,
+        color: Colors.white.withValues(alpha: 0.96),
+        shadowColor: Colors.black.withValues(alpha: 0.08),
+        surfaceTintColor: Colors.transparent,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+      ),
+    );
+
+    if (selected case final selected?) {
+      onSelected(selected);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tooltip = this.tooltip;
+    final button = _FloatingActionBarCircularActionSurface(
+      child: Material(
+        color: Colors.transparent,
+        shape: const CircleBorder(),
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          splashFactory: InkRipple.splashFactory,
+          splashColor: Colors.black12,
+          highlightColor: Colors.black12,
+          onTap: _enabled ? () => _showPopupMenu(context) : null,
+          child: _FloatingActionBarActionIcon(icon: icon),
+        ),
+      ),
+    );
+
+    if (tooltip == null) {
+      return button;
+    }
+
+    return Tooltip(
+      message: tooltip,
+      child: button,
+    );
+  }
+}
+
+class _FloatingActionBarMenuRoute<T> extends PopupRoute<T> {
+  _FloatingActionBarMenuRoute({
+    required this.anchorRect,
+    required this.items,
+    required this.constraints,
+    required this.menuPadding,
+    required this.gap,
+    required this.barrierLabelText,
+    required this.capturedThemes,
+    required this.elevation,
+    required this.color,
+    required this.shadowColor,
+    required this.surfaceTintColor,
+    required this.shape,
+  });
+
+  final Rect anchorRect;
+  final List<PopupMenuEntry<T>> items;
+  final BoxConstraints constraints;
+  final EdgeInsetsGeometry menuPadding;
+  final double gap;
+  final String barrierLabelText;
+  final CapturedThemes capturedThemes;
+  final double elevation;
+  final Color color;
+  final Color shadowColor;
+  final Color surfaceTintColor;
+  final ShapeBorder shape;
+
+  @override
+  bool get barrierDismissible => true;
+
+  @override
+  Color? get barrierColor => null;
+
+  @override
+  String get barrierLabel => barrierLabelText;
+
+  @override
+  Duration get transitionDuration =>
+      _floatingActionBarPopupMenuAnimationDuration;
+
+  @override
+  Widget buildPage(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+  ) {
+    final menu = _FloatingActionBarPopupMenu<T>(
+      animation: animation,
+      items: items,
+      constraints: constraints,
+      menuPadding: menuPadding,
+      elevation: elevation,
+      color: color,
+      shadowColor: shadowColor,
+      surfaceTintColor: surfaceTintColor,
+      shape: shape,
+    );
+    final mediaQuery = MediaQuery.of(context);
+
+    return MediaQuery.removePadding(
+      context: context,
+      removeTop: true,
+      removeBottom: true,
+      removeLeft: true,
+      removeRight: true,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return CustomSingleChildLayout(
+            delegate: _FloatingActionBarMenuRouteLayout(
+              anchorRect: anchorRect,
+              textDirection: Directionality.of(context),
+              padding: mediaQuery.padding,
+              gap: gap,
+            ),
+            child: capturedThemes.wrap(menu),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _FloatingActionBarPopupMenu<T> extends StatelessWidget {
+  const _FloatingActionBarPopupMenu({
+    required this.animation,
+    required this.items,
+    required this.constraints,
+    required this.menuPadding,
+    required this.elevation,
+    required this.color,
+    required this.shadowColor,
+    required this.surfaceTintColor,
+    required this.shape,
+  });
+
+  final Animation<double> animation;
+  final List<PopupMenuEntry<T>> items;
+  final BoxConstraints constraints;
+  final EdgeInsetsGeometry menuPadding;
+  final double elevation;
+  final Color color;
+  final Color shadowColor;
+  final Color surfaceTintColor;
+  final ShapeBorder shape;
+
+  @override
+  Widget build(BuildContext context) {
+    final size = CurvedAnimation(
+      parent: animation,
+      curve: Curves.easeOutCubic,
+      reverseCurve: Curves.easeInCubic,
+    );
+    final opacity = CurvedAnimation(
+      parent: animation,
+      curve: const Interval(0, 0.7, curve: Curves.easeOut),
+      reverseCurve: const Interval(0, 1, curve: Curves.easeIn),
+    );
+    final content = ConstrainedBox(
+      constraints: constraints,
+      child: IntrinsicWidth(
+        stepWidth: 56,
+        child: Semantics(
+          role: SemanticsRole.menu,
+          scopesRoute: true,
+          namesRoute: true,
+          explicitChildNodes: true,
+          label: MaterialLocalizations.of(context).popupMenuLabel,
+          child: SingleChildScrollView(
+            padding: menuPadding,
+            child: ListBody(children: items),
+          ),
+        ),
+      ),
+    );
+
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, child) {
+        return FadeTransition(
+          opacity: opacity,
+          child: Material(
+            color: color,
+            elevation: elevation,
+            shadowColor: shadowColor,
+            surfaceTintColor: surfaceTintColor,
+            shape: shape,
+            clipBehavior: Clip.antiAlias,
+            type: MaterialType.card,
+            child: Align(
+              alignment: AlignmentDirectional.bottomEnd,
+              widthFactor: 1,
+              heightFactor: size.value,
+              child: child,
+            ),
+          ),
+        );
+      },
+      child: content,
+    );
+  }
+}
+
+class _FloatingActionBarMenuRouteLayout extends SingleChildLayoutDelegate {
+  _FloatingActionBarMenuRouteLayout({
+    required this.anchorRect,
+    required this.textDirection,
+    required this.padding,
+    required this.gap,
+  });
+
+  final Rect anchorRect;
+  final TextDirection textDirection;
+  final EdgeInsets padding;
+  final double gap;
+
+  @override
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
+    return BoxConstraints.loose(
+      constraints.biggest,
+    ).deflate(
+      const EdgeInsets.all(_floatingActionBarPopupMenuScreenPadding) + padding,
+    );
+  }
+
+  @override
+  Offset getPositionForChild(Size size, Size childSize) {
+    final left = anchorRect.left;
+    final right = size.width - anchorRect.right;
+
+    final x = switch (left.compareTo(right)) {
+      > 0 => size.width - right - childSize.width,
+      < 0 => left,
+      _ => switch (textDirection) {
+        TextDirection.rtl => size.width - right - childSize.width,
+        TextDirection.ltr => left,
+      },
+    };
+    final y = anchorRect.top - gap - childSize.height;
+
+    return Offset(
+      _clampHorizontal(size, childSize, x),
+      _clampVertical(size, childSize, y),
+    );
+  }
+
+  double _clampHorizontal(Size overlaySize, Size childSize, double x) {
+    final minX = _floatingActionBarPopupMenuScreenPadding + padding.left;
+    final maxX =
+        overlaySize.width -
+        childSize.width -
+        _floatingActionBarPopupMenuScreenPadding -
+        padding.right;
+
+    return x.clamp(minX, maxX);
+  }
+
+  double _clampVertical(Size overlaySize, Size childSize, double y) {
+    final minY = _floatingActionBarPopupMenuScreenPadding + padding.top;
+    final maxY =
+        overlaySize.height -
+        childSize.height -
+        _floatingActionBarPopupMenuScreenPadding -
+        padding.bottom;
+
+    return y.clamp(minY, maxY);
+  }
+
+  @override
+  bool shouldRelayout(_FloatingActionBarMenuRouteLayout oldDelegate) {
+    return anchorRect != oldDelegate.anchorRect ||
+        textDirection != oldDelegate.textDirection ||
+        padding != oldDelegate.padding ||
+        gap != oldDelegate.gap;
+  }
+}
+
+class _FloatingActionBarCircularActionSurface extends StatelessWidget {
+  const _FloatingActionBarCircularActionSurface({
+    required this.child,
+  });
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
     return SizedBox.square(
       dimension: 52,
       child: _FloatingActionBarSurface(
         shape: const CircleBorder(),
-        child: Material(
-          color: Colors.transparent,
-          shape: const CircleBorder(),
-          child: InkWell(
-            customBorder: const CircleBorder(),
-            splashFactory: InkRipple.splashFactory,
-            splashColor: Colors.black12,
-            highlightColor: Colors.black12,
-            onTap: onTap,
-            child: LayoutBuilder(
-              builder: (context, constraints) {
-                final iconSize = constraints.biggest.shortestSide * 0.4;
-
-                return Center(
-                  child: Icon(icon, size: iconSize),
-                );
-              },
-            ),
-          ),
-        ),
+        child: child,
       ),
+    );
+  }
+}
+
+class _FloatingActionBarActionIcon extends StatelessWidget {
+  const _FloatingActionBarActionIcon({
+    required this.icon,
+  });
+
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final iconSize = constraints.biggest.shortestSide * 0.4;
+
+        return Center(
+          child: Icon(icon, size: iconSize),
+        );
+      },
     );
   }
 }
@@ -354,9 +827,21 @@ Widget previewFloatingActionBar() {
               icon: Icons.share_outlined,
               onTap: () {},
             ),
-            FloatingActionBarActionButton(
+            FloatingActionBarMenuButton<String>(
               icon: Icons.more_vert_outlined,
-              onTap: () {},
+              items: const [
+                FloatingActionBarMenuItem(
+                  value: 'refresh',
+                  label: 'Refresh',
+                  icon: Icons.refresh_outlined,
+                ),
+                FloatingActionBarMenuItem(
+                  value: 'display',
+                  label: 'Display options',
+                  icon: Icons.tune_outlined,
+                ),
+              ],
+              onSelected: (_) {},
             ),
           ],
           child: ChipTabSwitcher(
@@ -387,9 +872,21 @@ Widget previewScrollAwareFloatingActionBar() {
           floatingActionBarBuilder: (context, visible) => FloatingActionBar(
             visible: visible,
             actions: [
-              FloatingActionBarActionButton(
+              FloatingActionBarMenuButton<String>(
                 icon: Icons.more_vert_outlined,
-                onTap: () {},
+                items: const [
+                  FloatingActionBarMenuItem(
+                    value: 'refresh',
+                    label: 'Refresh',
+                    icon: Icons.refresh_outlined,
+                  ),
+                  FloatingActionBarMenuItem(
+                    value: 'display',
+                    label: 'Display options',
+                    icon: Icons.tune_outlined,
+                  ),
+                ],
+                onSelected: (_) {},
               ),
             ],
             child: ChipTabSwitcher(

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -1,19 +1,8 @@
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart' show SemanticsRole;
 import 'package:flutter/widget_previews.dart';
+import 'package:tattoo/components/anchored_popup_menu.dart';
 import 'package:tattoo/components/chip_tab_switcher.dart';
 import 'package:tattoo/components/widget_preview_frame.dart';
-
-const _floatingActionBarPopupMenuMinWidth = 112.0;
-const _floatingActionBarPopupMenuMaxWidth = 280.0;
-const _floatingActionBarPopupMenuScreenPadding = 8.0;
-const _floatingActionBarPopupMenuGap = 8.0;
-const _floatingActionBarPopupMenuPadding = EdgeInsets.symmetric(vertical: 8.0);
-const _floatingActionBarPopupMenuAnimationDuration = Duration(
-  milliseconds: 220,
-);
 
 /// A layout helper that overlays a floating action bar above a scrollable body.
 ///
@@ -204,10 +193,12 @@ class _ScrollAwareFloatingActionBarState
 ///     FloatingActionBarMenuButton<String>(
 ///       icon: Icons.more_vert_outlined,
 ///       items: const [
-///         FloatingActionBarMenuItem(
+///         PopupMenuItem(
 ///           value: 'refresh',
-///           label: 'Refresh',
-///           icon: Icons.refresh_outlined,
+///           child: ListTile(
+///             leading: Icon(Icons.refresh_outlined),
+///             title: Text('Refresh'),
+///           ),
 ///         ),
 ///       ],
 ///       onSelected: onMenuSelected,
@@ -312,46 +303,12 @@ class FloatingActionBarActionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return _FloatingActionBarCircularActionSurface(
-      child: Material(
-        color: Colors.transparent,
-        shape: const CircleBorder(),
-        child: InkWell(
-          customBorder: const CircleBorder(),
-          splashFactory: InkRipple.splashFactory,
-          splashColor: Colors.black12,
-          highlightColor: Colors.black12,
-          onTap: onTap,
-          child: _FloatingActionBarActionIcon(icon: icon),
-        ),
+      child: _FloatingActionBarIconButton(
+        icon: icon,
+        onTap: onTap,
       ),
     );
   }
-}
-
-/// A menu item definition used by [FloatingActionBarMenuButton].
-///
-/// Each item maps a displayed label and optional icon to a typed [value] that
-/// is returned to [FloatingActionBarMenuButton.onSelected].
-class FloatingActionBarMenuItem<T> {
-  /// Creates a floating action bar menu item.
-  const FloatingActionBarMenuItem({
-    required this.value,
-    required this.label,
-    this.icon,
-    this.enabled = true,
-  });
-
-  /// The value returned when the menu item is selected.
-  final T value;
-
-  /// The label shown in the popup menu.
-  final String label;
-
-  /// An optional leading icon shown next to the menu item label.
-  final IconData? icon;
-
-  /// Whether the item can be selected.
-  final bool enabled;
 }
 
 /// A circular trailing action that expands into a popup menu.
@@ -369,378 +326,46 @@ class FloatingActionBarMenuButton<T> extends StatelessWidget {
     required this.icon,
     required this.items,
     required this.onSelected,
+    this.enabled = true,
     this.tooltip,
+    this.style = AnchoredPopupMenuStyle.floatingSurface,
   });
 
   /// The icon shown at the center of the button.
   final IconData icon;
 
-  /// The menu items shown when the button is tapped.
-  ///
-  /// Add more entries here to extend the popup menu without changing the
-  /// button's public API.
-  final List<FloatingActionBarMenuItem<T>> items;
+  /// The popup menu entries shown when the button is tapped.
+  final List<PopupMenuEntry<T>> items;
 
   /// Called after the user selects a menu item.
   final ValueChanged<T> onSelected;
 
+  /// Whether the trigger can open the popup menu.
+  final bool enabled;
+
   /// Optional tooltip shown for long-press and accessibility affordances.
   final String? tooltip;
 
-  bool get _enabled => items.any((item) => item.enabled);
-
-  List<PopupMenuEntry<T>> _buildPopupMenuEntries() {
-    return [
-      for (final item in items)
-        PopupMenuItem<T>(
-          value: item.value,
-          enabled: item.enabled,
-          child: Row(
-            spacing: 12,
-            children: [
-              if (item.icon case final icon?) Icon(icon, size: 20),
-              Flexible(
-                child: Text(
-                  item.label,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            ],
-          ),
-        ),
-    ];
-  }
-
-  Future<void> _showPopupMenu(BuildContext context) async {
-    if (!_enabled) {
-      return;
-    }
-
-    final navigator = Navigator.of(context);
-    final button = context.findRenderObject() as RenderBox?;
-    final overlay = navigator.overlay?.context.findRenderObject() as RenderBox?;
-    if (button == null || overlay == null) {
-      return;
-    }
-
-    final entries = _buildPopupMenuEntries();
-    final buttonRect = Rect.fromPoints(
-      button.localToGlobal(Offset.zero, ancestor: overlay),
-      button.localToGlobal(
-        button.size.bottomRight(Offset.zero),
-        ancestor: overlay,
-      ),
-    );
-    final mediaPadding = MediaQuery.paddingOf(context);
-    final availableHeightAbove = math.max(
-      0.0,
-      buttonRect.top -
-          mediaPadding.top -
-          _floatingActionBarPopupMenuScreenPadding -
-          _floatingActionBarPopupMenuGap,
-    );
-    final popupMenuConstraints = availableHeightAbove > 0
-        ? BoxConstraints(
-            minWidth: _floatingActionBarPopupMenuMinWidth,
-            maxWidth: _floatingActionBarPopupMenuMaxWidth,
-            maxHeight: availableHeightAbove,
-          )
-        : const BoxConstraints(
-            minWidth: _floatingActionBarPopupMenuMinWidth,
-            maxWidth: _floatingActionBarPopupMenuMaxWidth,
-          );
-
-    final selected = await navigator.push<T>(
-      _FloatingActionBarMenuRoute<T>(
-        anchorRect: buttonRect,
-        items: entries,
-        constraints: popupMenuConstraints,
-        menuPadding: _floatingActionBarPopupMenuPadding,
-        gap: _floatingActionBarPopupMenuGap,
-        barrierLabelText: MaterialLocalizations.of(context).menuDismissLabel,
-        capturedThemes: InheritedTheme.capture(
-          from: context,
-          to: navigator.context,
-        ),
-        elevation: 4,
-        color: Colors.white.withValues(alpha: 0.96),
-        shadowColor: Colors.black.withValues(alpha: 0.08),
-        surfaceTintColor: Colors.transparent,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(16),
-        ),
-      ),
-    );
-
-    if (selected case final selected?) {
-      onSelected(selected);
-    }
-  }
+  /// Popup menu styling shared across floating action surfaces.
+  final AnchoredPopupMenuStyle style;
 
   @override
   Widget build(BuildContext context) {
-    final tooltip = this.tooltip;
-    final button = _FloatingActionBarCircularActionSurface(
-      child: Material(
-        color: Colors.transparent,
-        shape: const CircleBorder(),
-        child: InkWell(
-          customBorder: const CircleBorder(),
-          splashFactory: InkRipple.splashFactory,
-          splashColor: Colors.black12,
-          highlightColor: Colors.black12,
-          onTap: _enabled ? () => _showPopupMenu(context) : null,
-          child: _FloatingActionBarActionIcon(icon: icon),
-        ),
-      ),
-    );
-
-    if (tooltip == null) {
-      return button;
-    }
-
-    return Tooltip(
-      message: tooltip,
-      child: button,
-    );
-  }
-}
-
-class _FloatingActionBarMenuRoute<T> extends PopupRoute<T> {
-  _FloatingActionBarMenuRoute({
-    required this.anchorRect,
-    required this.items,
-    required this.constraints,
-    required this.menuPadding,
-    required this.gap,
-    required this.barrierLabelText,
-    required this.capturedThemes,
-    required this.elevation,
-    required this.color,
-    required this.shadowColor,
-    required this.surfaceTintColor,
-    required this.shape,
-  });
-
-  final Rect anchorRect;
-  final List<PopupMenuEntry<T>> items;
-  final BoxConstraints constraints;
-  final EdgeInsetsGeometry menuPadding;
-  final double gap;
-  final String barrierLabelText;
-  final CapturedThemes capturedThemes;
-  final double elevation;
-  final Color color;
-  final Color shadowColor;
-  final Color surfaceTintColor;
-  final ShapeBorder shape;
-
-  @override
-  bool get barrierDismissible => true;
-
-  @override
-  Color? get barrierColor => null;
-
-  @override
-  String get barrierLabel => barrierLabelText;
-
-  @override
-  Duration get transitionDuration =>
-      _floatingActionBarPopupMenuAnimationDuration;
-
-  @override
-  Widget buildPage(
-    BuildContext context,
-    Animation<double> animation,
-    Animation<double> secondaryAnimation,
-  ) {
-    final menu = _FloatingActionBarPopupMenu<T>(
-      animation: animation,
+    return AnchoredPopupMenuButton<T>(
       items: items,
-      constraints: constraints,
-      menuPadding: menuPadding,
-      elevation: elevation,
-      color: color,
-      shadowColor: shadowColor,
-      surfaceTintColor: surfaceTintColor,
-      shape: shape,
-    );
-    final mediaQuery = MediaQuery.of(context);
-
-    return MediaQuery.removePadding(
-      context: context,
-      removeTop: true,
-      removeBottom: true,
-      removeLeft: true,
-      removeRight: true,
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          return CustomSingleChildLayout(
-            delegate: _FloatingActionBarMenuRouteLayout(
-              anchorRect: anchorRect,
-              textDirection: Directionality.of(context),
-              padding: mediaQuery.padding,
-              gap: gap,
-            ),
-            child: capturedThemes.wrap(menu),
-          );
-        },
-      ),
-    );
-  }
-}
-
-class _FloatingActionBarPopupMenu<T> extends StatelessWidget {
-  const _FloatingActionBarPopupMenu({
-    required this.animation,
-    required this.items,
-    required this.constraints,
-    required this.menuPadding,
-    required this.elevation,
-    required this.color,
-    required this.shadowColor,
-    required this.surfaceTintColor,
-    required this.shape,
-  });
-
-  final Animation<double> animation;
-  final List<PopupMenuEntry<T>> items;
-  final BoxConstraints constraints;
-  final EdgeInsetsGeometry menuPadding;
-  final double elevation;
-  final Color color;
-  final Color shadowColor;
-  final Color surfaceTintColor;
-  final ShapeBorder shape;
-
-  @override
-  Widget build(BuildContext context) {
-    final size = CurvedAnimation(
-      parent: animation,
-      curve: Curves.easeOutCubic,
-      reverseCurve: Curves.easeInCubic,
-    );
-    final opacity = CurvedAnimation(
-      parent: animation,
-      curve: const Interval(0, 0.7, curve: Curves.easeOut),
-      reverseCurve: const Interval(0, 1, curve: Curves.easeIn),
-    );
-    final content = ConstrainedBox(
-      constraints: constraints,
-      child: IntrinsicWidth(
-        stepWidth: 56,
-        child: Semantics(
-          role: SemanticsRole.menu,
-          scopesRoute: true,
-          namesRoute: true,
-          explicitChildNodes: true,
-          label: MaterialLocalizations.of(context).popupMenuLabel,
-          child: SingleChildScrollView(
-            padding: menuPadding,
-            child: ListBody(children: items),
-          ),
-        ),
-      ),
-    );
-
-    return AnimatedBuilder(
-      animation: animation,
-      builder: (context, child) {
-        return FadeTransition(
-          opacity: opacity,
-          child: Material(
-            color: color,
-            elevation: elevation,
-            shadowColor: shadowColor,
-            surfaceTintColor: surfaceTintColor,
-            shape: shape,
-            clipBehavior: Clip.antiAlias,
-            type: MaterialType.card,
-            child: Align(
-              alignment: AlignmentDirectional.bottomEnd,
-              widthFactor: 1,
-              heightFactor: size.value,
-              child: child,
-            ),
+      onSelected: onSelected,
+      enabled: enabled,
+      tooltip: tooltip,
+      style: style,
+      triggerBuilder: (context, onPressed) {
+        return _FloatingActionBarCircularActionSurface(
+          child: _FloatingActionBarIconButton(
+            icon: icon,
+            onTap: onPressed,
           ),
         );
       },
-      child: content,
     );
-  }
-}
-
-class _FloatingActionBarMenuRouteLayout extends SingleChildLayoutDelegate {
-  _FloatingActionBarMenuRouteLayout({
-    required this.anchorRect,
-    required this.textDirection,
-    required this.padding,
-    required this.gap,
-  });
-
-  final Rect anchorRect;
-  final TextDirection textDirection;
-  final EdgeInsets padding;
-  final double gap;
-
-  @override
-  BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
-    return BoxConstraints.loose(
-      constraints.biggest,
-    ).deflate(
-      const EdgeInsets.all(_floatingActionBarPopupMenuScreenPadding) + padding,
-    );
-  }
-
-  @override
-  Offset getPositionForChild(Size size, Size childSize) {
-    final left = anchorRect.left;
-    final right = size.width - anchorRect.right;
-
-    final x = switch (left.compareTo(right)) {
-      > 0 => size.width - right - childSize.width,
-      < 0 => left,
-      _ => switch (textDirection) {
-        TextDirection.rtl => size.width - right - childSize.width,
-        TextDirection.ltr => left,
-      },
-    };
-    final y = anchorRect.top - gap - childSize.height;
-
-    return Offset(
-      _clampHorizontal(size, childSize, x),
-      _clampVertical(size, childSize, y),
-    );
-  }
-
-  double _clampHorizontal(Size overlaySize, Size childSize, double x) {
-    final minX = _floatingActionBarPopupMenuScreenPadding + padding.left;
-    final maxX =
-        overlaySize.width -
-        childSize.width -
-        _floatingActionBarPopupMenuScreenPadding -
-        padding.right;
-
-    return x.clamp(minX, maxX);
-  }
-
-  double _clampVertical(Size overlaySize, Size childSize, double y) {
-    final minY = _floatingActionBarPopupMenuScreenPadding + padding.top;
-    final maxY =
-        overlaySize.height -
-        childSize.height -
-        _floatingActionBarPopupMenuScreenPadding -
-        padding.bottom;
-
-    return y.clamp(minY, maxY);
-  }
-
-  @override
-  bool shouldRelayout(_FloatingActionBarMenuRouteLayout oldDelegate) {
-    return anchorRect != oldDelegate.anchorRect ||
-        textDirection != oldDelegate.textDirection ||
-        padding != oldDelegate.padding ||
-        gap != oldDelegate.gap;
   }
 }
 
@@ -763,23 +388,32 @@ class _FloatingActionBarCircularActionSurface extends StatelessWidget {
   }
 }
 
-class _FloatingActionBarActionIcon extends StatelessWidget {
-  const _FloatingActionBarActionIcon({
+class _FloatingActionBarIconButton extends StatelessWidget {
+  const _FloatingActionBarIconButton({
     required this.icon,
+    required this.onTap,
   });
 
+  static const _iconSize = 20.0;
+
   final IconData icon;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final iconSize = constraints.biggest.shortestSide * 0.4;
-
-        return Center(
-          child: Icon(icon, size: iconSize),
-        );
-      },
+    return Material(
+      color: Colors.transparent,
+      shape: const CircleBorder(),
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        splashFactory: InkRipple.splashFactory,
+        splashColor: Colors.black12,
+        highlightColor: Colors.black12,
+        onTap: onTap,
+        child: Center(
+          child: Icon(icon, size: _iconSize),
+        ),
+      ),
     );
   }
 }
@@ -830,15 +464,19 @@ Widget previewFloatingActionBar() {
             FloatingActionBarMenuButton<String>(
               icon: Icons.more_vert_outlined,
               items: const [
-                FloatingActionBarMenuItem(
+                PopupMenuItem(
                   value: 'refresh',
-                  label: 'Refresh',
-                  icon: Icons.refresh_outlined,
+                  child: const ListTile(
+                    leading: Icon(Icons.refresh_outlined),
+                    title: Text('Refresh'),
+                  ),
                 ),
-                FloatingActionBarMenuItem(
+                PopupMenuItem(
                   value: 'display',
-                  label: 'Display options',
-                  icon: Icons.tune_outlined,
+                  child: const ListTile(
+                    leading: Icon(Icons.tune_outlined),
+                    title: Text('Display options'),
+                  ),
                 ),
               ],
               onSelected: (_) {},
@@ -875,15 +513,19 @@ Widget previewScrollAwareFloatingActionBar() {
               FloatingActionBarMenuButton<String>(
                 icon: Icons.more_vert_outlined,
                 items: const [
-                  FloatingActionBarMenuItem(
+                  PopupMenuItem(
                     value: 'refresh',
-                    label: 'Refresh',
-                    icon: Icons.refresh_outlined,
+                    child: const ListTile(
+                      leading: Icon(Icons.refresh_outlined),
+                      title: Text('Refresh'),
+                    ),
                   ),
-                  FloatingActionBarMenuItem(
+                  PopupMenuItem(
                     value: 'display',
-                    label: 'Display options',
-                    icon: Icons.tune_outlined,
+                    child: const ListTile(
+                      leading: Icon(Icons.tune_outlined),
+                      title: Text('Display options'),
+                    ),
                   ),
                 ],
                 onSelected: (_) {},

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -13,6 +13,24 @@ import 'package:tattoo/components/widget_preview_frame.dart';
 ///
 /// This keeps scroll-aware visibility behavior close to the floating bar
 /// implementation instead of duplicating gesture logic in each screen.
+///
+/// Example:
+/// ```dart
+/// ScrollAwareFloatingActionBar(
+///   floatingActionBarBuilder: (context, visible) => FloatingActionBar(
+///     visible: visible,
+///     child: ChipTabSwitcher(
+///       tabs: const ['114-2', '114-1', '113-2'],
+///     ),
+///   ),
+///   child: ListView.builder(
+///     itemCount: 20,
+///     itemBuilder: (context, index) => ListTile(
+///       title: Text('Row $index'),
+///     ),
+///   ),
+/// )
+/// ```
 class ScrollAwareFloatingActionBar extends StatefulWidget {
   /// Creates a layout with a scroll-aware floating action bar overlay.
   const ScrollAwareFloatingActionBar({

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -1,0 +1,345 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widget_previews.dart';
+import 'package:tattoo/components/chip_tab_switcher.dart';
+import 'package:tattoo/components/widget_preview_frame.dart';
+
+/// A layout helper that overlays a floating action bar above a scrollable body.
+///
+/// The widget listens to descendant [ScrollNotification]s and uses vertical
+/// drag updates to drive the bar visibility:
+/// 1. Scrolling toward larger offsets hides the bar
+/// 2. Scrolling back toward the top shows the bar
+/// 3. Reaching the top always shows the bar
+///
+/// This keeps scroll-aware visibility behavior close to the floating bar
+/// implementation instead of duplicating gesture logic in each screen.
+class ScrollAwareFloatingActionBar extends StatefulWidget {
+  /// Creates a layout with a scroll-aware floating action bar overlay.
+  const ScrollAwareFloatingActionBar({
+    super.key,
+    required this.child,
+    required this.floatingActionBarBuilder,
+    this.margin = const EdgeInsets.all(16),
+  });
+
+  /// The scrollable content rendered behind the floating action bar.
+  final Widget child;
+
+  /// Builds the floating action bar using the resolved visibility state.
+  ///
+  /// Return null when the current screen state should not show a bar at all.
+  final Widget? Function(BuildContext context, bool visible)
+  floatingActionBarBuilder;
+
+  /// Margin applied when positioning the floating action bar overlay.
+  final EdgeInsetsGeometry margin;
+
+  @override
+  State<ScrollAwareFloatingActionBar> createState() =>
+      _ScrollAwareFloatingActionBarState();
+}
+
+class _ScrollAwareFloatingActionBarState
+    extends State<ScrollAwareFloatingActionBar> {
+  bool _isVisible = true;
+
+  bool _handleScrollNotification(ScrollNotification notification) {
+    if (notification.metrics.axis != Axis.vertical) {
+      return false;
+    }
+
+    final nextVisible = switch (notification) {
+      OverscrollNotification(:final metrics) when metrics.pixels <= 0 => true,
+      ScrollUpdateNotification(
+        dragDetails: final DragUpdateDetails _,
+        metrics: final metrics,
+      )
+          when metrics.pixels <= 0 =>
+        true,
+      ScrollUpdateNotification(
+        dragDetails: final DragUpdateDetails _,
+        scrollDelta: final scrollDelta?,
+      ) =>
+        scrollDelta < 0,
+      _ => _isVisible,
+    };
+
+    if (nextVisible == _isVisible) {
+      return false;
+    }
+
+    setState(() {
+      _isVisible = nextVisible;
+    });
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final floatingActionBar = widget.floatingActionBarBuilder(
+      context,
+      _isVisible,
+    );
+    final resolvedMargin = widget.margin.resolve(Directionality.of(context));
+
+    return NotificationListener<ScrollNotification>(
+      onNotification: _handleScrollNotification,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          widget.child,
+          if (floatingActionBar case final floatingActionBar?)
+            Positioned(
+              left: resolvedMargin.left,
+              top: resolvedMargin.top,
+              right: resolvedMargin.right,
+              bottom: resolvedMargin.bottom,
+              child: Align(
+                alignment: Alignment.bottomCenter,
+                child: floatingActionBar,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A bottom-floating action bar with one large pill surface and trailing actions.
+///
+/// The bar renders:
+/// 1. A primary pill surface that hosts [child]
+/// 2. Zero or more trailing action surfaces from [actions]
+/// 3. Slide and fade visibility transitions controlled by [visible]
+///
+/// Example:
+/// ```dart
+/// FloatingActionBar(
+///   visible: isVisible,
+///   actions: [
+///     FloatingActionBarActionButton(
+///       icon: Icons.more_vert_outlined,
+///       onTap: onMoreTap,
+///     ),
+///   ],
+///   child: ChipTabSwitcher(
+///     tabs: const ['114-2', '114-1', '113-2'],
+///     padding: const EdgeInsets.symmetric(horizontal: 12),
+///   ),
+/// )
+/// ```
+class FloatingActionBar extends StatelessWidget {
+  /// Creates a [FloatingActionBar] with one main content surface and
+  /// optional trailing action surfaces.
+  const FloatingActionBar({
+    super.key,
+    required this.child,
+    this.actions = const [],
+    this.visible = true,
+    this.spacing = 8,
+    this.contentPadding = const EdgeInsets.symmetric(vertical: 8),
+  });
+
+  static const _animationDuration = Duration(milliseconds: 200);
+  static const _motionCurve = Curves.easeInOutCubic;
+
+  /// The main content rendered inside the large pill surface.
+  ///
+  /// This is typically a horizontally scrollable control such as
+  /// [ChipTabSwitcher].
+  final Widget child;
+
+  /// Trailing action widgets shown as separate floating surfaces.
+  ///
+  /// Use [FloatingActionBarActionButton] for the built-in circular action
+  /// appearance.
+  final List<Widget> actions;
+
+  /// Whether the bar is interactive and visible.
+  ///
+  /// When false, the bar fades and slides downward, and pointer interaction is
+  /// disabled.
+  final bool visible;
+
+  /// Spacing between the pill surface and action surfaces.
+  final double spacing;
+
+  /// Padding applied inside the pill surface.
+  final EdgeInsetsGeometry contentPadding;
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      ignoring: !visible,
+      child: AnimatedSlide(
+        duration: _animationDuration,
+        curve: _motionCurve,
+        offset: visible ? Offset.zero : const Offset(0, 1),
+        child: AnimatedOpacity(
+          duration: _animationDuration,
+          curve: _motionCurve,
+          opacity: visible ? 1 : 0,
+          child: Row(
+            spacing: spacing,
+            children: [
+              Expanded(
+                child: _FloatingActionBarSurface(
+                  shape: const StadiumBorder(),
+                  child: Padding(
+                    padding: contentPadding,
+                    child: child,
+                  ),
+                ),
+              ),
+              ...actions,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A circular trailing action button used by [FloatingActionBar].
+class FloatingActionBarActionButton extends StatelessWidget {
+  /// Creates a circular floating action button surface.
+  const FloatingActionBarActionButton({
+    super.key,
+    required this.icon,
+    required this.onTap,
+  });
+
+  /// The icon shown at the center of the button.
+  final IconData icon;
+
+  /// Called when the button is tapped.
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: 52,
+      child: _FloatingActionBarSurface(
+        shape: const CircleBorder(),
+        child: Material(
+          color: Colors.transparent,
+          shape: const CircleBorder(),
+          child: InkWell(
+            customBorder: const CircleBorder(),
+            splashFactory: InkRipple.splashFactory,
+            splashColor: Colors.black12,
+            highlightColor: Colors.black12,
+            onTap: onTap,
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final iconSize = constraints.biggest.shortestSide * 0.4;
+
+                return Center(
+                  child: Icon(icon, size: iconSize),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Shared shaped material surface used by the floating bar and action buttons.
+class _FloatingActionBarSurface extends StatelessWidget {
+  const _FloatingActionBarSurface({
+    required this.shape,
+    required this.child,
+  });
+
+  final ShapeBorder shape;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white.withValues(alpha: 0.84),
+      elevation: 4,
+      shadowColor: Colors.black.withValues(alpha: 0.08),
+      surfaceTintColor: Colors.transparent,
+      shape: shape,
+      clipBehavior: Clip.antiAlias,
+      child: child,
+    );
+  }
+}
+
+@Preview(
+  name: 'FloatingActionBar',
+  group: 'Floating Action Bar',
+  size: Size(420, 120),
+)
+Widget previewFloatingActionBar() {
+  const tabs = ['114-2', '114-1', '113-2', '113-1'];
+
+  return WidgetPreviewFrame(
+    child: SizedBox(
+      width: 360,
+      child: DefaultTabController(
+        length: tabs.length,
+        child: FloatingActionBar(
+          actions: [
+            FloatingActionBarActionButton(
+              icon: Icons.share_outlined,
+              onTap: () {},
+            ),
+            FloatingActionBarActionButton(
+              icon: Icons.more_vert_outlined,
+              onTap: () {},
+            ),
+          ],
+          child: ChipTabSwitcher(
+            tabs: tabs,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+@Preview(
+  name: 'ScrollAwareFloatingActionBar',
+  group: 'Floating Action Bar',
+  size: Size(420, 320),
+)
+Widget previewScrollAwareFloatingActionBar() {
+  const tabs = ['114-2', '114-1', '113-2', '113-1'];
+
+  return WidgetPreviewFrame(
+    child: SizedBox(
+      width: 360,
+      height: 280,
+      child: DefaultTabController(
+        length: tabs.length,
+        child: ScrollAwareFloatingActionBar(
+          floatingActionBarBuilder: (context, visible) => FloatingActionBar(
+            visible: visible,
+            actions: [
+              FloatingActionBarActionButton(
+                icon: Icons.more_vert_outlined,
+                onTap: () {},
+              ),
+            ],
+            child: ChipTabSwitcher(
+              tabs: tabs,
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+            ),
+          ),
+          child: ListView.builder(
+            itemCount: 20,
+            itemBuilder: (context, index) => ListTile(
+              title: Text('Row $index'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -306,6 +306,7 @@ class FloatingActionBarActionButton extends StatelessWidget {
     super.key,
     required this.icon,
     required this.onTap,
+    this.tooltip,
   });
 
   /// The icon shown at the center of the button.
@@ -314,12 +315,16 @@ class FloatingActionBarActionButton extends StatelessWidget {
   /// Called when the button is tapped.
   final VoidCallback onTap;
 
+  /// Optional tooltip shown for long-press and accessibility affordances.
+  final String? tooltip;
+
   @override
   Widget build(BuildContext context) {
     return _FloatingActionBarCircularActionSurface(
       child: _FloatingActionBarIconButton(
         icon: icon,
         onTap: onTap,
+        tooltip: tooltip,
       ),
     );
   }
@@ -369,7 +374,7 @@ class FloatingActionBarMenuButton<T> extends StatelessWidget {
       items: items,
       onSelected: onSelected,
       enabled: enabled,
-      tooltip: tooltip,
+      tooltip: tooltip ?? '更多選項',
       style: style,
       triggerBuilder: (context, onPressed) {
         return _FloatingActionBarCircularActionSurface(
@@ -406,26 +411,32 @@ class _FloatingActionBarIconButton extends StatelessWidget {
   const _FloatingActionBarIconButton({
     required this.icon,
     required this.onTap,
+    this.tooltip,
   });
 
   static const _iconSize = 20.0;
 
   final IconData icon;
   final VoidCallback? onTap;
+  final String? tooltip;
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      shape: const CircleBorder(),
-      child: InkWell(
-        customBorder: const CircleBorder(),
-        splashFactory: InkRipple.splashFactory,
-        splashColor: Colors.black12,
-        highlightColor: Colors.black12,
-        onTap: onTap,
-        child: Center(
-          child: Icon(icon, size: _iconSize),
+    return Tooltip(
+      message: tooltip ?? '',
+      showDuration: const Duration(seconds: 3),
+      child: Material(
+        color: Colors.transparent,
+        shape: const CircleBorder(),
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          splashFactory: InkRipple.splashFactory,
+          splashColor: Colors.black12,
+          highlightColor: Colors.black12,
+          onTap: onTap,
+          child: Center(
+            child: Icon(icon, size: _iconSize),
+          ),
         ),
       ),
     );
@@ -474,6 +485,7 @@ Widget previewFloatingActionBar() {
             FloatingActionBarActionButton(
               icon: Icons.share_outlined,
               onTap: () {},
+              tooltip: '分享',
             ),
             FloatingActionBarMenuButton<String>(
               icon: Icons.more_vert_outlined,

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -375,7 +375,7 @@ class FloatingActionBarMenuButton<T> extends StatelessWidget {
       items: items,
       onSelected: onSelected,
       enabled: enabled,
-      tooltip: tooltip ?? t.courseTable.actions.displayOptions,
+      tooltip: tooltip ?? t.courseTable.actions.showMoreOptions,
       style: style,
       triggerBuilder: (context, onPressed) {
         return _FloatingActionBarCircularActionSurface(
@@ -423,30 +423,24 @@ class _FloatingActionBarIconButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final button = Material(
-      color: Colors.transparent,
-      shape: const CircleBorder(),
-      child: InkWell(
-        customBorder: const CircleBorder(),
-        splashFactory: InkRipple.splashFactory,
-        splashColor: Colors.black12,
-        highlightColor: Colors.black12,
-        onTap: onTap,
-        child: Center(
-          child: Icon(icon, size: _iconSize),
+    return Tooltip(
+      message: tooltip ?? '',
+      showDuration: const Duration(seconds: 3),
+      child: Material(
+        color: Colors.transparent,
+        shape: const CircleBorder(),
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          splashFactory: InkRipple.splashFactory,
+          splashColor: Colors.black12,
+          highlightColor: Colors.black12,
+          onTap: onTap,
+          child: Center(
+            child: Icon(icon, size: _iconSize),
+          ),
         ),
       ),
     );
-
-    if (tooltip case final tooltip?) {
-      return Tooltip(
-        message: tooltip,
-        showDuration: const Duration(seconds: 3),
-        child: button,
-      );
-    }
-
-    return button;
   }
 }
 

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -11,7 +11,8 @@ import 'package:tattoo/components/widget_preview_frame.dart';
 /// 1. Scrolling toward larger offsets hides the bar
 /// 2. Scrolling back toward the top shows the bar
 /// 3. Reaching the top always shows the bar
-/// 4. Tapping the body reveals the bar again when it is hidden
+/// 4. Tapping the body toggles the bar visibility
+/// 5. Swiping horizontally to change pages reveals the bar when hidden
 ///
 /// The [floatingActionBarBuilder] receives the resolved visibility state so the
 /// caller can decide whether to render a [FloatingActionBar] or omit the bar
@@ -68,6 +69,16 @@ class _ScrollAwareFloatingActionBarState
   double _dragHideDelta = 0;
 
   bool _handleScrollNotification(ScrollNotification notification) {
+    if (notification.metrics.axis == Axis.horizontal &&
+        !_isVisible &&
+        notification is ScrollUpdateNotification &&
+        notification.dragDetails != null) {
+      setState(() {
+        _isVisible = true;
+      });
+      return false;
+    }
+
     if (notification.metrics.axis != Axis.vertical) {
       return false;
     }
@@ -123,13 +134,9 @@ class _ScrollAwareFloatingActionBarState
     _dragHideDelta = 0;
   }
 
-  void _revealFloatingActionBar() {
-    if (_isVisible) {
-      return;
-    }
-
+  void _toggleFloatingActionBar() {
     setState(() {
-      _isVisible = true;
+      _isVisible = !_isVisible;
     });
   }
 
@@ -148,7 +155,7 @@ class _ScrollAwareFloatingActionBarState
         children: [
           GestureDetector(
             behavior: HitTestBehavior.translucent,
-            onTap: _revealFloatingActionBar,
+            onTap: _toggleFloatingActionBar,
             child: widget.child,
           ),
           if (floatingActionBar case final floatingActionBar?)

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 import 'package:tattoo/components/anchored_popup_menu.dart';
@@ -147,6 +149,11 @@ class _ScrollAwareFloatingActionBarState
       _isVisible,
     );
     final resolvedMargin = widget.margin.resolve(Directionality.of(context));
+    final mediaQuery = MediaQuery.of(context);
+    final bottomInset = math.max(
+      mediaQuery.padding.bottom,
+      mediaQuery.viewInsets.bottom,
+    );
 
     return NotificationListener<ScrollNotification>(
       onNotification: _handleScrollNotification,
@@ -163,7 +170,7 @@ class _ScrollAwareFloatingActionBarState
               left: resolvedMargin.left,
               top: resolvedMargin.top,
               right: resolvedMargin.right,
-              bottom: resolvedMargin.bottom,
+              bottom: resolvedMargin.bottom + bottomInset,
               child: Align(
                 alignment: Alignment.bottomCenter,
                 child: IgnorePointer(

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -473,14 +473,14 @@ Widget previewFloatingActionBar() {
               items: const [
                 PopupMenuItem(
                   value: 'refresh',
-                  child: const ListTile(
+                  child: ListTile(
                     leading: Icon(Icons.refresh_outlined),
                     title: Text('Refresh'),
                   ),
                 ),
                 PopupMenuItem(
                   value: 'display',
-                  child: const ListTile(
+                  child: ListTile(
                     leading: Icon(Icons.tune_outlined),
                     title: Text('Display options'),
                   ),
@@ -522,14 +522,14 @@ Widget previewScrollAwareFloatingActionBar() {
                 items: const [
                   PopupMenuItem(
                     value: 'refresh',
-                    child: const ListTile(
+                    child: ListTile(
                       leading: Icon(Icons.refresh_outlined),
                       title: Text('Refresh'),
                     ),
                   ),
                   PopupMenuItem(
                     value: 'display',
-                    child: const ListTile(
+                    child: ListTile(
                       leading: Icon(Icons.tune_outlined),
                       title: Text('Display options'),
                     ),

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widget_previews.dart';
 import 'package:tattoo/components/anchored_popup_menu.dart';
 import 'package:tattoo/components/chip_tab_switcher.dart';
 import 'package:tattoo/components/widget_preview_frame.dart';
+import 'package:tattoo/i18n/strings.g.dart';
 
 /// A layout helper that overlays a floating action bar above a scrollable body.
 ///
@@ -374,7 +375,7 @@ class FloatingActionBarMenuButton<T> extends StatelessWidget {
       items: items,
       onSelected: onSelected,
       enabled: enabled,
-      tooltip: tooltip ?? '更多選項',
+      tooltip: tooltip ?? t.courseTable.actions.displayOptions,
       style: style,
       triggerBuilder: (context, onPressed) {
         return _FloatingActionBarCircularActionSurface(
@@ -422,24 +423,30 @@ class _FloatingActionBarIconButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Tooltip(
-      message: tooltip ?? '',
-      showDuration: const Duration(seconds: 3),
-      child: Material(
-        color: Colors.transparent,
-        shape: const CircleBorder(),
-        child: InkWell(
-          customBorder: const CircleBorder(),
-          splashFactory: InkRipple.splashFactory,
-          splashColor: Colors.black12,
-          highlightColor: Colors.black12,
-          onTap: onTap,
-          child: Center(
-            child: Icon(icon, size: _iconSize),
-          ),
+    final button = Material(
+      color: Colors.transparent,
+      shape: const CircleBorder(),
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        splashFactory: InkRipple.splashFactory,
+        splashColor: Colors.black12,
+        highlightColor: Colors.black12,
+        onTap: onTap,
+        child: Center(
+          child: Icon(icon, size: _iconSize),
         ),
       ),
     );
+
+    if (tooltip case final tooltip?) {
+      return Tooltip(
+        message: tooltip,
+        showDuration: const Duration(seconds: 3),
+        child: button,
+      );
+    }
+
+    return button;
   }
 }
 

--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -52,7 +52,7 @@ nav:
 courseTable:
   notFound: Course table not found
   actions:
-    refresh: Refresh course table
+    showMoreOptions: Show more options
     displayOptions: Display options
   dayOfWeek(map):
     sunday: Sun

--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -51,6 +51,9 @@ nav:
   profile: Me
 courseTable:
   notFound: Course table not found
+  actions:
+    refresh: Refresh course table
+    displayOptions: Display options
   dayOfWeek(map):
     sunday: Sun
     monday: Mon

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 260 (130 per locale)
+/// Strings: 264 (132 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -142,6 +142,7 @@ class _TranslationsCourseTableEnUs extends TranslationsCourseTableZhTw {
 
 	// Translations
 	@override String get notFound => 'Course table not found';
+	@override late final _TranslationsCourseTableActionsEnUs actions = _TranslationsCourseTableActionsEnUs._(_root);
 	@override Map<String, String> get dayOfWeek => {
 		'sunday': 'Sun',
 		'monday': 'Mon',
@@ -254,6 +255,17 @@ class _TranslationsLoginErrorsEnUs extends TranslationsLoginErrorsZhTw {
 	@override String get accountLocked => 'Account locked due to too many failed attempts. Please try again later.';
 	@override String get passwordExpired => 'Your password has expired. Please change it on the NTUT portal.';
 	@override String get mobileVerificationRequired => 'Mobile phone verification is required. Please complete it on the NTUT portal.';
+}
+
+// Path: courseTable.actions
+class _TranslationsCourseTableActionsEnUs extends TranslationsCourseTableActionsZhTw {
+	_TranslationsCourseTableActionsEnUs._(TranslationsEnUs root) : this._root = root, super.internal(root);
+
+	final TranslationsEnUs _root; // ignore: unused_field
+
+	// Translations
+	@override String get refresh => 'Refresh course table';
+	@override String get displayOptions => 'Display options';
 }
 
 // Path: profile.sections
@@ -445,6 +457,8 @@ extension on TranslationsEnUs {
 			'nav.portal' => 'Portals',
 			'nav.profile' => 'Me',
 			'courseTable.notFound' => 'Course table not found',
+			'courseTable.actions.refresh' => 'Refresh course table',
+			'courseTable.actions.displayOptions' => 'Display options',
 			'courseTable.dayOfWeek.sunday' => 'Sun',
 			'courseTable.dayOfWeek.monday' => 'Mon',
 			'courseTable.dayOfWeek.tuesday' => 'Tue',

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -264,7 +264,7 @@ class _TranslationsCourseTableActionsEnUs extends TranslationsCourseTableActions
 	final TranslationsEnUs _root; // ignore: unused_field
 
 	// Translations
-	@override String get refresh => 'Refresh course table';
+	@override String get showMoreOptions => 'Show more options';
 	@override String get displayOptions => 'Display options';
 }
 
@@ -457,7 +457,7 @@ extension on TranslationsEnUs {
 			'nav.portal' => 'Portals',
 			'nav.profile' => 'Me',
 			'courseTable.notFound' => 'Course table not found',
-			'courseTable.actions.refresh' => 'Refresh course table',
+			'courseTable.actions.showMoreOptions' => 'Show more options',
 			'courseTable.actions.displayOptions' => 'Display options',
 			'courseTable.dayOfWeek.sunday' => 'Sun',
 			'courseTable.dayOfWeek.monday' => 'Mon',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -202,6 +202,7 @@ class TranslationsCourseTableZhTw {
 	/// zh-TW: '找不到課表'
 	String get notFound => '找不到課表';
 
+	late final TranslationsCourseTableActionsZhTw actions = TranslationsCourseTableActionsZhTw.internal(_root);
 	Map<String, String> get dayOfWeek => {
 		'sunday': '日',
 		'monday': '一',
@@ -381,6 +382,21 @@ class TranslationsLoginErrorsZhTw {
 
 	/// zh-TW: '需要進行手機驗證，請至校園入口網站完成驗證'
 	String get mobileVerificationRequired => '需要進行手機驗證，請至校園入口網站完成驗證';
+}
+
+// Path: courseTable.actions
+class TranslationsCourseTableActionsZhTw {
+	TranslationsCourseTableActionsZhTw.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// zh-TW: '重新整理課表'
+	String get refresh => '重新整理課表';
+
+	/// zh-TW: '顯示選項'
+	String get displayOptions => '顯示選項';
 }
 
 // Path: profile.sections
@@ -670,6 +686,8 @@ extension on Translations {
 			'nav.portal' => '傳送門',
 			'nav.profile' => '我',
 			'courseTable.notFound' => '找不到課表',
+			'courseTable.actions.refresh' => '重新整理課表',
+			'courseTable.actions.displayOptions' => '顯示選項',
 			'courseTable.dayOfWeek.sunday' => '日',
 			'courseTable.dayOfWeek.monday' => '一',
 			'courseTable.dayOfWeek.tuesday' => '二',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -392,8 +392,8 @@ class TranslationsCourseTableActionsZhTw {
 
 	// Translations
 
-	/// zh-TW: '重新整理課表'
-	String get refresh => '重新整理課表';
+	/// zh-TW: '顯示更多選項'
+	String get showMoreOptions => '顯示更多選項';
 
 	/// zh-TW: '顯示選項'
 	String get displayOptions => '顯示選項';
@@ -686,7 +686,7 @@ extension on Translations {
 			'nav.portal' => '傳送門',
 			'nav.profile' => '我',
 			'courseTable.notFound' => '找不到課表',
-			'courseTable.actions.refresh' => '重新整理課表',
+			'courseTable.actions.showMoreOptions' => '顯示更多選項',
 			'courseTable.actions.displayOptions' => '顯示選項',
 			'courseTable.dayOfWeek.sunday' => '日',
 			'courseTable.dayOfWeek.monday' => '一',

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -51,6 +51,9 @@ nav:
   profile: 我
 courseTable:
   notFound: 找不到課表
+  actions:
+    refresh: 重新整理課表
+    displayOptions: 顯示選項
   dayOfWeek(map):
     sunday: 日
     monday: 一

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -52,7 +52,7 @@ nav:
 courseTable:
   notFound: 找不到課表
   actions:
-    refresh: 重新整理課表
+    showMoreOptions: 顯示更多選項
     displayOptions: 顯示選項
   dayOfWeek(map):
     sunday: 日

--- a/lib/screens/main/course_table/course_table_grid.dart
+++ b/lib/screens/main/course_table/course_table_grid.dart
@@ -51,6 +51,8 @@ class CourseTableGrid extends StatelessWidget {
 
   // CourseTableCell accepts a minimum height of 52.
   // with padding(2.0), set 56 as the minimum height.
+  // Display about 10 periods in the viewport by default,
+  // but expand if there are fewer to avoid excessive whitespace.
   double get _periodRowHeight =>
       max((viewportHeight - _tableHeaderHeight) / 10, 56.0).toDouble();
   bool get _isEmpty =>

--- a/lib/screens/main/course_table/course_table_grid.dart
+++ b/lib/screens/main/course_table/course_table_grid.dart
@@ -27,11 +27,13 @@ class CourseTableGrid extends StatelessWidget {
     required this.viewportHeight,
     this.loading = false,
     this.onRefresh,
+    this.bottomInset = 0,
   });
 
   final CourseTableData courseTableData;
   final bool loading;
   final RefreshCallback? onRefresh;
+  final double bottomInset;
 
   /// Initial visible width of the grid viewport (before user scrolls).
   final double viewportWidth;
@@ -146,6 +148,10 @@ class CourseTableGrid extends StatelessWidget {
             ],
           ),
         ),
+        if (bottomInset > 0)
+          SliverToBoxAdapter(
+            child: SizedBox(height: bottomInset),
+          ),
       ],
     );
 

--- a/lib/screens/main/course_table/course_table_grid.dart
+++ b/lib/screens/main/course_table/course_table_grid.dart
@@ -52,7 +52,7 @@ class CourseTableGrid extends StatelessWidget {
   // CourseTableCell accepts a minimum height of 52.
   // with padding(2.0), set 56 as the minimum height.
   double get _periodRowHeight =>
-      max((viewportHeight - _tableHeaderHeight) / 9, 56.0).toDouble();
+      max((viewportHeight - _tableHeaderHeight) / 10, 56.0).toDouble();
   double get _periodNoonHeight => switch (courseTableData.hasNoonCourse) {
     true => _periodRowHeight,
     false => _periodRowHeight / 3,

--- a/lib/screens/main/course_table/course_table_screen.dart
+++ b/lib/screens/main/course_table/course_table_screen.dart
@@ -2,19 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tattoo/components/app_skeleton.dart';
 import 'package:tattoo/components/chip_tab_switcher.dart';
+import 'package:tattoo/components/floating_action_bar.dart';
 import 'package:tattoo/database/database.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/course_repository.dart';
-import 'package:tattoo/components/floating_action_bar.dart';
 import 'package:tattoo/screens/main/course_table/course_table_grid.dart';
 import 'package:tattoo/screens/main/course_table/course_table_providers.dart';
 import 'package:tattoo/screens/main/user_providers.dart';
 
 // TODO: Import mock data from demo mode when implemented
-const _placeholderOwnerName = '載入中';
-const _placeholderAvatarInitial = '載';
 const _loadingSemesterTabLabels = ['114-2', '114-1', '113-2'];
-const _ownerAppBarHeight = 56.0;
 const _floatingBarBottomInset = 80.0;
 const _floatingBarMargin = 16.0;
 
@@ -62,13 +59,7 @@ class CourseTableScreen extends ConsumerWidget {
         ),
         body: LayoutBuilder(
           builder: (context, constraints) {
-            final gridViewportSize = Size(
-              constraints.maxWidth,
-              (constraints.maxHeight - _ownerAppBarHeight).clamp(
-                0.0,
-                double.infinity,
-              ),
-            );
+            final gridViewportSize = constraints.biggest;
             final shouldShowFloatingBar = switch (semestersAsync) {
               AsyncError() => false,
               AsyncData(value: final semesters) => semesters.isNotEmpty,
@@ -99,114 +90,69 @@ class CourseTableScreen extends ConsumerWidget {
                   ),
                 );
               },
-              child: NestedScrollView(
-                headerSliverBuilder: (context, innerBoxIsScrolled) => [
-                  // primary app bar with owner indicator and action buttons
-                  SliverAppBar(
-                    primary: false,
-                    toolbarHeight: _ownerAppBarHeight,
-                    backgroundColor: Theme.of(context).colorScheme.primary,
-                    flexibleSpace: Align(
-                      alignment: Alignment.bottomCenter,
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                          vertical: 8,
-                        ),
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.end,
-                          children: [
-                            const _TableOwnerIndicator(),
-                            const Spacer(),
-                            Row(
-                              mainAxisSize: MainAxisSize.min,
-                              crossAxisAlignment: CrossAxisAlignment.end,
-                              spacing: 8,
-                              children: [
-                                _CircularIconButton(
-                                  icon: Icons.refresh_outlined,
-                                  onTap: () => _showDemoTap(context),
-                                ),
-                                _CircularIconButton(
-                                  icon: Icons.share_outlined,
-                                  onTap: () => _showDemoTap(context),
-                                ),
-                                _CircularIconButton(
-                                  icon: Icons.more_vert_outlined,
-                                  onTap: () => _showDemoTap(context),
-                                ),
-                              ],
+              child: switch (semestersAsync) {
+                // ERROR state: show error message
+                AsyncError(:final error) => Center(
+                  child: Center(child: Text('Error: $error')),
+                ),
+
+                // EMPTY state: show not found message
+                AsyncData(value: final semesters) when semesters.isEmpty =>
+                  Center(
+                    child: Center(
+                      child: Text(
+                        profileAsync.asData?.value == null
+                            ? t.general.notLoggedIn
+                            : t.courseTable.notFound,
+                      ),
+                    ),
+                  ),
+
+                // LOADED state: show course table with tabs
+                AsyncData(value: final semesters) => TabBarView(
+                  children: [
+                    for (final semester in semesters)
+                      Consumer(
+                        builder: (context, tabRef, child) {
+                          final courseTableAsync = tabRef.watch(
+                            courseTableProvider(semester.id),
+                          );
+
+                          return switch (courseTableAsync) {
+                            AsyncError(:final error) => Center(
+                              child: Center(child: Text('Error: $error')),
                             ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-                body: switch (semestersAsync) {
-                  // ERROR state: show error message
-                  AsyncError(:final error) => Center(
-                    child: Center(child: Text('Error: $error')),
-                  ),
-
-                  // EMPTY state: show not found message
-                  AsyncData(value: final semesters) when semesters.isEmpty =>
-                    Center(
-                      child: Center(
-                        child: Text(
-                          profileAsync.asData?.value == null
-                              ? t.general.notLoggedIn
-                              : t.courseTable.notFound,
-                        ),
-                      ),
-                    ),
-
-                  // LOADED state: show course table with tabs
-                  AsyncData(value: final semesters) => TabBarView(
-                    children: [
-                      for (final semester in semesters)
-                        Consumer(
-                          builder: (context, tabRef, child) {
-                            final courseTableAsync = tabRef.watch(
-                              courseTableProvider(semester.id),
-                            );
-
-                            return switch (courseTableAsync) {
-                              AsyncError(:final error) => Center(
-                                child: Center(child: Text('Error: $error')),
+                            _ => CourseTableGrid(
+                              key: ValueKey(_semesterLabel(semester)),
+                              courseTableData:
+                                  courseTableAsync.asData?.value ??
+                                  CourseTableData(),
+                              loading:
+                                  courseTableAsync.isLoading &&
+                                  !courseTableAsync.hasValue,
+                              onRefresh: () => _refreshCourseTable(
+                                ref,
+                                semester,
                               ),
-                              _ => CourseTableGrid(
-                                key: ValueKey(_semesterLabel(semester)),
-                                courseTableData:
-                                    courseTableAsync.asData?.value ??
-                                    CourseTableData(),
-                                loading:
-                                    courseTableAsync.isLoading &&
-                                    !courseTableAsync.hasValue,
-                                onRefresh: () => _refreshCourseTable(
-                                  ref,
-                                  semester,
-                                ),
-                                viewportWidth: gridViewportSize.width,
-                                viewportHeight: gridViewportSize.height,
-                                bottomInset: _floatingBarBottomInset,
-                              ),
-                            };
-                          },
-                        ),
-                    ],
-                  ),
+                              viewportWidth: gridViewportSize.width,
+                              viewportHeight: gridViewportSize.height,
+                              bottomInset: _floatingBarBottomInset,
+                            ),
+                          };
+                        },
+                      ),
+                  ],
+                ),
 
-                  // LOADING state: show loading skeleton
-                  _ => CourseTableGrid(
-                    courseTableData: CourseTableData(),
-                    loading: true,
-                    viewportWidth: gridViewportSize.width,
-                    viewportHeight: gridViewportSize.height,
-                    bottomInset: _floatingBarBottomInset,
-                  ),
-                },
-              ),
+                // LOADING state: show loading skeleton
+                _ => CourseTableGrid(
+                  courseTableData: CourseTableData(),
+                  loading: true,
+                  viewportWidth: gridViewportSize.width,
+                  viewportHeight: gridViewportSize.height,
+                  bottomInset: _floatingBarBottomInset,
+                ),
+              },
             );
           },
         ),
@@ -215,149 +161,4 @@ class CourseTableScreen extends ConsumerWidget {
   }
 }
 
-class _TableOwnerIndicator extends ConsumerWidget {
-  const _TableOwnerIndicator();
-
-  static const double _height = 36;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final profileAsync = ref.watch(userProfileProvider);
-    final avatarAsync = ref.watch(userAvatarProvider);
-    final profile = profileAsync.asData?.value;
-    final avatarFile = avatarAsync.asData?.value;
-    final isLoading = profileAsync is AsyncLoading<User?> && profile == null;
-    final ownerName = switch (profileAsync) {
-      AsyncLoading() => _placeholderOwnerName,
-      AsyncData(value: null) => t.general.notLoggedIn,
-      AsyncError() => t.general.unknown,
-      _ when profile?.nameZh.isNotEmpty == true => profile!.nameZh,
-      _ => t.general.unknown,
-    };
-    final avatarInitial = switch (profile?.nameZh) {
-      final name? when name.isNotEmpty => name.substring(0, 1),
-      _ when isLoading => _placeholderAvatarInitial,
-      _ => '?',
-    };
-
-    const shape = StadiumBorder();
-
-    return AppSkeleton(
-      enabled: isLoading,
-      child: Material(
-        type: MaterialType.transparency,
-        child: InkWell(
-          customBorder: shape,
-          splashFactory: InkRipple.splashFactory,
-          splashColor: Colors.black12,
-          highlightColor: Colors.black12,
-          // TODO: implement course table sharing feature and switch here
-          onTap: () {},
-          child: Ink(
-            height: _height,
-            padding: const EdgeInsets.fromLTRB(4, 4, 16, 4),
-            decoration: ShapeDecoration(
-              shape: shape,
-              color: Colors.white.withValues(alpha: 0.7),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              spacing: 8,
-              children: [
-                AspectRatio(
-                  aspectRatio: 1,
-                  child: Container(
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    child: ClipOval(
-                      child: switch (avatarFile) {
-                        final file? => Image.file(
-                          file,
-                          fit: BoxFit.cover,
-                        ),
-                        null => Center(
-                          child: FittedBox(
-                            fit: BoxFit.scaleDown,
-                            child: Text(
-                              avatarInitial,
-                              style: TextStyle(
-                                color: Colors.white,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                          ),
-                        ),
-                      },
-                    ),
-                  ),
-                ),
-                RichText(
-                  text: TextSpan(
-                    // TODO: Design text style here
-                    style: DefaultTextStyle.of(context).style,
-                    children: [
-                      TextSpan(text: ownerName),
-                      // TODO: Enable this dropdown indicator when course table sharing feature is implemented
-                      // WidgetSpan(
-                      //   alignment: PlaceholderAlignment.middle,
-                      //   child: Icon(
-                      //     Icons.arrow_drop_down_outlined,
-                      //     size:
-                      //         (DefaultTextStyle.of(context).style.fontSize ?? 14) *
-                      //         1.5,
-                      //   ),
-                      // ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
 String _semesterLabel(Semester semester) => '${semester.year}-${semester.term}';
-
-class _CircularIconButton extends StatelessWidget {
-  const _CircularIconButton({
-    required this.icon,
-    required this.onTap,
-  });
-
-  final IconData icon;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: 28,
-      height: 28,
-      child: Material(
-        color: Colors.white.withValues(alpha: 0.7),
-        shape: const CircleBorder(),
-        child: InkWell(
-          customBorder: const CircleBorder(),
-          splashFactory: InkRipple.splashFactory,
-          splashColor: Colors.black12,
-          highlightColor: Colors.black12,
-          onTap: onTap,
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              final iconSize = constraints.biggest.shortestSide * 0.45;
-
-              return Center(
-                child: Icon(icon, size: iconSize),
-              );
-            },
-          ),
-        ),
-      ),
-    );
-  }
-}

--- a/lib/screens/main/course_table/course_table_screen.dart
+++ b/lib/screens/main/course_table/course_table_screen.dart
@@ -116,16 +116,22 @@ class CourseTableScreen extends ConsumerWidget {
                         >(
                           icon: Icons.more_vert_outlined,
                           items: [
-                            FloatingActionBarMenuItem(
+                            PopupMenuItem(
                               value: _CourseTableMenuAction.refresh,
-                              label: t.courseTable.actions.refresh,
-                              icon: Icons.refresh_outlined,
                               enabled: selectedSemester != null,
+                              child: ListTile(
+                                leading: const Icon(Icons.refresh_outlined),
+                                title: Text(t.courseTable.actions.refresh),
+                              ),
                             ),
-                            FloatingActionBarMenuItem(
+                            PopupMenuItem(
                               value: _CourseTableMenuAction.displayOptions,
-                              label: t.courseTable.actions.displayOptions,
-                              icon: Icons.tune_outlined,
+                              child: ListTile(
+                                leading: const Icon(Icons.tune_outlined),
+                                title: Text(
+                                  t.courseTable.actions.displayOptions,
+                                ),
+                              ),
                             ),
                           ],
                           onSelected: (action) {

--- a/lib/screens/main/course_table/course_table_screen.dart
+++ b/lib/screens/main/course_table/course_table_screen.dart
@@ -15,6 +15,11 @@ const _loadingSemesterTabLabels = ['114-2', '114-1', '113-2'];
 const _floatingBarBottomInset = 80.0;
 const _floatingBarMargin = 16.0;
 
+enum _CourseTableMenuAction {
+  refresh,
+  displayOptions,
+}
+
 class CourseTableScreen extends ConsumerWidget {
   const CourseTableScreen({super.key});
 
@@ -30,6 +35,25 @@ class CourseTableScreen extends ConsumerWidget {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(t.general.notImplemented)),
     );
+  }
+
+  Semester? _resolveSelectedSemester(
+    BuildContext context,
+    List<Semester>? semesters,
+  ) {
+    if (semesters == null || semesters.isEmpty) {
+      return null;
+    }
+
+    final controller = DefaultTabController.maybeOf(context);
+    if (controller == null) {
+      return semesters.first;
+    }
+
+    final clampedIndex = controller.index
+        .clamp(0, semesters.length - 1)
+        .toInt();
+    return semesters[clampedIndex];
   }
 
   @override
@@ -76,8 +100,48 @@ class CourseTableScreen extends ConsumerWidget {
                   visible: visible,
                   actions: [
                     FloatingActionBarActionButton(
-                      icon: Icons.more_vert_outlined,
+                      icon: Icons.view_day_outlined,
                       onTap: () => _showDemoTap(context),
+                    ),
+                    Builder(
+                      builder: (context) {
+                        final semesters = semestersAsync.asData?.value;
+                        final selectedSemester = _resolveSelectedSemester(
+                          context,
+                          semesters,
+                        );
+
+                        return FloatingActionBarMenuButton<
+                          _CourseTableMenuAction
+                        >(
+                          icon: Icons.more_vert_outlined,
+                          items: [
+                            FloatingActionBarMenuItem(
+                              value: _CourseTableMenuAction.refresh,
+                              label: t.courseTable.actions.refresh,
+                              icon: Icons.refresh_outlined,
+                              enabled: selectedSemester != null,
+                            ),
+                            FloatingActionBarMenuItem(
+                              value: _CourseTableMenuAction.displayOptions,
+                              label: t.courseTable.actions.displayOptions,
+                              icon: Icons.tune_outlined,
+                            ),
+                          ],
+                          onSelected: (action) {
+                            switch (action) {
+                              case _CourseTableMenuAction.refresh:
+                                if (selectedSemester != null) {
+                                  _refreshCourseTable(ref, selectedSemester);
+                                }
+                                break;
+                              case _CourseTableMenuAction.displayOptions:
+                                _showDemoTap(context);
+                                break;
+                            }
+                          },
+                        );
+                      },
                     ),
                   ],
                   child: AppSkeleton(

--- a/lib/screens/main/course_table/course_table_screen.dart
+++ b/lib/screens/main/course_table/course_table_screen.dart
@@ -18,7 +18,6 @@ const _floatingBarBottomInset = 80.0;
 const _floatingBarMargin = 16.0;
 
 enum _CourseTableMenuAction {
-  refresh,
   displayOptions,
 }
 
@@ -37,25 +36,6 @@ class CourseTableScreen extends ConsumerWidget {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(t.general.notImplemented)),
     );
-  }
-
-  Semester? _resolveSelectedSemester(
-    BuildContext context,
-    List<Semester>? semesters,
-  ) {
-    if (semesters == null || semesters.isEmpty) {
-      return null;
-    }
-
-    final controller = DefaultTabController.maybeOf(context);
-    if (controller == null) {
-      return semesters.first;
-    }
-
-    final clampedIndex = controller.index
-        .clamp(0, semesters.length - 1)
-        .toInt();
-    return semesters[clampedIndex];
   }
 
   @override
@@ -109,12 +89,6 @@ class CourseTableScreen extends ConsumerWidget {
                     // TODO: add day view and week view toggle when implemented
                     Builder(
                       builder: (context) {
-                        final semesters = semestersAsync.asData?.value;
-                        final selectedSemester = _resolveSelectedSemester(
-                          context,
-                          semesters,
-                        );
-
                         return FloatingActionBarMenuButton<
                           _CourseTableMenuAction
                         >(
@@ -132,24 +106,6 @@ class CourseTableScreen extends ConsumerWidget {
                           ],
                           onSelected: (action) async {
                             switch (action) {
-                              case _CourseTableMenuAction.refresh:
-                                if (selectedSemester != null) {
-                                  try {
-                                    await _refreshCourseTable(
-                                      ref,
-                                      selectedSemester,
-                                    );
-                                  } catch (error) {
-                                    if (!context.mounted) {
-                                      return;
-                                    }
-
-                                    ScaffoldMessenger.of(context).showSnackBar(
-                                      SnackBar(content: Text('Error: $error')),
-                                    );
-                                  }
-                                }
-                                break;
                               case _CourseTableMenuAction.displayOptions:
                                 _showDemoTap(context);
                                 break;

--- a/lib/screens/main/course_table/course_table_screen.dart
+++ b/lib/screens/main/course_table/course_table_screen.dart
@@ -55,7 +55,6 @@ class CourseTableScreen extends ConsumerWidget {
         // A scaffold AppBar to handle status bar height.
         appBar: AppBar(
           toolbarHeight: 0,
-          backgroundColor: Theme.of(context).colorScheme.primary,
         ),
         body: LayoutBuilder(
           builder: (context, constraints) {

--- a/lib/screens/main/course_table/course_table_screen.dart
+++ b/lib/screens/main/course_table/course_table_screen.dart
@@ -95,7 +95,7 @@ class CourseTableScreen extends ConsumerWidget {
                           icon: Icons.more_vert_outlined,
                           items: [
                             PopupMenuItem(
-                              value: _CourseTableMenuAction.displayOptions,
+                              value: .displayOptions,
                               child: ListTile(
                                 leading: const Icon(Icons.tune_outlined),
                                 title: Text(
@@ -106,7 +106,7 @@ class CourseTableScreen extends ConsumerWidget {
                           ],
                           onSelected: (action) async {
                             switch (action) {
-                              case _CourseTableMenuAction.displayOptions:
+                              case .displayOptions:
                                 _showDemoTap(context);
                                 break;
                             }

--- a/lib/screens/main/course_table/course_table_screen.dart
+++ b/lib/screens/main/course_table/course_table_screen.dart
@@ -99,10 +99,7 @@ class CourseTableScreen extends ConsumerWidget {
                 return FloatingActionBar(
                   visible: visible,
                   actions: [
-                    FloatingActionBarActionButton(
-                      icon: Icons.view_day_outlined,
-                      onTap: () => _showDemoTap(context),
-                    ),
+                    // TODO: add day view and week view toggle when implemented
                     Builder(
                       builder: (context) {
                         final semesters = semestersAsync.asData?.value;

--- a/lib/screens/main/course_table/course_table_screen.dart
+++ b/lib/screens/main/course_table/course_table_screen.dart
@@ -5,24 +5,23 @@ import 'package:tattoo/components/chip_tab_switcher.dart';
 import 'package:tattoo/database/database.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/course_repository.dart';
-import 'package:tattoo/screens/main/user_providers.dart';
+import 'package:tattoo/components/floating_action_bar.dart';
 import 'package:tattoo/screens/main/course_table/course_table_grid.dart';
 import 'package:tattoo/screens/main/course_table/course_table_providers.dart';
+import 'package:tattoo/screens/main/user_providers.dart';
 
 // TODO: Import mock data from demo mode when implemented
 const _placeholderOwnerName = '載入中';
 const _placeholderAvatarInitial = '載';
 const _loadingSemesterTabLabels = ['114-2', '114-1', '113-2'];
 const _ownerAppBarHeight = 56.0;
-const _semesterTabsHeight = 48.0;
+const _floatingBarBottomInset = 80.0;
+const _floatingBarMargin = 16.0;
 
 class CourseTableScreen extends ConsumerWidget {
   const CourseTableScreen({super.key});
 
-  Future<void> _refreshCourseTable(
-    WidgetRef ref,
-    Semester semester,
-  ) async {
+  Future<void> _refreshCourseTable(WidgetRef ref, Semester semester) async {
     final courseRepository = ref.read(courseRepositoryProvider);
     await [
       courseRepository.refreshSemesters(),
@@ -40,14 +39,13 @@ class CourseTableScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final profileAsync = ref.watch(userProfileProvider);
     final semestersAsync = ref.watch(courseTableSemestersProvider);
-    final displayedSemesterTabLabels = switch (semestersAsync) {
-      AsyncData(value: final semesters) =>
-        semesters.map(_semesterLabel).toList(growable: false),
-      _ => _loadingSemesterTabLabels,
-    };
+    final displayedSemesterTabLabels =
+        semestersAsync.asData?.value
+            .map(_semesterLabel)
+            .toList(growable: false) ??
+        _loadingSemesterTabLabels;
     final isSemesterLoading =
-        semestersAsync is AsyncLoading<List<Semester>> &&
-        semestersAsync.asData?.value == null;
+        semestersAsync.isLoading && !semestersAsync.hasValue;
 
     final tabLength = displayedSemesterTabLabels.isEmpty
         ? 1
@@ -66,140 +64,149 @@ class CourseTableScreen extends ConsumerWidget {
           builder: (context, constraints) {
             final gridViewportSize = Size(
               constraints.maxWidth,
-              (constraints.maxHeight - _ownerAppBarHeight - _semesterTabsHeight)
-                  .clamp(0.0, double.infinity),
+              (constraints.maxHeight - _ownerAppBarHeight).clamp(
+                0.0,
+                double.infinity,
+              ),
             );
+            final shouldShowFloatingBar = switch (semestersAsync) {
+              AsyncError() => false,
+              AsyncData(value: final semesters) => semesters.isNotEmpty,
+              _ => true,
+            };
 
-            return NestedScrollView(
-              headerSliverBuilder: (context, innerBoxIsScrolled) => [
-                // primary app bar with owner indicator and action buttons
-                SliverAppBar(
-                  primary: false,
-                  toolbarHeight: _ownerAppBarHeight,
-                  backgroundColor: Theme.of(context).colorScheme.primary,
-                  flexibleSpace: Align(
-                    alignment: Alignment.bottomCenter,
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 8,
-                      ),
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.end,
-                        children: [
-                          const _TableOwnerIndicator(),
-                          const Spacer(),
-                          Row(
-                            mainAxisSize: MainAxisSize.min,
-                            crossAxisAlignment: CrossAxisAlignment.end,
-                            spacing: 8,
-                            children: [
-                              _CircularIconButton(
-                                icon: Icons.refresh_outlined,
-                                onTap: () => _showDemoTap(context),
-                              ),
-                              _CircularIconButton(
-                                icon: Icons.share_outlined,
-                                onTap: () => _showDemoTap(context),
-                              ),
-                              _CircularIconButton(
-                                icon: Icons.more_vert_outlined,
-                                onTap: () => _showDemoTap(context),
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
+            return ScrollAwareFloatingActionBar(
+              margin: const EdgeInsets.all(_floatingBarMargin),
+              floatingActionBarBuilder: (context, visible) {
+                if (!shouldShowFloatingBar) {
+                  return null;
+                }
+
+                return FloatingActionBar(
+                  visible: visible,
+                  actions: [
+                    FloatingActionBarActionButton(
+                      icon: Icons.more_vert_outlined,
+                      onTap: () => _showDemoTap(context),
                     ),
-                  ),
-                ),
-
-                // secondary app bar with semester tabs
-                SliverAppBar(
-                  primary: false,
-                  floating: true,
-                  snap: true,
-                  pinned: false,
-                  toolbarHeight: _semesterTabsHeight,
-                  backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-                  surfaceTintColor: Colors.transparent,
-                  elevation: 0,
-                  titleSpacing: 0,
-                  title: displayedSemesterTabLabels.isEmpty
-                      ? const SizedBox.shrink()
-                      : IgnorePointer(
-                          ignoring: isSemesterLoading,
-                          child: AppSkeleton(
-                            enabled: isSemesterLoading,
-                            child: ChipTabSwitcher(
-                              tabs: displayedSemesterTabLabels,
-                            ),
-                          ),
-                        ),
-                ),
-              ],
-
-              body: switch (semestersAsync) {
-                // ERROR state: show error message
-                AsyncError(:final error) => Center(
-                  child: Center(child: Text('Error: $error')),
-                ),
-
-                // EMPTY state: show not found message
-                AsyncData(value: final semesters) when semesters.isEmpty =>
-                  Center(
-                    child: Center(
-                      child: Text(
-                        profileAsync.asData?.value == null
-                            ? t.general.notLoggedIn
-                            : t.courseTable.notFound,
-                      ),
-                    ),
-                  ),
-
-                // LOADED state: show course table with tabs
-                AsyncData(value: final semesters) => TabBarView(
-                  children: [
-                    for (final semester in semesters)
-                      Consumer(
-                        builder: (context, tabRef, child) {
-                          final courseTableAsync = tabRef.watch(
-                            courseTableProvider(semester.id),
-                          );
-
-                          return switch (courseTableAsync) {
-                            AsyncError(:final error) => Center(
-                              child: Center(child: Text('Error: $error')),
-                            ),
-                            _ => CourseTableGrid(
-                              key: ValueKey(_semesterLabel(semester)),
-                              courseTableData:
-                                  courseTableAsync.asData?.value ??
-                                  CourseTableData(),
-                              loading:
-                                  courseTableAsync.isLoading &&
-                                  !courseTableAsync.hasValue,
-                              onRefresh: () => _refreshCourseTable(
-                                ref,
-                                semester,
-                              ),
-                              viewportWidth: gridViewportSize.width,
-                              viewportHeight: gridViewportSize.height,
-                            ),
-                          };
-                        },
-                      ),
                   ],
-                ),
-
-                // LOADING state: show loading skeleton
-                _ => CourseTableGrid(
-                  courseTableData: CourseTableData(),
-                  loading: true,
-                  viewportWidth: gridViewportSize.width,
-                  viewportHeight: gridViewportSize.height,
-                ),
+                  child: AppSkeleton(
+                    enabled: isSemesterLoading,
+                    child: ChipTabSwitcher(
+                      tabs: displayedSemesterTabLabels,
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                    ),
+                  ),
+                );
               },
+              child: NestedScrollView(
+                headerSliverBuilder: (context, innerBoxIsScrolled) => [
+                  // primary app bar with owner indicator and action buttons
+                  SliverAppBar(
+                    primary: false,
+                    toolbarHeight: _ownerAppBarHeight,
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                    flexibleSpace: Align(
+                      alignment: Alignment.bottomCenter,
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 8,
+                        ),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            const _TableOwnerIndicator(),
+                            const Spacer(),
+                            Row(
+                              mainAxisSize: MainAxisSize.min,
+                              crossAxisAlignment: CrossAxisAlignment.end,
+                              spacing: 8,
+                              children: [
+                                _CircularIconButton(
+                                  icon: Icons.refresh_outlined,
+                                  onTap: () => _showDemoTap(context),
+                                ),
+                                _CircularIconButton(
+                                  icon: Icons.share_outlined,
+                                  onTap: () => _showDemoTap(context),
+                                ),
+                                _CircularIconButton(
+                                  icon: Icons.more_vert_outlined,
+                                  onTap: () => _showDemoTap(context),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+                body: switch (semestersAsync) {
+                  // ERROR state: show error message
+                  AsyncError(:final error) => Center(
+                    child: Center(child: Text('Error: $error')),
+                  ),
+
+                  // EMPTY state: show not found message
+                  AsyncData(value: final semesters) when semesters.isEmpty =>
+                    Center(
+                      child: Center(
+                        child: Text(
+                          profileAsync.asData?.value == null
+                              ? t.general.notLoggedIn
+                              : t.courseTable.notFound,
+                        ),
+                      ),
+                    ),
+
+                  // LOADED state: show course table with tabs
+                  AsyncData(value: final semesters) => TabBarView(
+                    children: [
+                      for (final semester in semesters)
+                        Consumer(
+                          builder: (context, tabRef, child) {
+                            final courseTableAsync = tabRef.watch(
+                              courseTableProvider(semester.id),
+                            );
+
+                            return switch (courseTableAsync) {
+                              AsyncError(:final error) => Center(
+                                child: Center(child: Text('Error: $error')),
+                              ),
+                              _ => CourseTableGrid(
+                                key: ValueKey(_semesterLabel(semester)),
+                                courseTableData:
+                                    courseTableAsync.asData?.value ??
+                                    CourseTableData(),
+                                loading:
+                                    courseTableAsync.isLoading &&
+                                    !courseTableAsync.hasValue,
+                                onRefresh: () => _refreshCourseTable(
+                                  ref,
+                                  semester,
+                                ),
+                                viewportWidth: gridViewportSize.width,
+                                viewportHeight: gridViewportSize.height,
+                                bottomInset: _floatingBarBottomInset,
+                              ),
+                            };
+                          },
+                        ),
+                    ],
+                  ),
+
+                  // LOADING state: show loading skeleton
+                  _ => CourseTableGrid(
+                    courseTableData: CourseTableData(),
+                    loading: true,
+                    viewportWidth: gridViewportSize.width,
+                    viewportHeight: gridViewportSize.height,
+                    bottomInset: _floatingBarBottomInset,
+                  ),
+                },
+              ),
             );
           },
         ),

--- a/lib/screens/main/course_table/course_table_screen.dart
+++ b/lib/screens/main/course_table/course_table_screen.dart
@@ -121,14 +121,6 @@ class CourseTableScreen extends ConsumerWidget {
                           icon: Icons.more_vert_outlined,
                           items: [
                             PopupMenuItem(
-                              value: _CourseTableMenuAction.refresh,
-                              enabled: selectedSemester != null,
-                              child: ListTile(
-                                leading: const Icon(Icons.refresh_outlined),
-                                title: Text(t.courseTable.actions.refresh),
-                              ),
-                            ),
-                            PopupMenuItem(
                               value: _CourseTableMenuAction.displayOptions,
                               child: ListTile(
                                 leading: const Icon(Icons.tune_outlined),

--- a/lib/screens/main/course_table/course_table_screen.dart
+++ b/lib/screens/main/course_table/course_table_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tattoo/components/app_skeleton.dart';
@@ -83,6 +85,11 @@ class CourseTableScreen extends ConsumerWidget {
         body: LayoutBuilder(
           builder: (context, constraints) {
             final gridViewportSize = constraints.biggest;
+            final mediaQuery = MediaQuery.of(context);
+            final bottomInset = math.max(
+              mediaQuery.padding.bottom,
+              mediaQuery.viewInsets.bottom,
+            );
             final shouldShowFloatingBar = switch (semestersAsync) {
               AsyncError() => false,
               AsyncData(value: final semesters) => semesters.isNotEmpty,
@@ -131,11 +138,24 @@ class CourseTableScreen extends ConsumerWidget {
                               ),
                             ),
                           ],
-                          onSelected: (action) {
+                          onSelected: (action) async {
                             switch (action) {
                               case _CourseTableMenuAction.refresh:
                                 if (selectedSemester != null) {
-                                  _refreshCourseTable(ref, selectedSemester);
+                                  try {
+                                    await _refreshCourseTable(
+                                      ref,
+                                      selectedSemester,
+                                    );
+                                  } catch (error) {
+                                    if (!context.mounted) {
+                                      return;
+                                    }
+
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(content: Text('Error: $error')),
+                                    );
+                                  }
                                 }
                                 break;
                               case _CourseTableMenuAction.displayOptions:
@@ -202,7 +222,8 @@ class CourseTableScreen extends ConsumerWidget {
                               ),
                               viewportWidth: gridViewportSize.width,
                               viewportHeight: gridViewportSize.height,
-                              bottomInset: _floatingBarBottomInset,
+                              bottomInset:
+                                  _floatingBarBottomInset + bottomInset,
                             ),
                           };
                         },
@@ -216,7 +237,7 @@ class CourseTableScreen extends ConsumerWidget {
                   loading: true,
                   viewportWidth: gridViewportSize.width,
                   viewportHeight: gridViewportSize.height,
-                  bottomInset: _floatingBarBottomInset,
+                  bottomInset: _floatingBarBottomInset + bottomInset,
                 ),
               },
             );


### PR DESCRIPTION
# 在課表頁面新增懸浮動作列

## 主要變更

- 移除課表頁面中用以承載 Owner Indicator 、Menu 和 Tab Swicher 的 Appber，改以懸浮列呈現。
- 一個全新的元件 `components/floating_action_bar.dart`，可承載一個主要元件和數個動作按鈕。
- 課表 grid 補上底部 inset，避免內容被懸浮列遮住，並微調列高分配以配合新版面。

## 懸浮操作列 Floating Action Bar
- 將 scrollable 包在 `ScrollAwareFloatingActionBar` 內並且傳入一個 `FloatingActionBar`。
- 可以傳入多個 `FloatingActionBarActionButton` 和一個 `FloatingActionBarMenuButton` (包含多個選項)，並且帶有 tooltip。
- 動作列在向下滑動頁面時自動隱藏，也可以透過直接在上面向下滑動來隱藏。
- 隱藏狀態時點擊空白處可以隱藏或恢復隱藏
- 水平滑動切換分頁時，將一律顯示 
 
<table>
<thead>
	<tr>
		<th>一個按鈕的情況</th>
		<th>兩個按鈕的情況</th>
		<th>選單展開</th>
	<tr>
</thead>
<tbody>
	<td>
		<img  src=https://github.com/user-attachments/assets/69c6fd30-543e-4fb8-b0ec-7da201dbad56 width=200px>
	</td><td>
		<img  src=https://github.com/user-attachments/assets/0f25800d-ba21-4715-bd16-8425685aeef0 width=250px>
	</td><td>
				<img  src=https://github.com/user-attachments/assets/028e6764-5be5-48f2-84c2-9ce828c77c58 width=200px>
	</td>
</tbody>

## 後續追蹤
1. 在此 PR 中發現 ChipTabSwicher 於自動移動時露出下一個項目的幅度不夠大，導致難以直接點擊下一個。
2. 最佳化 pop-up menu 內的更新課表選項行為和 UX 提示，那在此 PR 中只是個隨便接上去的 demo 選項，所以暫不變更。
3. 研議讓 floating bar 變成 sticky footer 的可能性

![Works on my machine](https://img.shields.io/badge/works_on-my_machine-green)