### PR TITLE
chore: ignore tmp workspace directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .svn/
 .swiftpm/
 migrate_working_dir/
+/tmp/
 
 # IntelliJ related
 *.iml


### PR DESCRIPTION
## 說明
- 將 	tmp/ 加入 .gitignore
- 避免本機暫存工作目錄或測試副本被誤提交到版本控制