### PR TITLE
ci: reduce fastlane output noise in CI

### DIFF
--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -31,6 +31,14 @@ concurrency:
 permissions:
   contents: write
 
+env:
+  FASTLANE_SKIP_UPDATE_CHECK: true
+  FASTLANE_HIDE_CHANGELOG: true
+  FASTLANE_HIDE_GITHUB_ISSUES: true
+  FASTLANE_DISABLE_OUTPUT_FORMAT: true
+  FASTLANE_HIDE_PLUGINS_TABLE: true
+  FASTLANE_SKIP_ACTION_SUMMARY: true
+
 jobs:
   prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -36,6 +36,14 @@ concurrency:
       && '-noop' || '' }}
   cancel-in-progress: true
 
+env:
+  FASTLANE_SKIP_UPDATE_CHECK: true
+  FASTLANE_HIDE_CHANGELOG: true
+  FASTLANE_HIDE_GITHUB_ISSUES: true
+  FASTLANE_DISABLE_OUTPUT_FORMAT: true
+  FASTLANE_HIDE_PLUGINS_TABLE: true
+  FASTLANE_SKIP_ACTION_SUMMARY: true
+
 jobs:
   prepare:
     if: >-


### PR DESCRIPTION
## Summary
Add `FASTLANE_SKIP_UPDATE_CHECK`, `FASTLANE_HIDE_GITHUB_ISSUES`, `FASTLANE_DISABLE_OUTPUT_FORMAT`, `FASTLANE_HIDE_PLUGINS_TABLE`, `FASTLANE_SKIP_ACTION_SUMMARY`, and `FASTLANE_HIDE_CHANGELOG` env vars to all fastlane jobs in `pr-preview` and `daily-release` workflows

## Test plan
- [x] Trigger a PR preview build and verify fastlane output is cleaner