### PR TITLE
feat: add unscheduled course cards and summary

### DIFF
--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -52,6 +52,9 @@ nav:
 courseTable:
   notFound: Course table not found
   unscheduled: Unscheduled Courses
+  summary:
+    credits: Credits
+    hours: Hours
   actions:
     showMoreOptions: Show more options
     displayOptions: Display options

--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -51,6 +51,7 @@ nav:
   profile: Me
 courseTable:
   notFound: Course table not found
+  unscheduled: Unscheduled Courses
   actions:
     showMoreOptions: Show more options
     displayOptions: Display options

--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -53,8 +53,12 @@ courseTable:
   notFound: Course table not found
   unscheduled: Unscheduled Courses
   summary:
-    credits: Credits
-    hours: Hours
+    credits(plural, param=count):
+      one: ${count} credit
+      other: ${count} credits
+    hours(plural, param=count):
+      one: ${count} hour
+      other: ${count} hours
   actions:
     showMoreOptions: Show more options
     displayOptions: Display options

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 270 (135 per locale)
+/// Strings: 272 (136 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 272 (136 per locale)
+/// Strings: 276 (138 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 276 (138 per locale)
+/// Strings: 280 (140 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -267,8 +267,14 @@ class _TranslationsCourseTableSummaryEnUs extends TranslationsCourseTableSummary
 	final TranslationsEnUs _root; // ignore: unused_field
 
 	// Translations
-	@override String get credits => 'Credits';
-	@override String get hours => 'Hours';
+	@override String credits({required num count}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'))(count,
+		one: '${count} credit',
+		other: '${count} credits',
+	);
+	@override String hours({required num count}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'))(count,
+		one: '${count} hour',
+		other: '${count} hours',
+	);
 }
 
 // Path: courseTable.actions
