### PR TITLE
docs: tighten and Android-focus the e2e skill

### DIFF
--- a/.agents/skills/e2e/SKILL.md
+++ b/.agents/skills/e2e/SKILL.md
@@ -1,21 +1,15 @@
 ---
 name: e2e
-description: Drive the app in an Android emulator or iOS Simulator for manual E2E testing
+description: Drive the app in an Android emulator for manual E2E testing
 ---
 
 ## Setup
 
-### Android emulator (preferred)
+### Android emulator
 
 - Launch the app with `flutter run` (in the background) so logs are inspectable and the running build reflects the current code
 - If `adb devices` lists more than one device, pick the emulator and pass `-s <serial>` to every `adb` call
 - Screen resolution: `adb -s <serial> shell wm size`
-
-### iOS Simulator (fallback)
-
-Requires Xcode Simulator with the app running. Limited to screenshots only via `xcrun simctl` — touch input requires the computer-use MCP (takes over the user's screen).
-
-- Booted devices: run `xcrun simctl list devices booted`
 
 ### Login credentials
 
@@ -27,10 +21,13 @@ If a flow needs login, look for project-local Dart test credentials in `test/tes
 
 Some AI image APIs reject screenshots with any side longer than 2000px, so always clamp the long edge before reading.
 
-- **Android:** `adb exec-out screencap -p | magick - -resize '1999x1999>' /tmp/android_screen.png` then read the PNG with the agent's image tool
-- **iOS:** `xcrun simctl io <UDID> screenshot /tmp/sim_screen.png && magick /tmp/sim_screen.png -resize '1999x1999>' /tmp/sim_screen.png` then read the PNG with the agent's image tool
+```bash
+adb exec-out screencap -p | magick - -resize '1999x1999>' /tmp/android_screen.png
+```
 
-### UI hierarchy (Android only)
+Then read the PNG with the agent's image tool.
+
+### UI hierarchy
 
 `adb shell uiautomator dump` produces an XML accessibility tree with exact pixel bounds and `content-desc` for every element. This is the primary way to find tap coordinates — do not guess from screenshots.
 
@@ -46,7 +43,7 @@ grep -oE 'content-desc="[^"]*"[^/]*bounds="[^"]*"' /tmp/ui.xml
 
 Flutter widgets with `Semantics` labels appear as `content-desc`. The bounds format is `[left,top][right,bottom]` in pixels. Tap the center: `x = (left+right)/2`, `y = (top+bottom)/2`.
 
-### Touch input (Android only)
+### Touch input
 
 - **Tap:** `adb shell input tap <x> <y>`
 - **Swipe:** `adb shell input swipe <x1> <y1> <x2> <y2> <duration_ms>`

--- a/.agents/skills/e2e/SKILL.md
+++ b/.agents/skills/e2e/SKILL.md
@@ -18,12 +18,18 @@ Requires Xcode Simulator with the app running. Limited to screenshots only via `
 
 - Booted devices: run `xcrun simctl list devices booted`
 
+### Login credentials
+
+If a flow needs login, look for project-local Dart test credentials in `test/test_config.json` under the current workspace. Do not copy credentials into this skill or into permanent notes.
+
 ## Tools
 
 ### Screenshots
 
-- **Android:** `adb exec-out screencap -p > /tmp/android_screen.png` then `Read` to view
-- **iOS:** `xcrun simctl io <UDID> screenshot /tmp/sim_screen.png` then `Read` to view
+Some AI image APIs reject screenshots with any side longer than 2000px, so always clamp the long edge before reading.
+
+- **Android:** `adb exec-out screencap -p | magick - -resize '1999x1999>' /tmp/android_screen.png` then read the PNG with the agent's image tool
+- **iOS:** `xcrun simctl io <UDID> screenshot /tmp/sim_screen.png && magick /tmp/sim_screen.png -resize '1999x1999>' /tmp/sim_screen.png` then read the PNG with the agent's image tool
 
 ### UI hierarchy (Android only)
 

--- a/.agents/skills/e2e/SKILL.md
+++ b/.agents/skills/e2e/SKILL.md
@@ -54,6 +54,27 @@ Flutter widgets with `Semantics` labels appear as `content-desc`. The bounds for
 - **Key event:** `adb shell input keyevent <code>` (BACK=4, HOME=3, ENTER=66)
 - **Text:** `adb shell input text '<text>'`
 
+### Text input pitfalls
+
+`input text` passes through both the host shell and the device shell, which silently drop or expand `$`, `#`, `\``, spaces, and other shell metacharacters. Failures look like a too-short string in the field.
+
+```bash
+# Wrong — host and device shell both expand $, leading to truncation
+adb shell input text "$PASSWORD"
+
+# Right — single-quote on the device side so the device shell treats it literally
+adb shell "input text '$PASSWORD'"
+```
+
+Tapping a non-empty field places the cursor at the end, so the next `input text` appends rather than replaces. Clear the field first:
+
+```bash
+adb shell input tap <x> <y>
+for i in $(seq 1 50); do adb shell input keyevent 67; done  # 67 = DEL/backspace
+```
+
+Password fields hide their contents, so the only way to verify what was typed is the dot count — count it against the expected length before submitting.
+
 ### Scrollable containers
 
 Swiping on a `TabBarView` body switches tabs. Swiping on a `SingleChildScrollView`/`HorizontalScrollView` scrolls it. The `uiautomator` dump shows `scrollable="true"` on scrollable containers — use those bounds for swipe coordinates.

--- a/.agents/skills/e2e/SKILL.md
+++ b/.agents/skills/e2e/SKILL.md
@@ -52,13 +52,13 @@ Flutter widgets with `Semantics` labels appear as `content-desc`. The bounds for
 
 ### Text input pitfalls
 
-`input text` passes through both the host shell and the device shell, which silently drop or expand `$`, `#`, `\``, spaces, and other shell metacharacters. Failures look like a too-short string in the field.
+`input text` runs through the device's shell, so any `$`, `#`, backticks, or unquoted whitespace in the value get expanded or word-split there — even after the host shell has already substituted `$PASSWORD`. Failures look like a too-short string in the field.
 
 ```bash
-# Wrong — host and device shell both expand $, leading to truncation
+# Wrong — host expands $PASSWORD, then the device shell re-parses the value
 adb shell input text "$PASSWORD"
 
-# Right — single-quote on the device side so the device shell treats it literally
+# Right — single-quote on the device side so the device shell treats the value literally
 adb shell "input text '$PASSWORD'"
 ```
 

--- a/.agents/skills/e2e/SKILL.md
+++ b/.agents/skills/e2e/SKILL.md
@@ -77,11 +77,10 @@ Swiping on a `TabBarView` body switches tabs. Swiping on a `SingleChildScrollVie
 
 ## Workflow
 
-1. **Take a screenshot** to see current app state
-2. **Dump UI hierarchy** with `uiautomator` to get element bounds
-3. **Find the target element** by `content-desc` or position in the tree
-4. **Calculate center coordinates** from bounds and tap
-5. **Screenshot again** to verify the result
-6. Repeat until the task is complete
+1. **Dump UI hierarchy** with `uiautomator` to get element bounds
+2. **Find the target element** by `content-desc` or position in the tree
+3. **Calculate center coordinates** from bounds and tap
+4. **Screenshot** to confirm the resulting state
+5. Repeat until the task is complete
 
-Always dump the UI hierarchy before tapping — never guess coordinates from screenshots alone. Re-dump after each navigation since bounds change between screens.
+Bounds in the XML are exact pixels — that's where tap coordinates come from. Screenshots are best used as a state check between actions: confirming a screen rendered, an error appeared, or content updated. Re-dump after each navigation since bounds change between screens.

--- a/.agents/skills/e2e/SKILL.md
+++ b/.agents/skills/e2e/SKILL.md
@@ -7,10 +7,9 @@ description: Drive the app in an Android emulator or iOS Simulator for manual E2
 
 ### Android emulator (preferred)
 
-Requires a running Android emulator with the app installed.
-
-- Verify connection: run `adb devices`
-- Screen resolution: run `adb shell wm size`
+- Launch the app with `flutter run` (in the background) so logs are inspectable and the running build reflects the current code
+- If `adb devices` lists more than one device, pick the emulator and pass `-s <serial>` to every `adb` call
+- Screen resolution: `adb -s <serial> shell wm size`
 
 ### iOS Simulator (fallback)
 


### PR DESCRIPTION
Iterative refinements to `.agents/skills/e2e/SKILL.md` based on a real run-through of an avatar-change flow.

## Summary

- Drop iOS Simulator support — the skill is Android-only now (description, headings, screenshots section, "(Android only)" parentheticals all cleaned up).
- Require launching the app via `flutter run` in the background so logs are inspectable and the running build reflects current code, instead of relying on a pre-installed APK.
- Document multi-device handling: pick the emulator and pass `-s <serial>` to every `adb` call.
- Clamp screenshots to 1999px on the long edge before reading (some image APIs reject anything ≥2000px).
- Add a "Text input pitfalls" section covering `$`/`#`/spaces being eaten by host+device shells, single-quote escaping, clearing populated fields before re-typing, and the password-field dot-count check.
- Reorder the workflow to lead with the UI dump and frame the screenshot as a state check between actions.

## Test plan

- [x] Re-run a representative E2E flow (e.g. avatar change) following the updated skill end-to-end without doubling back to debug shell-escaping or device targeting.