### PR TITLE
ci: pin Xcode and Ruby to stop iOS Podfile.lock drift

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -76,7 +76,7 @@ runs:
     - name: Select Xcode version
       if: ${{ inputs.platform == 'ios' }}
       shell: bash
-      run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
 
     - name: Setup CocoaPods cache
       if: ${{ inputs.platform == 'ios' }}
@@ -112,5 +112,6 @@ runs:
       if: ${{ inputs.platform == 'ios' && steps.ios-drift.outputs.changed == 'true' }}
       shell: bash
       run: |
-        echo "::error::ios/ has uncommitted changes after flutter build ios --config-only. Download the patch artifact and apply it with: git apply ios-drift.patch"
+        XCODE_VERSION=$(xcodebuild -version | head -1)
+        echo "::error::ios/ drifted after flutter build ios --config-only (CI ${XCODE_VERSION}). Mismatched local Xcode is the usual cause; otherwise apply ios-drift.patch from artifacts."
         exit 1

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,48 +10,32 @@
     "flutter": "3.41.6"
   },
   "bundler": {
-    "managerFilePatterns": [
-      "/(^|/)Pluginfile$/"
-    ]
+    "managerFilePatterns": ["/(^|/)Pluginfile$/"]
   },
   "packageRules": [
     {
-      "matchPackageNames": [
-        "dart",
-        "dev.flutter.flutter-plugin-loader"
-      ],
+      "matchPackageNames": ["dart", "dev.flutter.flutter-plugin-loader"],
       "enabled": false
     },
     {
-      "matchManagers": [
-        "mise"
-      ],
-      "matchDepNames": [
-        "java",
-        "ruby"
-      ],
+      "matchManagers": ["mise"],
+      "matchDepNames": ["java"],
       "enabled": false
     },
     {
-      "matchManagers": [
-        "pub"
-      ],
+      "matchManagers": ["pub"],
       "groupName": "Flutter dependencies",
       "groupSlug": "pub",
       "rangeStrategy": "bump",
       "versioning": "npm"
     },
     {
-      "matchFileNames": [
-        "android/**"
-      ],
+      "matchFileNames": ["android/**"],
       "groupName": "Android dependencies",
       "groupSlug": "android"
     },
     {
-      "matchFileNames": [
-        "ios/**"
-      ],
+      "matchFileNames": ["ios/**"],
       "groupName": "iOS dependencies",
       "groupSlug": "ios"
     },

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -206,7 +206,7 @@ jobs:
             > Installing the App Distribution app is optional but recommended.
 
   ios:
-    runs-on: macos-latest
+    runs-on: macos-26
     needs: [prepare]
     if: needs.prepare.outputs.skip_build != 'true'
     env:

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -183,7 +183,7 @@ jobs:
           edit-mode: append
 
   ios:
-    runs-on: macos-latest
+    runs-on: macos-26
     needs: [prepare]
     env:
       FASTLANE_APP_IDENTIFIER: ${{ secrets.FASTLANE_APP_IDENTIFIER }}

--- a/.github/workflows/seed-caches.yaml
+++ b/.github/workflows/seed-caches.yaml
@@ -21,7 +21,7 @@ jobs:
         run: flutter build apk --debug --no-pub
 
   ios:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -235,9 +235,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Firebase: 065f2bb395062046623036d8e6dc857bc2521d56
-  firebase_analytics: 42693ebf35c4d330b74abcb46ca80351703644e0
-  firebase_core: 98bcc1bd1a097bcb8b1ed6e091de3039802527c4
-  firebase_crashlytics: 2fd6c030ca2f91e8d3b13d2e6e9a08a282c9d259
+  firebase_analytics: 8288e2480a2b2a5eb2cc3c474e4a4327e8dc520b
+  firebase_core: 8e6f58412ca227827c366b92e7cee047a2148c60
+  firebase_crashlytics: c399f9682c474beb06a89c11dfab04db537f3cd2
   FirebaseAnalytics: cd7d01d352f3c237c9a0e31552c257cd0b0c0352
   FirebaseCore: 428912f751178b06bef0a1793effeb4a5e09a9b8
   FirebaseCoreExtension: e911052d59cd0da237a45d706fc0f81654f035c1
@@ -247,24 +247,24 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 765ee19cd2bfa8e54937c8dae901eb634ad6787d
   FirebaseSessions: a2d06fd980431fda934c7a543901aca05fc4edcc
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
-  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
+  flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
+  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   GoogleAdsOnDeviceConversion: d68c69dd9581a0f5da02617b6f377e5be483970f
   GoogleAppMeasurement: fce7c1c90640d2f9f5c56771f71deacb2ba3f98c
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
+  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
-  mobile_scanner: 77265f3dc8d580810e91849d4a0811a90467ed5e
+  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageWebPCoder: 0e06e365080397465cc73a7a9b472d8a3bd0f377
-  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
-  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 
 PODFILE CHECKSUM: ce2a4dd764e1c7aeed6a7cdc5e61d092b6dc6d32
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
 flutter = "3.41.6"
 java = "temurin-17" # Required by Android build
-ruby = "3"          # For Fastlane and CocoaPods
+ruby = "3.4.9"      # For Fastlane and CocoaPods


### PR DESCRIPTION
## Problem

`ios/Podfile.lock` drifts on every `pod install` / `flutter build ios --config-only`. Always in the **Flutter plugin pods** (`:path`-based), never in trunk pods.

## Root cause

CocoaPods checksums trunk pods from pre-shipped `.podspec.json`, but for `:path` pods it evaluates the podspec in-process and SHA1s the generated JSON — so anything that changes the evaluation environment changes the checksum. The drift source turned out to be **Xcode version mismatch** between contributors and CI.

## Changes

- Xcode pin 26.2 → 26.4 (`setup-project/action.yml`)
- iOS runners `macos-latest` → `macos-26` — Xcode 26.4 is only available on macOS 26; `macos-latest` currently resolves to macOS 15
- Ruby `"3"` → `"3.4.9"` in `mise.toml` (defensive; loose pin was risky). `ruby/setup-ruby` reads `mise.toml` natively.
- Renovate now tracks Ruby
- Drift error message surfaces CI Xcode version for faster future diagnosis
- `ios/Podfile.lock` regenerated under the aligned toolchain

## Migration

```bash
mise install      # pulls Ruby 3.4.9
bundle install    # refresh gems under new Ruby
flutter pub get   # refresh pub packages
```

Also make sure local Xcode is **26.4** (`xcodebuild -version`). If drift recurs after this, CI's error now prints its Xcode version.

## Test plan

- [x] iOS config-drift check passes on this branch
- [x] Seed caches + PR preview iOS build succeed on `macos-26`