@@ -486,8 +492,8 @@ extension on TranslationsEnUs {
 			'nav.profile' => 'Me',
 			'courseTable.notFound' => 'Course table not found',
 			'courseTable.unscheduled' => 'Unscheduled Courses',
-			'courseTable.summary.credits' => 'Credits',
-			'courseTable.summary.hours' => 'Hours',
+			'courseTable.summary.credits' => ({required num count}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'))(count, one: '${count} credit', other: '${count} credits', ), 
+			'courseTable.summary.hours' => ({required num count}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'))(count, one: '${count} hour', other: '${count} hours', ), 
 			'courseTable.actions.showMoreOptions' => 'Show more options',
 			'courseTable.actions.displayOptions' => 'Display options',
 			'courseTable.dayOfWeek.sunday' => 'Sun',

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -142,6 +142,7 @@ class _TranslationsCourseTableEnUs extends TranslationsCourseTableZhTw {
 
 	// Translations
 	@override String get notFound => 'Course table not found';
+	@override String get unscheduled => 'Unscheduled Courses';
 	@override late final _TranslationsCourseTableActionsEnUs actions = _TranslationsCourseTableActionsEnUs._(_root);
 	@override Map<String, String> get dayOfWeek => {
 		'sunday': 'Sun',
@@ -472,6 +473,7 @@ extension on TranslationsEnUs {
 			'nav.portal' => 'Portals',
 			'nav.profile' => 'Me',
 			'courseTable.notFound' => 'Course table not found',
+			'courseTable.unscheduled' => 'Unscheduled Courses',
 			'courseTable.actions.showMoreOptions' => 'Show more options',
 			'courseTable.actions.displayOptions' => 'Display options',
 			'courseTable.dayOfWeek.sunday' => 'Sun',

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -143,6 +143,7 @@ class _TranslationsCourseTableEnUs extends TranslationsCourseTableZhTw {
 	// Translations
 	@override String get notFound => 'Course table not found';
 	@override String get unscheduled => 'Unscheduled Courses';
+	@override late final _TranslationsCourseTableSummaryEnUs summary = _TranslationsCourseTableSummaryEnUs._(_root);
 	@override late final _TranslationsCourseTableActionsEnUs actions = _TranslationsCourseTableActionsEnUs._(_root);
 	@override Map<String, String> get dayOfWeek => {
 		'sunday': 'Sun',
@@ -257,6 +258,17 @@ class _TranslationsLoginErrorsEnUs extends TranslationsLoginErrorsZhTw {
 	@override String get accountLocked => 'Account locked due to too many failed attempts. Please try again later.';
 	@override String get passwordExpired => 'Your password has expired. Please change it on the NTUT portal.';
 	@override String get mobileVerificationRequired => 'Mobile phone verification is required. Please complete it on the NTUT portal.';
+}
+
+// Path: courseTable.summary
+class _TranslationsCourseTableSummaryEnUs extends TranslationsCourseTableSummaryZhTw {
+	_TranslationsCourseTableSummaryEnUs._(TranslationsEnUs root) : this._root = root, super.internal(root);
+
+	final TranslationsEnUs _root; // ignore: unused_field
+
+	// Translations
+	@override String get credits => 'Credits';
+	@override String get hours => 'Hours';
 }
 
 // Path: courseTable.actions
@@ -474,6 +486,8 @@ extension on TranslationsEnUs {
 			'nav.profile' => 'Me',
 			'courseTable.notFound' => 'Course table not found',
 			'courseTable.unscheduled' => 'Unscheduled Courses',
+			'courseTable.summary.credits' => 'Credits',
+			'courseTable.summary.hours' => 'Hours',
 			'courseTable.actions.showMoreOptions' => 'Show more options',
 			'courseTable.actions.displayOptions' => 'Display options',
 			'courseTable.dayOfWeek.sunday' => 'Sun',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -205,6 +205,7 @@ class TranslationsCourseTableZhTw {
 	/// zh-TW: '未安排時間的課程'
 	String get unscheduled => '未安排時間的課程';
 
+	late final TranslationsCourseTableSummaryZhTw summary = TranslationsCourseTableSummaryZhTw.internal(_root);
 	late final TranslationsCourseTableActionsZhTw actions = TranslationsCourseTableActionsZhTw.internal(_root);
 	Map<String, String> get dayOfWeek => {
 		'sunday': '日',
@@ -386,6 +387,21 @@ class TranslationsLoginErrorsZhTw {
 
 	/// zh-TW: '需要進行手機驗證，請至校園入口網站完成驗證'
 	String get mobileVerificationRequired => '需要進行手機驗證，請至校園入口網站完成驗證';
+}
+
+// Path: courseTable.summary
+class TranslationsCourseTableSummaryZhTw {
+	TranslationsCourseTableSummaryZhTw.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// zh-TW: '學分'
+	String get credits => '學分';
+
+	/// zh-TW: '時數'
+	String get hours => '時數';
 }
 
 // Path: courseTable.actions
@@ -709,6 +725,8 @@ extension on Translations {
 			'nav.profile' => '我',
 			'courseTable.notFound' => '找不到課表',
 			'courseTable.unscheduled' => '未安排時間的課程',
+			'courseTable.summary.credits' => '學分',
+			'courseTable.summary.hours' => '時數',
 			'courseTable.actions.showMoreOptions' => '顯示更多選項',
 			'courseTable.actions.displayOptions' => '顯示選項',
 			'courseTable.dayOfWeek.sunday' => '日',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -397,11 +397,17 @@ class TranslationsCourseTableSummaryZhTw {
 
 	// Translations
 
-	/// zh-TW: '學分'
-	String get credits => '學分';
+	/// zh-TW: '(one) {${count}學分} (other) {${count}學分}'
+	String credits({required num count}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('zh'))(count,
+		one: '${count}學分',
+		other: '${count}學分',
+	);
 
-	/// zh-TW: '時數'
-	String get hours => '時數';
+	/// zh-TW: '(one) {${count}小時} (other) {${count}小時}'
+	String hours({required num count}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('zh'))(count,
+		one: '${count}小時',
+		other: '${count}小時',
+	);
 }
 
 // Path: courseTable.actions
@@ -725,8 +731,8 @@ extension on Translations {
 			'nav.profile' => '我',
 			'courseTable.notFound' => '找不到課表',
 			'courseTable.unscheduled' => '未安排時間的課程',
-			'courseTable.summary.credits' => '學分',
-			'courseTable.summary.hours' => '時數',
+			'courseTable.summary.credits' => ({required num count}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('zh'))(count, one: '${count}學分', other: '${count}學分', ), 
+			'courseTable.summary.hours' => ({required num count}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('zh'))(count, one: '${count}小時', other: '${count}小時', ), 
 			'courseTable.actions.showMoreOptions' => '顯示更多選項',
 			'courseTable.actions.displayOptions' => '顯示選項',
 			'courseTable.dayOfWeek.sunday' => '日',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -202,6 +202,9 @@ class TranslationsCourseTableZhTw {
 	/// zh-TW: '找不到課表'
 	String get notFound => '找不到課表';
 
+	/// zh-TW: '未安排時間的課程'
+	String get unscheduled => '未安排時間的課程';
+
 	late final TranslationsCourseTableActionsZhTw actions = TranslationsCourseTableActionsZhTw.internal(_root);
 	Map<String, String> get dayOfWeek => {
 		'sunday': '日',
@@ -705,6 +708,7 @@ extension on Translations {
 			'nav.portal' => '傳送門',
 			'nav.profile' => '我',
 			'courseTable.notFound' => '找不到課表',
+			'courseTable.unscheduled' => '未安排時間的課程',
 			'courseTable.actions.showMoreOptions' => '顯示更多選項',
 			'courseTable.actions.displayOptions' => '顯示選項',
 			'courseTable.dayOfWeek.sunday' => '日',

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -51,6 +51,7 @@ nav:
   profile: 我
 courseTable:
   notFound: 找不到課表
+  unscheduled: 未安排時間的課程
   actions:
     showMoreOptions: 顯示更多選項
     displayOptions: 顯示選項

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -52,6 +52,9 @@ nav:
 courseTable:
   notFound: 找不到課表
   unscheduled: 未安排時間的課程
+  summary:
+    credits: 學分
+    hours: 時數
   actions:
     showMoreOptions: 顯示更多選項
     displayOptions: 顯示選項

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -53,8 +53,12 @@ courseTable:
   notFound: 找不到課表
   unscheduled: 未安排時間的課程
   summary:
-    credits: 學分
-    hours: 時數
+    credits(plural, param=count):
+      one: ${count}學分
+      other: ${count}學分
+    hours(plural, param=count):
+      one: ${count}小時
+      other: ${count}小時
   actions:
     showMoreOptions: 顯示更多選項
     displayOptions: 顯示選項

--- a/lib/screens/main/course_table/course_table_cell.dart
+++ b/lib/screens/main/course_table/course_table_cell.dart
@@ -148,6 +148,17 @@ class CourseTableUnscheduledCell extends StatelessWidget {
     final theme = Theme.of(context);
     final splashColor = theme.colorScheme.primary.withValues(alpha: 0.18);
     final highlightColor = theme.colorScheme.primary.withValues(alpha: 0.12);
+    final courseName = courseTableCellData.courseName.trim();
+    final number = courseTableCellData.number?.trim();
+    final titleText = switch ((courseName, number)) {
+      (final courseName, _) when courseName.isNotEmpty => courseName,
+      (_, final number?) when number.isNotEmpty => number,
+      _ => t.general.unknown,
+    };
+    final subtitleText = switch (number) {
+      final number? when number.isNotEmpty && number != titleText => number,
+      _ => null,
+    };
 
     return Card(
       margin: .zero,
@@ -186,18 +197,16 @@ class CourseTableUnscheduledCell extends StatelessWidget {
                   dense: true,
                   visualDensity: .compact,
                   title: Text(
-                    courseTableCellData.courseName.isNotEmpty
-                        ? courseTableCellData.courseName
-                        : courseTableCellData.number ?? t.general.unknown,
+                    titleText,
                     style: theme.textTheme.bodyLarge?.copyWith(
                       fontWeight: .w600,
                     ),
                     maxLines: 1,
                     overflow: .ellipsis,
                   ),
-                  subtitle: switch (courseTableCellData.number) {
-                    final number? => Text(
-                      number,
+                  subtitle: switch (subtitleText) {
+                    final subtitleText? => Text(
+                      subtitleText,
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: theme.colorScheme.onSurfaceVariant,
                       ),

--- a/lib/screens/main/course_table/course_table_cell.dart
+++ b/lib/screens/main/course_table/course_table_cell.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 import 'package:tattoo/components/app_skeleton.dart';
 import 'package:tattoo/components/widget_preview_frame.dart';
+import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/course_repository.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 
@@ -115,7 +116,107 @@ class CourseTableCell extends StatelessWidget {
   }
 }
 
+/// A card row used by the unscheduled course section under the grid.
+///
+/// It displays the course name/number and credits/hours, with a colored
+/// leading indicator that matches the corresponding scheduled course color.
+class CourseTableUnscheduledCell extends StatelessWidget {
+  /// Creates an unscheduled-course list row.
+  const CourseTableUnscheduledCell({
+    required this.courseTableCellData,
+    required this.indicatorColor,
+    this.onTap,
+    super.key,
+  });
+
+  /// Course data rendered by this list row.
+  final CourseTableCellData courseTableCellData;
+
+  /// Color of the leading indicator stripe.
+  final Color indicatorColor;
+
+  /// Called when the user taps this row.
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      margin: .zero,
+      elevation: 0,
+      color: theme.colorScheme.surfaceContainerLow,
+      shape: RoundedRectangleBorder(
+        borderRadius: .circular(12),
+        side: BorderSide(color: theme.colorScheme.outlineVariant),
+      ),
+      child: InkWell(
+        borderRadius: .circular(12),
+        onTap: onTap,
+        child: Padding(
+          padding: const .symmetric(
+            horizontal: 12,
+            vertical: 6,
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 4,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: indicatorColor,
+                  borderRadius: .circular(999),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: ListTile(
+                  contentPadding: .zero,
+                  dense: true,
+                  visualDensity: .compact,
+                  title: Text(
+                    courseTableCellData.courseName.isNotEmpty
+                        ? courseTableCellData.courseName
+                        : courseTableCellData.number ?? t.general.unknown,
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      fontWeight: .w600,
+                    ),
+                    maxLines: 1,
+                    overflow: .ellipsis,
+                  ),
+                  subtitle: switch (courseTableCellData.number) {
+                    final number? => Text(
+                      number,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      maxLines: 1,
+                      overflow: .ellipsis,
+                    ),
+                    null => null,
+                  },
+                ),
+              ),
+              Text(
+                '${courseTableCellData.credits} / ${courseTableCellData.hours}',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: .w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Skeleton placeholder for [CourseTableCell] while loading.
+///
+/// This keeps the same rounded border silhouette as the real cell to reduce
+/// layout shift between loading and loaded states.
 class CourseTableCellSkeleton extends StatelessWidget {
+  /// Creates a loading placeholder for a course table cell.
   const CourseTableCellSkeleton({super.key});
 
   @override

--- a/lib/screens/main/course_table/course_table_cell.dart
+++ b/lib/screens/main/course_table/course_table_cell.dart
@@ -54,6 +54,8 @@ class CourseTableCell extends StatelessWidget {
         ? courseTableCellData.courseName
         : courseTableCellData.number ?? '';
     final classroomName = courseTableCellData.classroomName;
+    final splashColor = borderColor.withValues(alpha: 0.22);
+    final highlightColor = borderColor.withValues(alpha: 0.14);
 
     return MediaQuery(
       data: MediaQuery.of(context).copyWith(textScaler: TextScaler.noScaling),
@@ -68,6 +70,9 @@ class CourseTableCell extends StatelessWidget {
           child: InkWell(
             onTap: onTap,
             borderRadius: borderRadius,
+            splashFactory: InkRipple.splashFactory,
+            splashColor: splashColor,
+            highlightColor: highlightColor,
             child: LayoutBuilder(
               builder: (context, constraints) {
                 final titleMaxLines = constraints.maxHeight > 100 ? 3 : 2;
@@ -141,6 +146,8 @@ class CourseTableUnscheduledCell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final splashColor = theme.colorScheme.primary.withValues(alpha: 0.18);
+    final highlightColor = theme.colorScheme.primary.withValues(alpha: 0.12);
 
     return Card(
       margin: .zero,
@@ -150,9 +157,13 @@ class CourseTableUnscheduledCell extends StatelessWidget {
         borderRadius: .circular(12),
         side: BorderSide(color: theme.colorScheme.outlineVariant),
       ),
+      clipBehavior: Clip.antiAlias,
       child: InkWell(
         borderRadius: .circular(12),
         onTap: onTap,
+        splashFactory: InkRipple.splashFactory,
+        splashColor: splashColor,
+        highlightColor: highlightColor,
         child: Padding(
           padding: const .symmetric(
             horizontal: 12,

--- a/lib/screens/main/course_table/course_table_cell.dart
+++ b/lib/screens/main/course_table/course_table_cell.dart
@@ -218,7 +218,7 @@ class CourseTableUnscheduledCell extends StatelessWidget {
                 ),
               ),
               Text(
-                '${courseTableCellData.credits} / ${courseTableCellData.hours}',
+                '${courseTableCellData.credits} · ${courseTableCellData.hours}',
                 style: theme.textTheme.bodyMedium?.copyWith(
                   fontWeight: .w600,
                 ),

--- a/lib/screens/main/course_table/course_table_grid.dart
+++ b/lib/screens/main/course_table/course_table_grid.dart
@@ -199,7 +199,7 @@ class CourseTableGrid extends StatelessWidget {
           ),
         if (!loading && !_isEmpty)
           SliverToBoxAdapter(
-            child: _bulidCourseTableSummary(context),
+            child: _buildCourseTableSummary(context),
           ),
 
         if (bottomInset > 0)
@@ -588,7 +588,7 @@ class CourseTableGrid extends StatelessWidget {
     );
   }
 
-  Widget _bulidCourseTableSummary(BuildContext context) {
+  Widget _buildCourseTableSummary(BuildContext context) {
     return Padding(
       padding: const .all(8),
       child: Center(

--- a/lib/screens/main/course_table/course_table_grid.dart
+++ b/lib/screens/main/course_table/course_table_grid.dart
@@ -197,6 +197,11 @@ class CourseTableGrid extends StatelessWidget {
           SliverToBoxAdapter(
             child: _buildUnscheduledCourses(context, colorByCourseId),
           ),
+        if (!loading && !_isEmpty)
+          SliverToBoxAdapter(
+            child: _bulidCourseTableSummary(context),
+          ),
+
         if (bottomInset > 0)
           SliverToBoxAdapter(
             child: SizedBox(height: bottomInset),
@@ -579,6 +584,21 @@ class CourseTableGrid extends StatelessWidget {
               },
             ),
         ],
+      ),
+    );
+  }
+
+  Widget _bulidCourseTableSummary(BuildContext context) {
+    return Padding(
+      padding: const .all(8),
+      child: Center(
+        child: Text(
+          ' - '
+          '${t.courseTable.summary.credits}: ${courseTableData.totalCredits} / '
+          '${t.courseTable.summary.hours}: ${courseTableData.totalHours}'
+          ' - ',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
       ),
     );
   }

--- a/lib/screens/main/course_table/course_table_grid.dart
+++ b/lib/screens/main/course_table/course_table_grid.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:tattoo/components/widget_preview_frame.dart';
+import 'package:tattoo/components/section_header.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/models/course.dart';
 import 'package:tattoo/repositories/course_repository.dart';
@@ -44,6 +45,43 @@ class CourseTableGrid extends StatelessWidget {
   static const double _tableHeaderHeight = 25;
   static const double _stubWidth = 20;
   static const double _gridLineThickness = 1;
+  static const List<Color> _cellColors = [
+    Colors.red,
+    Colors.blue,
+    Colors.green,
+    Colors.orange,
+    Colors.purple,
+    Colors.teal,
+    Colors.pink,
+    Colors.indigo,
+    Colors.amber,
+    Colors.cyan,
+    Colors.deepOrange,
+    Colors.lightGreen,
+    Colors.deepPurple,
+    Colors.lightBlue,
+    Colors.lime,
+    Colors.brown,
+    Colors.blueGrey,
+    Colors.redAccent,
+    Colors.blueAccent,
+    Colors.greenAccent,
+    Colors.orangeAccent,
+    Colors.purpleAccent,
+    Colors.tealAccent,
+    Colors.pinkAccent,
+    Colors.indigoAccent,
+    Colors.amberAccent,
+    Colors.cyanAccent,
+    Colors.deepOrangeAccent,
+    Colors.lightGreenAccent,
+    Colors.deepPurpleAccent,
+    Colors.lightBlueAccent,
+    Colors.limeAccent,
+    Colors.yellow,
+    Colors.grey,
+    Colors.yellowAccent,
+  ];
 
   late final _GridRange _gridRange = _visibleGridRange();
   List<DayOfWeek> get _visibleDaysOfWeek => _gridRange.visibleDaysOfWeek;
@@ -118,6 +156,7 @@ class CourseTableGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorByCourseId = _buildColorByCourseId();
     final scrollView = CustomScrollView(
       physics: const AlwaysScrollableScrollPhysics().applyTo(
         ScrollConfiguration.of(context).getScrollPhysics(context),
@@ -147,12 +186,17 @@ class CourseTableGrid extends StatelessWidget {
                   ? _buildSkeleton(_visibleDaysOfWeek, _visiblePeriods)
                   : _buildCourseCells(
                       context,
+                      colorByCourseId,
                       _visibleDaysOfWeek,
                       _visiblePeriods,
                     )),
             ],
           ),
         ),
+        if (!loading && courseTableData.unscheduled.isNotEmpty)
+          SliverToBoxAdapter(
+            child: _buildUnscheduledCourses(context, colorByCourseId),
+          ),
         if (bottomInset > 0)
           SliverToBoxAdapter(
             child: SizedBox(height: bottomInset),
@@ -166,6 +210,18 @@ class CourseTableGrid extends StatelessWidget {
         child: scrollView,
       ),
       null => scrollView,
+    };
+  }
+
+  Map<int, Color> _buildColorByCourseId() {
+    final courseIds = {
+      ...courseTableData.scheduled.values.map((cell) => cell.id),
+      ...courseTableData.unscheduled.map((cell) => cell.id),
+    }.toList()..sort();
+
+    return {
+      for (var i = 0; i < courseIds.length; i++)
+        courseIds[i]: _cellColors[i % _cellColors.length],
     };
   }
 
@@ -425,61 +481,12 @@ class CourseTableGrid extends StatelessWidget {
 
   List<Widget> _buildCourseCells(
     BuildContext context,
+    Map<int, Color> colorByCourseId,
     List<DayOfWeek> visibleDaysOfWeek,
     List<Period> visiblePeriods,
   ) {
-    const List<Color> cellColors = [
-      Colors.red,
-      Colors.blue,
-      Colors.green,
-      Colors.orange,
-      Colors.purple,
-      Colors.teal,
-      Colors.pink,
-      Colors.indigo,
-      Colors.amber,
-      Colors.cyan,
-      Colors.deepOrange,
-      Colors.lightGreen,
-      Colors.deepPurple,
-      Colors.lightBlue,
-      Colors.lime,
-      Colors.brown,
-      Colors.blueGrey,
-      Colors.redAccent,
-      Colors.blueAccent,
-      Colors.greenAccent,
-      Colors.orangeAccent,
-      Colors.purpleAccent,
-      Colors.tealAccent,
-      Colors.pinkAccent,
-      Colors.indigoAccent,
-      Colors.amberAccent,
-      Colors.cyanAccent,
-      Colors.deepOrangeAccent,
-      Colors.lightGreenAccent,
-      Colors.deepPurpleAccent,
-      Colors.lightBlueAccent,
-      Colors.limeAccent,
-      Colors.yellow,
-      Colors.grey,
-      Colors.yellowAccent,
-    ];
-
     final columnWidth = _dayColumnWidth;
     final random = Random();
-    final availableColors = cellColors.reversed.toList(growable: true);
-    final colorByCourseId = <int, Color>{};
-
-    Color resolveCellColor(int courseId) {
-      return colorByCourseId.putIfAbsent(courseId, () {
-        if (availableColors.isEmpty) {
-          availableColors.addAll(cellColors.reversed);
-        }
-
-        return availableColors.removeLast();
-      });
-    }
 
     final sortedEntries = courseTableData.scheduled.entries.toList()
       ..sort((a, b) {
@@ -537,7 +544,7 @@ class CourseTableGrid extends StatelessWidget {
                 },
                 child: CourseTableCell(
                   courseTableCellData: cell,
-                  cellColor: resolveCellColor(cell.id),
+                  cellColor: colorByCourseId[cell.id] ?? Colors.grey,
                   onTap: () {
                     showCourseTableDetailSheet(context, cell: cell);
                   },
@@ -550,6 +557,30 @@ class CourseTableGrid extends StatelessWidget {
     }
 
     return cells;
+  }
+
+  Widget _buildUnscheduledCourses(
+    BuildContext context,
+    Map<int, Color> colorByCourseId,
+  ) {
+    return Padding(
+      padding: const .all(16),
+      child: Column(
+        crossAxisAlignment: .center,
+        spacing: 8,
+        children: [
+          SectionHeader(title: t.courseTable.unscheduled),
+          for (final cell in courseTableData.unscheduled)
+            CourseTableUnscheduledCell(
+              courseTableCellData: cell,
+              indicatorColor: colorByCourseId[cell.id] ?? Colors.grey,
+              onTap: () {
+                showCourseTableDetailSheet(context, cell: cell);
+              },
+            ),
+        ],
+      ),
+    );
   }
 }
 
@@ -605,7 +636,18 @@ final CourseTableData _previewCourseTableData = (
       hours: 3,
     ),
   },
-  unscheduled: <CourseTableCellData>[],
+  unscheduled: [
+    (
+      id: 4,
+      number: 'CSIE4999',
+      span: 0,
+      crossesNoon: false,
+      courseName: '校外實習',
+      classroomName: null,
+      credits: 9.0,
+      hours: 9,
+    ),
+  ],
   hasWeekdayCourse: true,
   hasSaturdayCourse: false,
   hasSundayCourse: false,
@@ -615,6 +657,6 @@ final CourseTableData _previewCourseTableData = (
   hasEveningCourse: false,
   earliestPeriod: .first,
   latestPeriod: .eighth,
-  totalCredits: 9.0,
-  totalHours: 9,
+  totalCredits: 18.0,
+  totalHours: 18,
 );

--- a/lib/screens/main/course_table/course_table_grid.dart
+++ b/lib/screens/main/course_table/course_table_grid.dart
@@ -156,7 +156,7 @@ class CourseTableGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorByCourseId = _buildColorByCourseId();
+    late final colorByCourseId = _buildColorByCourseId();
     final scrollView = CustomScrollView(
       physics: const AlwaysScrollableScrollPhysics().applyTo(
         ScrollConfiguration.of(context).getScrollPhysics(context),

--- a/lib/screens/main/course_table/course_table_grid.dart
+++ b/lib/screens/main/course_table/course_table_grid.dart
@@ -594,7 +594,7 @@ class CourseTableGrid extends StatelessWidget {
       child: Center(
         child: Text(
           ' - '
-          '${t.courseTable.summary.credits}: ${courseTableData.totalCredits} / '
+          '${t.courseTable.summary.credits}: ${courseTableData.totalCredits} · '
           '${t.courseTable.summary.hours}: ${courseTableData.totalHours}'
           ' - ',
           style: Theme.of(context).textTheme.bodyMedium,

--- a/lib/screens/main/course_table/course_table_grid.dart
+++ b/lib/screens/main/course_table/course_table_grid.dart
@@ -594,8 +594,8 @@ class CourseTableGrid extends StatelessWidget {
       child: Center(
         child: Text(
           ' - '
-          '${t.courseTable.summary.credits}: ${courseTableData.totalCredits} · '
-          '${t.courseTable.summary.hours}: ${courseTableData.totalHours}'
+          '${t.courseTable.summary.credits(count: courseTableData.totalCredits)} · '
+          '${t.courseTable.summary.hours(count: courseTableData.totalHours)}'
           ' - ',
           style: Theme.of(context).textTheme.bodyMedium,
         ),


### PR DESCRIPTION
# 新增未安排時間的課程與課表總結資訊

## 總結

接續 #249 的工作，
- 將未安排時間的課堂顯示於課表下方
- 加入學分 / 時間資訊

<img width="250" alt="image" src="https://github.com/user-attachments/assets/eadbddbb-d4bd-474b-9aa7-2f4aab80c581" />

## 後續追蹤

- 討論是否該將動作按鈕也放到課表下方，或是僅維持在 action bar 中。