### PR TITLE
feat: warn user via snackbar when password is about to expire

### DIFF
--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -65,7 +65,9 @@ courseTable:
 profile:
   dataDisclaimer: Reference only. Not official.
   passwordExpiry:
-    warning: Password expires in ${days} days
+    warning(plural, param=days):
+      one: Password expires in 1 day
+      other: Password expires in ${days} days
     action: Change
   sections:
     accountSettings: Account Settings

--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -64,6 +64,9 @@ courseTable:
     saturday: Sat
 profile:
   dataDisclaimer: Reference only. Not official.
+  passwordExpiry:
+    warning: Password expires in ${days} days
+    action: Change
   sections:
     accountSettings: Account Settings
     appSettings: App Settings

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 268 (134 per locale)
+/// Strings: 270 (135 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 264 (132 per locale)
+/// Strings: 268 (134 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -276,7 +276,10 @@ class _TranslationsProfilePasswordExpiryEnUs extends TranslationsProfilePassword
 	final TranslationsEnUs _root; // ignore: unused_field
 
 	// Translations
-	@override String warning({required Object days}) => 'Password expires in ${days} days';
+	@override String warning({required num days}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'))(days,
+		one: 'Password expires in 1 day',
+		other: 'Password expires in ${days} days',
+	);
 	@override String get action => 'Change';
 }
 
@@ -479,7 +482,7 @@ extension on TranslationsEnUs {
 			'courseTable.dayOfWeek.friday' => 'Fri',
 			'courseTable.dayOfWeek.saturday' => 'Sat',
 			'profile.dataDisclaimer' => 'Reference only. Not official.',
-			'profile.passwordExpiry.warning' => ({required Object days}) => 'Password expires in ${days} days',
+			'profile.passwordExpiry.warning' => ({required num days}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'))(days, one: 'Password expires in 1 day', other: 'Password expires in ${days} days', ), 
 			'profile.passwordExpiry.action' => 'Change',
 			'profile.sections.accountSettings' => 'Account Settings',
 			'profile.sections.appSettings' => 'App Settings',

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -162,6 +162,7 @@ class _TranslationsProfileEnUs extends TranslationsProfileZhTw {
 
 	// Translations
 	@override String get dataDisclaimer => 'Reference only. Not official.';
+	@override late final _TranslationsProfilePasswordExpiryEnUs passwordExpiry = _TranslationsProfilePasswordExpiryEnUs._(_root);
 	@override late final _TranslationsProfileSectionsEnUs sections = _TranslationsProfileSectionsEnUs._(_root);
 	@override late final _TranslationsProfileOptionsEnUs options = _TranslationsProfileOptionsEnUs._(_root);
 	@override late final _TranslationsProfileAvatarEnUs avatar = _TranslationsProfileAvatarEnUs._(_root);
@@ -266,6 +267,17 @@ class _TranslationsCourseTableActionsEnUs extends TranslationsCourseTableActions
 	// Translations
 	@override String get showMoreOptions => 'Show more options';
 	@override String get displayOptions => 'Display options';
+}
+
+// Path: profile.passwordExpiry
+class _TranslationsProfilePasswordExpiryEnUs extends TranslationsProfilePasswordExpiryZhTw {
+	_TranslationsProfilePasswordExpiryEnUs._(TranslationsEnUs root) : this._root = root, super.internal(root);
+
+	final TranslationsEnUs _root; // ignore: unused_field
+
+	// Translations
+	@override String warning({required Object days}) => 'Password expires in ${days} days';
+	@override String get action => 'Change';
 }
 
 // Path: profile.sections
@@ -467,6 +479,8 @@ extension on TranslationsEnUs {
 			'courseTable.dayOfWeek.friday' => 'Fri',
 			'courseTable.dayOfWeek.saturday' => 'Sat',
 			'profile.dataDisclaimer' => 'Reference only. Not official.',
+			'profile.passwordExpiry.warning' => ({required Object days}) => 'Password expires in ${days} days',
+			'profile.passwordExpiry.action' => 'Change',
 			'profile.sections.accountSettings' => 'Account Settings',
 			'profile.sections.appSettings' => 'App Settings',
 			'profile.sections.dangerZone' => 'Danger Zone',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -408,8 +408,11 @@ class TranslationsProfilePasswordExpiryZhTw {
 
 	// Translations
 
-	/// zh-TW: '密碼將在${days}天後過期'
-	String warning({required Object days}) => '密碼將在${days}天後過期';
+	/// zh-TW: '(one) {密碼將在1天後過期} (other) {密碼將在${days}天後過期}'
+	String warning({required num days}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('zh'))(days,
+		one: '密碼將在1天後過期',
+		other: '密碼將在${days}天後過期',
+	);
 
 	/// zh-TW: '更改'
 	String get action => '更改';
@@ -712,7 +715,7 @@ extension on Translations {
 			'courseTable.dayOfWeek.friday' => '五',
 			'courseTable.dayOfWeek.saturday' => '六',
 			'profile.dataDisclaimer' => '僅供參考，非正式文件',
-			'profile.passwordExpiry.warning' => ({required Object days}) => '密碼將在${days}天後過期',
+			'profile.passwordExpiry.warning' => ({required num days}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('zh'))(days, one: '密碼將在1天後過期', other: '密碼將在${days}天後過期', ), 
 			'profile.passwordExpiry.action' => '更改',
 			'profile.sections.accountSettings' => '帳號設定',
 			'profile.sections.appSettings' => '應用程式設定',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -225,6 +225,7 @@ class TranslationsProfileZhTw {
 	/// zh-TW: '僅供參考，非正式文件'
 	String get dataDisclaimer => '僅供參考，非正式文件';
 
+	late final TranslationsProfilePasswordExpiryZhTw passwordExpiry = TranslationsProfilePasswordExpiryZhTw.internal(_root);
 	late final TranslationsProfileSectionsZhTw sections = TranslationsProfileSectionsZhTw.internal(_root);
 	late final TranslationsProfileOptionsZhTw options = TranslationsProfileOptionsZhTw.internal(_root);
 	late final TranslationsProfileAvatarZhTw avatar = TranslationsProfileAvatarZhTw.internal(_root);
@@ -397,6 +398,21 @@ class TranslationsCourseTableActionsZhTw {
 
 	/// zh-TW: '顯示選項'
 	String get displayOptions => '顯示選項';
+}
+
+// Path: profile.passwordExpiry
+class TranslationsProfilePasswordExpiryZhTw {
+	TranslationsProfilePasswordExpiryZhTw.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// zh-TW: '密碼將在${days}天後過期'
+	String warning({required Object days}) => '密碼將在${days}天後過期';
+
+	/// zh-TW: '更改'
+	String get action => '更改';
 }
 
 // Path: profile.sections
@@ -696,6 +712,8 @@ extension on Translations {
 			'courseTable.dayOfWeek.friday' => '五',
 			'courseTable.dayOfWeek.saturday' => '六',
 			'profile.dataDisclaimer' => '僅供參考，非正式文件',
+			'profile.passwordExpiry.warning' => ({required Object days}) => '密碼將在${days}天後過期',
+			'profile.passwordExpiry.action' => '更改',
 			'profile.sections.accountSettings' => '帳號設定',
 			'profile.sections.appSettings' => '應用程式設定',
 			'profile.sections.dangerZone' => '危險區域',

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -65,7 +65,9 @@ courseTable:
 profile:
   dataDisclaimer: 僅供參考，非正式文件
   passwordExpiry:
-    warning: 密碼將在${days}天後過期
+    warning(plural, param=days):
+      one: 密碼將在1天後過期
+      other: 密碼將在${days}天後過期
     action: 更改
   sections:
     accountSettings: 帳號設定

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -64,6 +64,9 @@ courseTable:
     saturday: 六
 profile:
   dataDisclaimer: 僅供參考，非正式文件
+  passwordExpiry:
+    warning: 密碼將在${days}天後過期
+    action: 更改
   sections:
     accountSettings: 帳號設定
     appSettings: 應用程式設定

--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -369,6 +369,7 @@ class AuthRepository {
           avatarFilename: Value(userDto.avatarFilename ?? ''),
           nameZh: Value(userDto.name ?? ''),
           email: Value(userDto.email ?? ''),
+          passwordExpiresInDays: Value(userDto.passwordExpiresInDays),
           nameEn: Value(profile.englishName),
           dateOfBirth: Value(profile.dateOfBirth),
           programZh: Value(profile.programZh),

--- a/lib/screens/main/home_screen.dart
+++ b/lib/screens/main/home_screen.dart
@@ -4,8 +4,9 @@ import 'package:go_router/go_router.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/router/app_router.dart';
 import 'package:tattoo/screens/main/profile/profile_providers.dart';
+import 'package:tattoo/screens/main/user_providers.dart';
 
-class HomeScreen extends ConsumerWidget {
+class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({
     super.key,
     required this.navigationShell,
@@ -13,21 +14,59 @@ class HomeScreen extends ConsumerWidget {
 
   final StatefulNavigationShell navigationShell;
 
-  void _onDestinationSelected(WidgetRef ref, int index) {
-    final route = navigationShell.route.branches[index].defaultRoute?.path;
+  @override
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends ConsumerState<HomeScreen> {
+  bool _shownPasswordWarning = false;
+
+  void _onDestinationSelected(int index) {
+    final route =
+        widget.navigationShell.route.branches[index].defaultRoute?.path;
     if (route == AppRoutes.profile) {
       ref.invalidate(dangerZoneActionProvider);
     }
-    navigationShell.goBranch(
+    widget.navigationShell.goBranch(
       index,
-      initialLocation: index == navigationShell.currentIndex,
+      initialLocation: index == widget.navigationShell.currentIndex,
     );
   }
 
+  void _showPasswordExpirySnackbar(BuildContext context, int days) {
+    final t = Translations.of(context);
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(t.profile.passwordExpiry.warning(days: days)),
+          action: SnackBarAction(
+            label: t.profile.passwordExpiry.action,
+            onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(t.general.notImplemented)),
+            ), // TODO: navigate to change-password flow
+          ),
+        ),
+      );
+  }
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
+    ref.listen(
+      userProfileProvider.select((a) => a.asData?.value?.passwordExpiresInDays),
+      (_, days) {
+        if (days != null && !_shownPasswordWarning) {
+          _shownPasswordWarning = true;
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            _showPasswordExpirySnackbar(context, days);
+          });
+        }
+      },
+    );
+
     return Scaffold(
-      body: navigationShell,
+      body: widget.navigationShell,
       bottomNavigationBar: NavigationBar(
         destinations: <NavigationDestination>[
           NavigationDestination(
@@ -44,8 +83,8 @@ class HomeScreen extends ConsumerWidget {
             label: t.nav.profile,
           ),
         ],
-        selectedIndex: navigationShell.currentIndex,
-        onDestinationSelected: (index) => _onDestinationSelected(ref, index),
+        selectedIndex: widget.navigationShell.currentIndex,
+        onDestinationSelected: _onDestinationSelected,
       ),
     );
   }

--- a/lib/screens/main/home_screen.dart
+++ b/lib/screens/main/home_screen.dart
@@ -35,14 +35,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   void _showPasswordExpirySnackbar(BuildContext context, int days) {
     final t = Translations.of(context);
-    ScaffoldMessenger.of(context)
+    final messenger = ScaffoldMessenger.of(context);
+    messenger
       ..hideCurrentSnackBar()
       ..showSnackBar(
         SnackBar(
           content: Text(t.profile.passwordExpiry.warning(days: days)),
           action: SnackBarAction(
             label: t.profile.passwordExpiry.action,
-            onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+            onPressed: () => messenger.showSnackBar(
               SnackBar(content: Text(t.general.notImplemented)),
             ), // TODO: navigate to change-password flow
           ),

--- a/lib/screens/main/home_screen.dart
+++ b/lib/screens/main/home_screen.dart
@@ -41,6 +41,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       ..showSnackBar(
         SnackBar(
           content: Text(t.profile.passwordExpiry.warning(days: days)),
+          // SnackBar defaults persist=true when an action is set; we want the
+          // warning to auto-dismiss so the user isn't left staring at it.
+          persist: false,
           action: SnackBarAction(
             label: t.profile.passwordExpiry.action,
             onPressed: () => messenger.showSnackBar(


### PR DESCRIPTION
## Summary

The NTUT Portal login response includes a `passwordExpiredRemind` field when the password is nearing expiry. We've been persisting it as `passwordExpiresInDays` but never surfacing it. This PR shows a one-shot snackbar on the home screen with a "Change" action (currently a no-op stub).

## Test plan

- [x] Snackbar appears on app open when `passwordExpiresInDays` is non-null
- [x] "Change" action shows the "Not implemented" snackbar
- [x] Snackbar does not reappear after dismissal within the same session
- [x] No snackbar when `passwordExpiresInDays` is null