### PR TITLE
refactor: adopt prefer_shorthands lint and migrate to dot shorthands

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,6 +2,7 @@ include: package:flutter_lints/flutter.yaml
 
 plugins:
   riverpod_lint: 3.1.2
+  prefer_shorthands: 0.4.7
 
 formatter:
   trailing_commas: preserve

--- a/lib/components/anchored_popup_menu.dart
+++ b/lib/components/anchored_popup_menu.dart
@@ -12,7 +12,7 @@ const _anchoredPopupMenuGap = 8.0;
 const _anchoredPopupMenuPadding = EdgeInsets.symmetric(vertical: 8.0);
 const _anchoredPopupMenuAnimationDuration = Duration(milliseconds: 220);
 const _anchoredPopupMenuShape = RoundedRectangleBorder(
-  borderRadius: BorderRadius.all(Radius.circular(16)),
+  borderRadius: .all(.circular(16)),
 );
 
 /// Controls how an [AnchoredPopupMenuButton] is sized and positioned.
@@ -182,7 +182,7 @@ class AnchoredPopupMenuStyle {
     shadowColor: Color(0x14000000),
     surfaceTintColor: Colors.transparent,
     shape: RoundedRectangleBorder(
-      borderRadius: BorderRadius.all(Radius.circular(16)),
+      borderRadius: .all(.circular(16)),
     ),
   );
 
@@ -296,9 +296,9 @@ class AnchoredPopupMenuButton<T> extends StatelessWidget {
     }
 
     return Rect.fromPoints(
-      button.localToGlobal(Offset.zero, ancestor: overlay),
+      button.localToGlobal(.zero, ancestor: overlay),
       button.localToGlobal(
-        button.size.bottomRight(Offset.zero),
+        button.size.bottomRight(.zero),
         ancestor: overlay,
       ),
     );

--- a/lib/components/chip_tab_switcher.dart
+++ b/lib/components/chip_tab_switcher.dart
@@ -259,7 +259,7 @@ class _ChipTabSwitcherState extends State<ChipTabSwitcher> {
 
       final tabLeftInViewport = tabBox
           .localToGlobal(
-            Offset.zero,
+            .zero,
             ancestor: viewportBox,
           )
           .dx;
@@ -315,7 +315,7 @@ class _ChipTabSwitcherState extends State<ChipTabSwitcher> {
       key: _scrollViewportKey,
       controller: _scrollController,
       padding: widget.padding,
-      scrollDirection: Axis.horizontal,
+      scrollDirection: .horizontal,
       child: Row(
         spacing: widget.spacing,
         children: [
@@ -373,7 +373,7 @@ class _TabSwitchChip extends StatelessWidget {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        borderRadius: BorderRadius.circular(_borderRadius),
+        borderRadius: .circular(_borderRadius),
         onTap: onTap,
         child: AnimatedContainer(
           duration: _containerAnimationDuration,
@@ -381,15 +381,15 @@ class _TabSwitchChip extends StatelessWidget {
           padding: _chipPadding,
           decoration: BoxDecoration(
             color: backgroundColor,
-            borderRadius: BorderRadius.circular(_borderRadius),
+            borderRadius: .circular(_borderRadius),
             border: Border.all(
               color: borderColor,
               width: borderWidth,
             ),
           ),
           child: Row(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: .min,
+            mainAxisAlignment: .center,
             children: [
               SizedBox(
                 width: _checkIconSize,
@@ -473,7 +473,7 @@ Widget tabSwitcherPreview() {
       length: tabs.length,
       child: ChipTabSwitcher(
         tabs: tabs,
-        padding: const EdgeInsets.symmetric(horizontal: 12),
+        padding: const .symmetric(horizontal: 12),
         spacing: 12,
       ),
     ),

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -511,7 +511,7 @@ Widget previewFloatingActionBar() {
           ],
           child: ChipTabSwitcher(
             tabs: tabs,
-            padding: const EdgeInsets.symmetric(horizontal: 12),
+            padding: const .symmetric(horizontal: 12),
           ),
         ),
       ),
@@ -560,7 +560,7 @@ Widget previewScrollAwareFloatingActionBar() {
             ],
             child: ChipTabSwitcher(
               tabs: tabs,
-              padding: const EdgeInsets.symmetric(horizontal: 12),
+              padding: const .symmetric(horizontal: 12),
             ),
           ),
           child: ListView.builder(

--- a/lib/components/notices.dart
+++ b/lib/components/notices.dart
@@ -47,11 +47,11 @@ class ClearNotice extends StatelessWidget {
     final resolvedColor = color ?? Colors.grey[600];
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const .symmetric(horizontal: 16),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisAlignment: .center,
+        mainAxisSize: .min,
+        crossAxisAlignment: .center,
         spacing: 8,
         children: [
           IconTheme(
@@ -61,12 +61,12 @@ class ClearNotice extends StatelessWidget {
           Flexible(
             child: Text(
               text,
-              textAlign: TextAlign.justify,
+              textAlign: .justify,
               style:
                   textStyle?.copyWith(color: resolvedColor) ??
                   TextStyle(color: resolvedColor),
               softWrap: true,
-              overflow: TextOverflow.fade,
+              overflow: .fade,
             ),
           ),
         ],
@@ -156,7 +156,7 @@ class ClearNoticeVertical extends StatelessWidget {
             height: 1.6,
             color: resolvedColor,
           ),
-          textAlign: TextAlign.center,
+          textAlign: .center,
         ),
       ],
     );
@@ -220,7 +220,7 @@ class BackgroundNotice extends StatelessWidget {
     final resolvedTextStyle =
         (theme.textTheme.bodyMedium ?? const TextStyle(fontSize: 12))
             .merge(textStyle)
-            .copyWith(color: resolvedColor, fontWeight: FontWeight.w800);
+            .copyWith(color: resolvedColor, fontWeight: .w800);
     final borderRadius = BorderRadius.circular(14);
 
     return Material(
@@ -232,9 +232,9 @@ class BackgroundNotice extends StatelessWidget {
           color: resolvedColor.withValues(alpha: 0.08),
         ),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          padding: const .symmetric(horizontal: 12, vertical: 10),
           child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
+            crossAxisAlignment: .center,
             spacing: 10,
             children: [
               IconTheme(
@@ -258,16 +258,16 @@ class BackgroundNotice extends StatelessWidget {
   Color _presetColor(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     return switch (noticeType) {
-      NoticeType.warning => colorScheme.tertiary,
-      NoticeType.error => colorScheme.error,
-      NoticeType.info => colorScheme.primary,
+      .warning => colorScheme.tertiary,
+      .error => colorScheme.error,
+      .info => colorScheme.primary,
     };
   }
 
   IconData _presetIcon() => switch (noticeType) {
-    NoticeType.warning => Icons.warning_amber_rounded,
-    NoticeType.error => Icons.error_outline,
-    NoticeType.info => Icons.info_outline,
+    .warning => Icons.warning_amber_rounded,
+    .error => Icons.error_outline,
+    .info => Icons.info_outline,
   };
 }
 
@@ -290,15 +290,15 @@ Widget clearNoticeProfileDataDisclaimerPreview() {
 Widget clearNoticeVerticalIntroDevelopedByPreview() {
   return WidgetPreviewFrame(
     child: Column(
-      mainAxisSize: MainAxisSize.min,
+      mainAxisSize: .min,
       children: [
         ClearNoticeVertical(
           icon: SvgPicture.asset(
             'assets/npc_horizontal.svg',
             height: 24,
-            colorFilter: ColorFilter.mode(
+            colorFilter: .mode(
               Colors.grey[600]!,
-              BlendMode.srcIn,
+              .srcIn,
             ),
           ),
           text: TextSpan(text: t.intro.developedBy),
@@ -316,15 +316,15 @@ Widget clearNoticeVerticalIntroDevelopedByPreview() {
 Widget clearNoticeVerticalLoginPrivacyPreview() {
   return WidgetPreviewFrame(
     child: Column(
-      mainAxisSize: MainAxisSize.min,
+      mainAxisSize: .min,
       children: [
         Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
+          padding: const .symmetric(horizontal: 16),
           child: ClearNoticeVertical(
             text: t.login.privacyNotice(
               privacyPolicy: (text) => TextSpan(
                 text: text,
-                style: const TextStyle(decoration: TextDecoration.underline),
+                style: const TextStyle(decoration: .underline),
                 recognizer: TapGestureRecognizer()..onTap = () {},
               ),
             ),
@@ -343,22 +343,22 @@ Widget clearNoticeVerticalLoginPrivacyPreview() {
 Widget backgroundNoticeProfileNoticesPreview() {
   return WidgetPreviewFrame(
     child: Padding(
-      padding: const EdgeInsets.all(16),
+      padding: const .all(16),
       child: Column(
         spacing: 8,
-        mainAxisSize: MainAxisSize.min,
+        mainAxisSize: .min,
         children: [
           BackgroundNotice(
             text: "目前新版的TAT仍在測試階段，若有問題歡迎和我們反映。",
-            noticeType: NoticeType.info,
+            noticeType: .info,
           ),
           BackgroundNotice(
             text: "您的密碼將於7天後到期，請盡快更新以免無法登入。",
-            noticeType: NoticeType.warning,
+            noticeType: .warning,
           ),
           BackgroundNotice(
             text: "無法連接到伺服器，資料可能不正確。",
-            noticeType: NoticeType.error,
+            noticeType: .error,
           ),
         ],
       ),

--- a/lib/components/option_entry_tile.dart
+++ b/lib/components/option_entry_tile.dart
@@ -149,7 +149,7 @@ class OptionEntryTile extends StatelessWidget {
             ),
           ),
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+            padding: const .symmetric(horizontal: 12, vertical: 12),
             child: Row(
               spacing: 12,
               children: [
@@ -159,8 +159,8 @@ class OptionEntryTile extends StatelessWidget {
 
                 Expanded(
                   child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: .center,
+                    crossAxisAlignment: .start,
                     spacing: 4,
                     children: [
                       Text(
@@ -181,7 +181,7 @@ class OptionEntryTile extends StatelessWidget {
 
                 customActionIcon ??
                     Icon(
-                      actionIcon == OptionEntryTileActionIcon.navigateNext
+                      actionIcon == .navigateNext
                           ? Icons.navigate_next
                           : Icons.exit_to_app,
                       color: colorScheme.outlineVariant,
@@ -202,11 +202,11 @@ class OptionEntryTile extends StatelessWidget {
         dimension: 24,
         child: SvgPicture.asset(
           _svgIconAsset,
-          fit: BoxFit.contain,
+          fit: .contain,
           alignment: Alignment.center,
-          colorFilter: ColorFilter.mode(
+          colorFilter: .mode(
             color ?? colorScheme.primary,
-            BlendMode.srcIn,
+            .srcIn,
           ),
         ),
       );
@@ -224,10 +224,10 @@ class OptionEntryTile extends StatelessWidget {
 Widget optionEntryTileProfileOptionsPreview() {
   return WidgetPreviewFrame(
     child: Padding(
-      padding: const EdgeInsets.all(16),
+      padding: const .all(16),
       child: Column(
         spacing: 8,
-        mainAxisSize: MainAxisSize.min,
+        mainAxisSize: .min,
         children: [
           OptionEntryTile.icon(
             icon: Icons.image,
@@ -242,7 +242,7 @@ Widget optionEntryTileProfileOptionsPreview() {
           OptionEntryTile.svg(
             svgIconAsset: 'assets/npc_logo.svg',
             title: t.profile.options.npcClub,
-            actionIcon: OptionEntryTileActionIcon.exitToApp,
+            actionIcon: .exitToApp,
             onTap: () {},
           ),
           OptionEntryTile.icon(

--- a/lib/components/section_header.dart
+++ b/lib/components/section_header.dart
@@ -13,11 +13,11 @@ class SectionHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Padding(
-      padding: const EdgeInsets.only(top: 8),
+      padding: const .only(top: 8),
       child: Text(
         title,
         style: theme.textTheme.titleMedium?.copyWith(
-          fontWeight: FontWeight.bold,
+          fontWeight: .bold,
           color: color ?? theme.colorScheme.primary,
         ),
       ),

--- a/lib/database/actions.dart
+++ b/lib/database/actions.dart
@@ -53,8 +53,8 @@ extension DatabaseActions on AppDatabase {
     final companion = SemestersCompanion.insert(
       year: year,
       term: term,
-      inCourseSemesterList: Value.absentIfNull(inCourseSemesterList),
-      inScoreSemesterList: Value.absentIfNull(inScoreSemesterList),
+      inCourseSemesterList: .absentIfNull(inCourseSemesterList),
+      inScoreSemesterList: .absentIfNull(inScoreSemesterList),
     );
 
     return into(semesters).insertReturning(
@@ -87,7 +87,7 @@ extension DatabaseActions on AppDatabase {
           credits: Value(credits),
           hours: Value(hours),
           nameZh: Value(nameZh),
-          nameEn: Value.absentIfNull(nameEn),
+          nameEn: .absentIfNull(nameEn),
         ),
         target: [courses.code],
       ),
@@ -117,7 +117,7 @@ extension DatabaseActions on AppDatabase {
         onConflict: DoUpdate(
           (old) => TeachersCompanion(
             nameZh: Value(nameZh),
-            nameEn: Value.absentIfNull(nameEn),
+            nameEn: .absentIfNull(nameEn),
           ),
           target: [teachers.code],
         ),
@@ -132,17 +132,17 @@ extension DatabaseActions on AppDatabase {
           title: Value(title),
           teachingHours: Value(teachingHours),
           officeHoursNote: Value(officeHoursNote),
-          fetchedAt: Value.absentIfNull(fetchedAt),
+          fetchedAt: .absentIfNull(fetchedAt),
         ),
         onConflict: DoUpdate(
           (old) => TeacherSemestersCompanion(
             teacher: Value(teacher.id),
-            email: Value.absentIfNull(email),
-            department: Value.absentIfNull(departmentId),
-            title: Value.absentIfNull(title),
-            teachingHours: Value.absentIfNull(teachingHours),
-            officeHoursNote: Value.absentIfNull(officeHoursNote),
-            fetchedAt: Value.absentIfNull(fetchedAt),
+            email: .absentIfNull(email),
+            department: .absentIfNull(departmentId),
+            title: .absentIfNull(title),
+            teachingHours: .absentIfNull(teachingHours),
+            officeHoursNote: .absentIfNull(officeHoursNote),
+            fetchedAt: .absentIfNull(fetchedAt),
           ),
           target: [teacherSemesters.teacher, teacherSemesters.semester],
         ),
@@ -167,7 +167,7 @@ extension DatabaseActions on AppDatabase {
       onConflict: DoUpdate(
         (old) => ClassroomsCompanion(
           nameZh: Value(nameZh),
-          nameEn: Value.absentIfNull(nameEn),
+          nameEn: .absentIfNull(nameEn),
         ),
         target: [classrooms.code],
       ),
@@ -191,7 +191,7 @@ extension DatabaseActions on AppDatabase {
       onConflict: DoUpdate(
         (old) => ClassesCompanion(
           nameZh: Value(nameZh),
-          nameEn: Value.absentIfNull(nameEn),
+          nameEn: .absentIfNull(nameEn),
         ),
         target: [classes.code, classes.semester],
       ),
@@ -235,7 +235,7 @@ extension DatabaseActions on AppDatabase {
         (old) => CourseOfferingsCompanion(
           courseCode: Value(courseCode),
           nameZh: Value(nameZh),
-          nameEn: Value.absentIfNull(nameEn),
+          nameEn: .absentIfNull(nameEn),
           credits: Value(credits),
           hours: Value(hours),
           phase: Value(phase),

--- a/lib/database/schema.dart
+++ b/lib/database/schema.dart
@@ -440,7 +440,7 @@ class CourseOfferingTeachers extends Table {
   late final courseOffering = integer().references(
     CourseOfferings,
     #id,
-    onDelete: KeyAction.cascade,
+    onDelete: .cascade,
   )();
 
   /// Reference to the teacher profile.
@@ -458,7 +458,7 @@ class CourseOfferingClasses extends Table {
   late final courseOffering = integer().references(
     CourseOfferings,
     #id,
-    onDelete: KeyAction.cascade,
+    onDelete: .cascade,
   )();
 
   /// Reference to the class/major.
@@ -476,7 +476,7 @@ class CourseOfferingStudents extends Table {
   late final courseOffering = integer().references(
     CourseOfferings,
     #id,
-    onDelete: KeyAction.cascade,
+    onDelete: .cascade,
   )();
 
   /// Reference to the student.
@@ -496,7 +496,7 @@ class Schedules extends Table with AutoIncrementId {
   late final courseOffering = integer().references(
     CourseOfferings,
     #id,
-    onDelete: KeyAction.cascade,
+    onDelete: .cascade,
   )();
 
   /// Day of the week for this class session.
@@ -527,7 +527,7 @@ class Scores extends Table with AutoIncrementId {
   late final user = integer().references(
     Users,
     #id,
-    onDelete: KeyAction.cascade,
+    onDelete: .cascade,
   )();
 
   /// Reference to the semester this score belongs to.
@@ -567,7 +567,7 @@ class UserSemesterSummaries extends Table with AutoIncrementId {
   late final user = integer().references(
     Users,
     #id,
-    onDelete: KeyAction.cascade,
+    onDelete: .cascade,
   )();
 
   /// Reference to the semester.
@@ -619,7 +619,7 @@ class UserSemesterSummaryTutors extends Table {
   late final summary = integer().references(
     UserSemesterSummaries,
     #id,
-    onDelete: KeyAction.cascade,
+    onDelete: .cascade,
   )();
 
   /// Reference to the teacher profile serving as tutor.
@@ -639,7 +639,7 @@ class UserSemesterSummaryCadreRoles extends Table with AutoIncrementId {
   late final summary = integer().references(
     UserSemesterSummaries,
     #id,
-    onDelete: KeyAction.cascade,
+    onDelete: .cascade,
   )();
 
   /// Cadre role title (e.g., "班代", "副班代").
@@ -660,7 +660,7 @@ class UserSemesterRankings extends Table {
   late final summary = integer().references(
     UserSemesterSummaries,
     #id,
-    onDelete: KeyAction.cascade,
+    onDelete: .cascade,
   )();
 
   /// The scope of this ranking (class, group, or department).
@@ -694,7 +694,7 @@ class Materials extends Table with AutoIncrementId {
   late final courseOffering = integer().references(
     CourseOfferings,
     #id,
-    onDelete: KeyAction.cascade,
+    onDelete: .cascade,
   )();
 
   /// Title/name of the material or resource.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,7 +37,7 @@ Future<void> main() async {
 
   void showErrorDialog(
     Object error, {
-    ErrorType type = ErrorType.unknown,
+    ErrorType type = .unknown,
     StackTrace? stackTrace,
   }) {
     final rootContext = rootNavigatorKey.currentContext;
@@ -48,9 +48,9 @@ Future<void> main() async {
       if (stackTrace != null) stackTrace.toString(),
     ].join('\n');
     final errorTitle = switch (type) {
-      ErrorType.flutter => t.errors.flutterError,
-      ErrorType.async => t.errors.asyncError,
-      ErrorType.unknown => t.errors.occurred,
+      .flutter => t.errors.flutterError,
+      .async => t.errors.asyncError,
+      .unknown => t.errors.occurred,
     };
 
     showDialog(
@@ -88,7 +88,7 @@ Future<void> main() async {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       showErrorDialog(
         details.exception,
-        type: ErrorType.flutter,
+        type: .flutter,
         stackTrace: details.stack,
       );
     });
@@ -97,7 +97,7 @@ Future<void> main() async {
   // Pass all uncaught asynchronous errors that aren't handled by the Flutter framework to Crashlytics
   PlatformDispatcher.instance.onError = (error, stack) {
     firebaseService.crashlytics?.recordError(error, stack, fatal: true);
-    showErrorDialog(error, type: ErrorType.async, stackTrace: stack);
+    showErrorDialog(error, type: .async, stackTrace: stack);
     log('Uncaught asynchronous error: $error', stackTrace: stack);
     return true;
   };

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -13,9 +13,9 @@ enum EnrollmentStatus {
   droppedOut;
 
   String toLabel() => switch (this) {
-    EnrollmentStatus.learning => t.enrollmentStatus.learning,
-    EnrollmentStatus.leaveOfAbsence => t.enrollmentStatus.leaveOfAbsence,
-    EnrollmentStatus.droppedOut => t.enrollmentStatus.droppedOut,
+    .learning => t.enrollmentStatus.learning,
+    .leaveOfAbsence => t.enrollmentStatus.leaveOfAbsence,
+    .droppedOut => t.enrollmentStatus.droppedOut,
   };
 }
 // dart format on

--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -9,7 +9,6 @@ import 'package:path_provider/path_provider.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:tattoo/database/database.dart';
 import 'package:tattoo/models/login_exception.dart';
-import 'package:tattoo/models/user.dart';
 import 'package:tattoo/services/portal/portal_service.dart';
 import 'package:tattoo/services/student_query/student_query_service.dart';
 import 'package:tattoo/utils/http.dart';
@@ -534,7 +533,7 @@ class AuthRepository {
   Stream<UserRegistration?> watchActiveRegistration() {
     return (_database.select(_database.userRegistrations)
           ..where(
-            (r) => r.enrollmentStatus.equalsValue(EnrollmentStatus.learning),
+            (r) => r.enrollmentStatus.equalsValue(.learning),
           )
           ..orderBy([
             (r) => OrderingTerm.desc(r.year),
@@ -551,7 +550,7 @@ class AuthRepository {
     try {
       final result = await FlutterImageCompress.compressWithList(
         bytes,
-        format: CompressFormat.jpeg,
+        format: .jpeg,
         quality: 85,
         minWidth: 1200,
         minHeight: 1200,

--- a/lib/repositories/course_repository.dart
+++ b/lib/repositories/course_repository.dart
@@ -416,7 +416,7 @@ class CourseRepository {
               if (nameEn == null && reportedUnknownClassrooms.add(id)) {
                 _firebaseService.crashlytics?.recordError(
                   Exception('Unknown classroom prefix: $name (code: $id)'),
-                  StackTrace.current,
+                  .current,
                   fatal: false,
                 );
               }
@@ -487,7 +487,7 @@ class CourseRepository {
     // When no course occupies the noon period on any day, courses that span
     // across noon (e.g. period 4 → 5) are merged. The noon period is skipped
     // (not counted in span) and crossesNoon is set for UI height calculation.
-    final hasNoon = scheduled.keys.any((s) => s.period == Period.nPeriod);
+    final hasNoon = scheduled.keys.any((s) => s.period == .nPeriod);
     final consumed = <({DayOfWeek day, Period period})>{};
     for (final entry in scheduled.entries) {
       if (consumed.contains(entry.key)) continue;
@@ -498,7 +498,7 @@ class CourseRepository {
       while (lookIndex < Period.values.length) {
         final nextPeriod = Period.values[lookIndex];
         // Skip noon if no courses use it
-        if (nextPeriod == Period.nPeriod && !hasNoon) {
+        if (nextPeriod == .nPeriod && !hasNoon) {
           lookIndex++;
           continue;
         }
@@ -577,11 +577,11 @@ class CourseRepository {
       scheduled: scheduled,
       unscheduled: unscheduled,
       hasWeekdayCourse: scheduled.keys.any((s) => s.day.isWeekday),
-      hasSaturdayCourse: scheduled.keys.any((s) => s.day == DayOfWeek.saturday),
-      hasSundayCourse: scheduled.keys.any((s) => s.day == DayOfWeek.sunday),
+      hasSaturdayCourse: scheduled.keys.any((s) => s.day == .saturday),
+      hasSundayCourse: scheduled.keys.any((s) => s.day == .sunday),
       hasAMCourse: allEntryPeriods.any((p) => p.isAM),
       hasPMCourse: allEntryPeriods.any((p) => p.isPM),
-      hasNoonCourse: allEntryPeriods.any((p) => p == Period.nPeriod),
+      hasNoonCourse: allEntryPeriods.any((p) => p == .nPeriod),
       hasEveningCourse: allEntryPeriods.any((p) => p.isEvening),
       earliestPeriod: scheduled.isEmpty
           ? null

--- a/lib/repositories/preferences_repository.dart
+++ b/lib/repositories/preferences_repository.dart
@@ -15,10 +15,10 @@ enum PrefType { boolean, integer, double, string, stringList }
 /// Typed preference keys with defaults.
 enum PrefKey<T> {
   /// Whether to use mock data instead of live NTUT services.
-  demoMode<bool>(PrefType.boolean, false),
+  demoMode<bool>(.boolean, false),
 
   /// Whether the danger zone section is shown on the profile screen.
-  showDangerZone<bool>(PrefType.boolean, false);
+  showDangerZone<bool>(.boolean, false);
 
   const PrefKey(this.type, this.defaultValue);
   final PrefType type;
@@ -64,11 +64,11 @@ class PreferencesRepository {
   /// Gets a preference value, returning the key's default if not set.
   Future<T> get<T>(PrefKey<T> key) async {
     final value = switch (key.type) {
-      PrefType.boolean => await _prefs.getBool(key.name),
-      PrefType.integer => await _prefs.getInt(key.name),
-      PrefType.double => await _prefs.getDouble(key.name),
-      PrefType.string => await _prefs.getString(key.name),
-      PrefType.stringList => await _prefs.getStringList(key.name),
+      .boolean => await _prefs.getBool(key.name),
+      .integer => await _prefs.getInt(key.name),
+      .double => await _prefs.getDouble(key.name),
+      .string => await _prefs.getString(key.name),
+      .stringList => await _prefs.getStringList(key.name),
     };
     return (value as T?) ?? key.defaultValue;
   }
@@ -76,11 +76,11 @@ class PreferencesRepository {
   /// Sets a preference value and marks local state as dirty for cloud sync.
   Future<void> set<T>(PrefKey<T> key, T value) async {
     await switch (key.type) {
-      PrefType.boolean => _prefs.setBool(key.name, value as bool),
-      PrefType.integer => _prefs.setInt(key.name, value as int),
-      PrefType.double => _prefs.setDouble(key.name, value as double),
-      PrefType.string => _prefs.setString(key.name, value as String),
-      PrefType.stringList => _prefs.setStringList(
+      .boolean => _prefs.setBool(key.name, value as bool),
+      .integer => _prefs.setInt(key.name, value as int),
+      .double => _prefs.setDouble(key.name, value as double),
+      .string => _prefs.setString(key.name, value as String),
+      .stringList => _prefs.setStringList(
         key.name,
         value as List<String>,
       ),
@@ -164,17 +164,17 @@ class PreferencesRepository {
       for (final key in PrefKey.values)
         if (map.containsKey(key.name))
           switch (key.type) {
-            PrefType.boolean => _prefs.setBool(key.name, map[key.name] as bool),
-            PrefType.integer => _prefs.setInt(key.name, map[key.name] as int),
-            PrefType.double => _prefs.setDouble(
+            .boolean => _prefs.setBool(key.name, map[key.name] as bool),
+            .integer => _prefs.setInt(key.name, map[key.name] as int),
+            .double => _prefs.setDouble(
               key.name,
               map[key.name] as double,
             ),
-            PrefType.string => _prefs.setString(
+            .string => _prefs.setString(
               key.name,
               map[key.name] as String,
             ),
-            PrefType.stringList => _prefs.setStringList(
+            .stringList => _prefs.setStringList(
               key.name,
               map[key.name] as List<String>,
             ),

--- a/lib/screens/main/calendar/calendar_screen.dart
+++ b/lib/screens/main/calendar/calendar_screen.dart
@@ -31,9 +31,9 @@ class CalendarScreen extends ConsumerStatefulWidget {
 class _CalendarScreenState extends ConsumerState<CalendarScreen> {
   static const _yearSpan = 5;
 
-  DateTime _focusedDay = DateTime.now();
-  DateTime _selectedDay = DateTime.now();
-  DateTimeRange _range = _threeMonthWindow(DateTime.now());
+  DateTime _focusedDay = .now();
+  DateTime _selectedDay = .now();
+  DateTimeRange _range = _threeMonthWindow(.now());
   final DateTime _firstDay = DateTime(DateTime.now().year - _yearSpan, 1, 1);
   final DateTime _lastDay = DateTime(DateTime.now().year + _yearSpan, 12, 31);
 
@@ -118,7 +118,7 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
           },
           eventLoader: (day) =>
               eventsMap[DateTime(day.year, day.month, day.day)] ?? const [],
-          calendarFormat: CalendarFormat.month,
+          calendarFormat: .month,
           headerStyle: const HeaderStyle(formatButtonVisible: false),
         ),
         const SizedBox(height: 8.0),
@@ -139,8 +139,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                     constraints: const BoxConstraints(maxWidth: 120),
                     child: Text(
                       place,
-                      overflow: TextOverflow.ellipsis,
-                      textAlign: TextAlign.end,
+                      overflow: .ellipsis,
+                      textAlign: .end,
                     ),
                   ),
                   _ => null,

--- a/lib/screens/main/course_table/course_table_cell.dart
+++ b/lib/screens/main/course_table/course_table_cell.dart
@@ -58,7 +58,7 @@ class CourseTableCell extends StatelessWidget {
     final highlightColor = borderColor.withValues(alpha: 0.14);
 
     return MediaQuery(
-      data: MediaQuery.of(context).copyWith(textScaler: TextScaler.noScaling),
+      data: MediaQuery.of(context).copyWith(textScaler: .noScaling),
       child: Material(
         color: Colors.transparent,
         child: Ink(
@@ -78,7 +78,7 @@ class CourseTableCell extends StatelessWidget {
                 final titleMaxLines = constraints.maxHeight > 100 ? 3 : 2;
 
                 return Padding(
-                  padding: const EdgeInsets.symmetric(
+                  padding: const .symmetric(
                     horizontal: 2,
                     vertical: 2,
                   ),
@@ -168,7 +168,7 @@ class CourseTableUnscheduledCell extends StatelessWidget {
         borderRadius: .circular(12),
         side: BorderSide(color: theme.colorScheme.outlineVariant),
       ),
-      clipBehavior: Clip.antiAlias,
+      clipBehavior: .antiAlias,
       child: InkWell(
         borderRadius: .circular(12),
         onTap: onTap,

--- a/lib/screens/main/course_table/course_table_detail_sheet.dart
+++ b/lib/screens/main/course_table/course_table_detail_sheet.dart
@@ -41,7 +41,7 @@ class CourseTableDetailSheet extends StatelessWidget {
           spacing: 16,
           children: [
             SizedBox(
-              width: double.infinity,
+              width: .infinity,
               child: Column(
                 crossAxisAlignment: .center,
                 children: [
@@ -55,12 +55,12 @@ class CourseTableDetailSheet extends StatelessWidget {
               ),
             ),
             SizedBox(
-              width: double.infinity,
+              width: .infinity,
               child: Card(
                 margin: .all(8),
                 elevation: 0,
                 shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
+                  borderRadius: .circular(12),
                   side: BorderSide(color: theme.colorScheme.outlineVariant),
                 ),
                 color: theme.colorScheme.surfaceContainer,

--- a/lib/screens/main/course_table/course_table_grid.dart
+++ b/lib/screens/main/course_table/course_table_grid.dart
@@ -106,7 +106,7 @@ class CourseTableGrid extends StatelessWidget {
   ).toDouble();
 
   double _periodHeight(Period period) => switch (period) {
-    Period.nPeriod => _periodNoonHeight,
+    .nPeriod => _periodNoonHeight,
     _ => _periodRowHeight,
   };
 
@@ -138,7 +138,7 @@ class CourseTableGrid extends StatelessWidget {
     var totalHeight = 0.0;
 
     for (final period in visiblePeriods.skip(startIndex)) {
-      if (period == Period.nPeriod && includeSyntheticNoonGap) {
+      if (period == .nPeriod && includeSyntheticNoonGap) {
         totalHeight += _periodNoonHeight;
         includeSyntheticNoonGap = false;
         continue;
@@ -236,7 +236,7 @@ class CourseTableGrid extends StatelessWidget {
         .toList(growable: false);
     final defaultPeriods = Period.values
         .where(
-          (period) => period.isAM || period == Period.nPeriod || period.isPM,
+          (period) => period.isAM || period == .nPeriod || period.isPM,
         )
         .toList(growable: false);
 
@@ -283,23 +283,23 @@ class CourseTableGrid extends StatelessWidget {
         addPeriods(Period.values.where((period) => period.isAM));
         break;
       case (false, true, false):
-        addPeriod(Period.nPeriod);
+        addPeriod(.nPeriod);
         break;
       case (false, false, true):
         addPeriods(Period.values.where((period) => period.isPM));
         break;
       case (true, true, false):
         addPeriods(Period.values.where((period) => period.isAM));
-        addPeriod(Period.nPeriod);
+        addPeriod(.nPeriod);
         break;
       case (false, true, true):
-        addPeriod(Period.nPeriod);
+        addPeriod(.nPeriod);
         addPeriods(Period.values.where((period) => period.isPM));
         break;
       case (true, false, true):
       case (true, true, true):
         addPeriods(Period.values.where((period) => period.isAM));
-        addPeriod(Period.nPeriod);
+        addPeriod(.nPeriod);
         addPeriods(Period.values.where((period) => period.isPM));
         break;
     }

--- a/lib/screens/main/course_table/course_table_screen.dart
+++ b/lib/screens/main/course_table/course_table_screen.dart
@@ -77,7 +77,7 @@ class CourseTableScreen extends ConsumerWidget {
             };
 
             return ScrollAwareFloatingActionBar(
-              margin: const EdgeInsets.all(_floatingBarMargin),
+              margin: const .all(_floatingBarMargin),
               floatingActionBarBuilder: (context, visible) {
                 if (!shouldShowFloatingBar) {
                   return null;
@@ -119,7 +119,7 @@ class CourseTableScreen extends ConsumerWidget {
                     enabled: isSemesterLoading,
                     child: ChipTabSwitcher(
                       tabs: displayedSemesterTabLabels,
-                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      padding: const .symmetric(horizontal: 12),
                     ),
                   ),
                 );

--- a/lib/screens/main/portal/portal_screen.dart
+++ b/lib/screens/main/portal/portal_screen.dart
@@ -145,7 +145,7 @@ class PortalScreen extends ConsumerWidget {
         child: CustomScrollView(
           slivers: [
             SliverPadding(
-              padding: const EdgeInsets.all(16),
+              padding: const .all(16),
               sliver: SliverToBoxAdapter(
                 child: Column(
                   crossAxisAlignment: .center,
@@ -156,7 +156,7 @@ class PortalScreen extends ConsumerWidget {
                     _PortalCard(
                       title: "打開校園入口網站",
                       onTap: () => launchUrl(
-                        Uri.parse('https://nportal.ntut.edu.tw'),
+                        .parse('https://nportal.ntut.edu.tw'),
                       ),
                     ),
                     for (final section in _portalSections)
@@ -205,7 +205,7 @@ class _PortalCard extends StatelessWidget {
       child: InkWell(
         onTap: onTap,
         child: SizedBox(
-          width: double.infinity,
+          width: .infinity,
           child: Padding(
             padding: const .symmetric(horizontal: 16, vertical: 12),
             child: Text(

--- a/lib/screens/main/profile/about_screen.dart
+++ b/lib/screens/main/profile/about_screen.dart
@@ -51,7 +51,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                 ? t.profile.dangerZone.barOpen
                 : t.profile.dangerZone.barClosed,
           ),
-          behavior: SnackBarBehavior.floating,
+          behavior: .floating,
         ),
       );
     }
@@ -71,7 +71,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
         child: CustomScrollView(
           slivers: [
             SliverPadding(
-              padding: const EdgeInsets.all(16),
+              padding: const .all(16),
               sliver: SliverToBoxAdapter(
                 child: Column(
                   spacing: 16,
@@ -91,7 +91,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                         Text(
                           t.general.appTitle,
                           style: theme.textTheme.headlineSmall?.copyWith(
-                            fontWeight: FontWeight.bold,
+                            fontWeight: .bold,
                           ),
                         ),
                         Text(
@@ -107,7 +107,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
 
                     // Description
                     Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      padding: const .symmetric(horizontal: 16),
                       child: Text(
                         t.about.description,
                         textAlign: .justify,
@@ -124,7 +124,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                           title: 'GitHub',
                           description: t.about.viewSource,
                           onTap: () => launchUrl(
-                            Uri.parse('https://github.com/NTUT-NPC/tattoo'),
+                            .parse('https://github.com/NTUT-NPC/tattoo'),
                           ),
                         ),
                         OptionEntryTile.icon(
@@ -132,7 +132,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                           title: 'Crowdin',
                           description: t.about.helpTranslate,
                           onTap: () => launchUrl(
-                            Uri.parse('https://translate.ntut.club'),
+                            .parse('https://translate.ntut.club'),
                           ),
                         ),
                         OptionEntryTile.icon(
@@ -140,7 +140,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                           title: t.about.privacyPolicy,
                           description: t.about.viewPrivacyPolicy,
                           onTap: () => launchUrl(
-                            Uri.parse(t.about.privacyPolicyUrl),
+                            .parse(t.about.privacyPolicyUrl),
                           ),
                         ),
                       ],
@@ -157,7 +157,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                                 ...contributors.map(
                                   (contributor) => OptionEntryTile(
                                     leading: ClipRRect(
-                                      borderRadius: BorderRadius.circular(12),
+                                      borderRadius: .circular(12),
                                       child: Image.network(
                                         contributor.avatarUrl,
                                         width: 24,
@@ -178,17 +178,16 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                                     ),
                                     title: contributor.login,
                                     onTap: () => launchUrl(
-                                      Uri.parse(contributor.htmlUrl),
+                                      .parse(contributor.htmlUrl),
                                     ),
                                   ),
                                 ),
                                 OptionEntryTile.svg(
                                   svgIconAsset: 'assets/npc_logo.svg',
                                   title: t.profile.options.npcClub,
-                                  actionIcon:
-                                      OptionEntryTileActionIcon.exitToApp,
+                                  actionIcon: .exitToApp,
                                   onTap: () =>
-                                      launchUrl(Uri.parse('https://ntut.club')),
+                                      launchUrl(.parse('https://ntut.club')),
                                 ),
                               ],
                             ),
@@ -199,7 +198,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                           Skeletonizer(
                             child: Column(
                               spacing: 8,
-                              children: List.generate(
+                              children: .generate(
                                 3,
                                 (index) => const OptionEntryTile.icon(
                                   icon: Icons.person,
@@ -217,8 +216,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                           OptionEntryTile.svg(
                             svgIconAsset: 'assets/npc_logo.svg',
                             title: t.profile.options.npcClub,
-                            onTap: () =>
-                                launchUrl(Uri.parse('https://ntut.club')),
+                            onTap: () => launchUrl(.parse('https://ntut.club')),
                           ),
                         ],
                       ),
@@ -233,7 +231,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                         height: 1.6,
                         color: Colors.grey[600],
                       ),
-                      textAlign: TextAlign.center,
+                      textAlign: .center,
                     ),
                   ],
                 ),

--- a/lib/screens/main/profile/profile_card.dart
+++ b/lib/screens/main/profile/profile_card.dart
@@ -7,7 +7,6 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:tattoo/components/app_skeleton.dart';
 import 'package:tattoo/database/database.dart';
 import 'package:tattoo/i18n/strings.g.dart';
-import 'package:tattoo/models/user.dart';
 import 'package:tattoo/screens/main/profile/profile_providers.dart';
 import 'package:tattoo/screens/main/user_providers.dart';
 
@@ -26,7 +25,7 @@ const _placeholderSemester = UserRegistration(
   year: 199,
   term: 6,
   className: '載入一申',
-  enrollmentStatus: EnrollmentStatus.learning,
+  enrollmentStatus: .learning,
 );
 
 // Configs for profile card styling
@@ -50,7 +49,7 @@ class ProfileCard extends ConsumerWidget {
 
     return MediaQuery(
       // no text scaling to prevent card style from breaking
-      data: mediaQuery.copyWith(textScaler: TextScaler.noScaling),
+      data: mediaQuery.copyWith(textScaler: .noScaling),
 
       child: switch ((profileAsync, registrationAsync)) {
         // NOT_LOGIN state: not logged in
@@ -126,7 +125,7 @@ class ProfileContent extends StatelessWidget {
               Positioned.fill(
                 child: SvgPicture.asset(
                   'assets/profile_card_background.svg',
-                  fit: BoxFit.cover,
+                  fit: .cover,
                 ),
               ),
 
@@ -137,11 +136,11 @@ class ProfileContent extends StatelessWidget {
                 child: Text(
                   registration?.enrollmentStatus?.toLabel() ??
                       t.general.student,
-                  textAlign: TextAlign.left,
+                  textAlign: .left,
                   style: textTheme.bodyMedium?.copyWith(
                     color: Color(0xFF3B3B3B),
                     fontSize: height * 0.07,
-                    fontWeight: FontWeight.w600,
+                    fontWeight: .w600,
                   ),
                 ),
               ),
@@ -156,13 +155,13 @@ class ProfileContent extends StatelessWidget {
                       textTheme.titleMedium?.copyWith(
                         color: Colors.white,
                         fontSize: height * 0.065,
-                        fontWeight: FontWeight.w400,
+                        fontWeight: .w400,
                         height: 1.1,
                       ) ??
                       const TextStyle(color: Colors.white),
                   child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: .start,
+                    mainAxisSize: .min,
                     spacing: height * 0.01,
                     children: [
                       Transform.translate(
@@ -173,11 +172,11 @@ class ProfileContent extends StatelessWidget {
                               ? profile.nameZh
                               : t.general.unknown,
                           maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                          overflow: .ellipsis,
                           style: textTheme.titleMedium?.copyWith(
                             color: Colors.white,
                             fontSize: height * 0.11,
-                            fontWeight: FontWeight.w700,
+                            fontWeight: .w700,
                             letterSpacing: 4,
                             height: 1.6,
                           ),
@@ -186,19 +185,19 @@ class ProfileContent extends StatelessWidget {
                       Text(
                         profile.departmentZh ?? '',
                         maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
+                        overflow: .ellipsis,
                       ),
                       Text(
                         profile.studentId,
                         maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
+                        overflow: .ellipsis,
                       ),
                       Text(
                         registration != null
                             ? '${registration!.year}-${registration!.term} ${registration!.className ?? ''}'
                             : '',
                         maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
+                        overflow: .ellipsis,
                       ),
                     ],
                   ),
@@ -214,18 +213,18 @@ class ProfileContent extends StatelessWidget {
                 child: Skeleton.leaf(
                   child: DecoratedBox(
                     decoration: const BoxDecoration(
-                      shape: BoxShape.circle,
+                      shape: .circle,
                       color: Color(0xFFB3B3B5),
                     ),
                     child: ClipOval(
                       child: switch (avatarFile) {
-                        final file? => Image.file(file, fit: BoxFit.cover),
+                        final file? => Image.file(file, fit: .cover),
                         null => Center(
                           child: Text(
                             avatarInitial,
                             style: TextStyle(
                               color: const Color(0xFF808080),
-                              fontWeight: FontWeight.w700,
+                              fontWeight: .w700,
                               fontSize: avatarSize * 0.36,
                             ),
                           ),

--- a/lib/screens/main/profile/profile_danger_zone.dart
+++ b/lib/screens/main/profile/profile_danger_zone.dart
@@ -50,7 +50,7 @@ class ProfileDangerZone extends ConsumerWidget {
   }
 
   void _triggerNonFlutterCrash() {
-    Future.delayed(Duration.zero, () {
+    Future.delayed(.zero, () {
       throw Exception(t.profile.dangerZone.nonFlutterCrashException);
     });
   }

--- a/lib/screens/main/profile/profile_screen.dart
+++ b/lib/screens/main/profile/profile_screen.dart
@@ -29,7 +29,7 @@ class ProfileScreen extends ConsumerWidget {
   Future<XFile?> _pickAvatarImage() {
     // Use OS picker to select a single image without broad media access.
     return _imagePicker.pickImage(
-      source: ImageSource.gallery,
+      source: .gallery,
       requestFullMetadata: false,
     );
   }
@@ -121,7 +121,7 @@ class ProfileScreen extends ConsumerWidget {
       OptionEntryTile.svg(
         svgIconAsset: "assets/npc_logo.svg",
         title: t.profile.options.npcClub,
-        onTap: () => launchUrl(Uri.parse('https://ntut.club')),
+        onTap: () => launchUrl(.parse('https://ntut.club')),
       ),
 
       SectionHeader(title: t.profile.sections.appSettings),
@@ -140,8 +140,8 @@ class ProfileScreen extends ConsumerWidget {
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: switch (Theme.of(context).brightness) {
-        Brightness.light => SystemUiOverlayStyle.dark,
-        Brightness.dark => SystemUiOverlayStyle.light,
+        .light => SystemUiOverlayStyle.dark,
+        .dark => SystemUiOverlayStyle.light,
       },
       child: Scaffold(
         body: SafeArea(
@@ -150,7 +150,7 @@ class ProfileScreen extends ConsumerWidget {
             child: CustomScrollView(
               slivers: [
                 SliverPadding(
-                  padding: const EdgeInsets.all(16),
+                  padding: const .all(16),
                   sliver: SliverToBoxAdapter(
                     child: Column(
                       spacing: 16,

--- a/lib/screens/main/scanner/scanner_guide_bottom_sheet.dart
+++ b/lib/screens/main/scanner/scanner_guide_bottom_sheet.dart
@@ -42,10 +42,10 @@ class ScannerGuideSheet extends StatelessWidget {
       snap: true,
       builder: (context, scrollController) {
         return Container(
-          padding: EdgeInsets.fromLTRB(24, 0, 24, bottomPadding),
+          padding: .fromLTRB(24, 0, 24, bottomPadding),
           decoration: BoxDecoration(
             color: colorScheme.surface,
-            borderRadius: const BorderRadius.vertical(top: Radius.circular(32)),
+            borderRadius: const .vertical(top: .circular(32)),
             boxShadow: [
               BoxShadow(
                 color: Colors.black.withAlpha(20),
@@ -60,12 +60,12 @@ class ScannerGuideSheet extends StatelessWidget {
               SliverToBoxAdapter(
                 child: Center(
                   child: Container(
-                    margin: const EdgeInsets.symmetric(vertical: 20),
+                    margin: const .symmetric(vertical: 20),
                     width: 40,
                     height: 5,
                     decoration: BoxDecoration(
                       color: colorScheme.onSurfaceVariant.withAlpha(100),
-                      borderRadius: BorderRadius.circular(2),
+                      borderRadius: .circular(2),
                     ),
                   ),
                 ),
@@ -96,7 +96,7 @@ class ScannerGuideSheet extends StatelessWidget {
     final theme = Theme.of(context);
     return Column(
       key: const ValueKey('success'),
-      mainAxisSize: MainAxisSize.min,
+      mainAxisSize: .min,
       children: [
         const SizedBox(height: 32),
         const Icon(Icons.check_circle_outline, color: Colors.green, size: 64),
@@ -104,7 +104,7 @@ class ScannerGuideSheet extends StatelessWidget {
         Text(
           t.scanner.success,
           style: theme.textTheme.headlineSmall?.copyWith(
-            fontWeight: FontWeight.bold,
+            fontWeight: .bold,
           ),
         ),
         const SizedBox(height: 48),
@@ -116,23 +116,23 @@ class ScannerGuideSheet extends StatelessWidget {
     final theme = Theme.of(context);
     return Column(
       key: const ValueKey('error'),
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: .min,
+      crossAxisAlignment: .stretch,
       children: [
         const SizedBox(height: 32),
         const Icon(Icons.error_outline, color: Colors.red, size: 64),
         const SizedBox(height: 16),
         Text(
           t.scanner.failed,
-          textAlign: TextAlign.center,
+          textAlign: .center,
           style: theme.textTheme.headlineSmall?.copyWith(
-            fontWeight: FontWeight.bold,
+            fontWeight: .bold,
           ),
         ),
         const SizedBox(height: 16),
         Text(
           message,
-          textAlign: TextAlign.center,
+          textAlign: .center,
           style: theme.textTheme.bodyLarge,
         ),
         const SizedBox(height: 32),
@@ -149,7 +149,7 @@ class ScannerGuideSheet extends StatelessWidget {
     final theme = Theme.of(context);
     return Column(
       key: const ValueKey('processing'),
-      mainAxisSize: MainAxisSize.min,
+      mainAxisSize: .min,
       children: [
         const SizedBox(height: 48),
         const CircularProgressIndicator(),
@@ -175,14 +175,14 @@ class ScannerGuideSheet extends StatelessWidget {
 
     return Column(
       key: const ValueKey('guide'),
-      crossAxisAlignment: CrossAxisAlignment.stretch,
+      crossAxisAlignment: .stretch,
       children: [
         const SizedBox(height: 8),
         Text(
           t.scanner.guide.title,
-          textAlign: TextAlign.center,
+          textAlign: .center,
           style: theme.textTheme.titleLarge?.copyWith(
-            fontWeight: FontWeight.bold,
+            fontWeight: .bold,
           ),
         ),
         const SizedBox(height: 16),
@@ -232,16 +232,16 @@ class ScannerGuideSheet extends StatelessWidget {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(t.general.copied),
-            behavior: SnackBarBehavior.floating,
+            behavior: .floating,
           ),
         );
       },
-      borderRadius: BorderRadius.circular(8),
+      borderRadius: .circular(8),
       child: Container(
-        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+        padding: const .symmetric(vertical: 8, horizontal: 12),
         decoration: BoxDecoration(
           color: colorScheme.surfaceContainerHighest.withAlpha(50),
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: .circular(8),
         ),
         child: Text.rich(
           TextSpan(
@@ -254,18 +254,18 @@ class ScannerGuideSheet extends StatelessWidget {
                 text: scheme,
                 style: TextStyle(
                   color: colorScheme.onSurfaceVariant.withAlpha(120),
-                  fontWeight: FontWeight.normal,
+                  fontWeight: .normal,
                 ),
               ),
               TextSpan(
                 text: rest,
                 style: const TextStyle(
-                  fontWeight: FontWeight.bold,
+                  fontWeight: .bold,
                 ),
               ),
             ],
           ),
-          textAlign: TextAlign.center,
+          textAlign: .center,
         ),
       ),
     );

--- a/lib/screens/main/scanner/scanner_screen.dart
+++ b/lib/screens/main/scanner/scanner_screen.dart
@@ -202,16 +202,16 @@ class _ScannerScreenState extends ConsumerState<ScannerScreen> {
       children: [
         // Darkened background with a hole
         ColorFiltered(
-          colorFilter: ColorFilter.mode(
+          colorFilter: .mode(
             Colors.black.withAlpha(150),
-            BlendMode.srcOut,
+            .srcOut,
           ),
           child: Stack(
             children: [
               Container(
                 decoration: const BoxDecoration(
                   color: Colors.black,
-                  backgroundBlendMode: BlendMode.dstOut,
+                  backgroundBlendMode: .dstOut,
                 ),
               ),
               Center(
@@ -220,7 +220,7 @@ class _ScannerScreenState extends ConsumerState<ScannerScreen> {
                   width: scanWindowSize,
                   decoration: BoxDecoration(
                     color: Colors.white,
-                    borderRadius: BorderRadius.circular(24),
+                    borderRadius: .circular(24),
                   ),
                 ),
               ),
@@ -236,7 +236,7 @@ class _ScannerScreenState extends ConsumerState<ScannerScreen> {
                 color: Colors.white, // 改回白色
                 width: 2,
               ),
-              borderRadius: BorderRadius.circular(24),
+              borderRadius: .circular(24),
             ),
           ),
         ),
@@ -250,11 +250,11 @@ class _ScannerScreenState extends ConsumerState<ScannerScreen> {
     IconData icon = Icons.error_outline;
 
     switch (error.errorCode) {
-      case MobileScannerErrorCode.permissionDenied:
+      case .permissionDenied:
         message = t.scanner.permissionDenied;
         description = t.scanner.permissionDeniedDescription;
         icon = Icons.no_photography_outlined;
-      case MobileScannerErrorCode.unsupported:
+      case .unsupported:
         message = t.scanner.cameraError;
         description = 'Scanning is not supported on this device';
       default:
@@ -263,11 +263,11 @@ class _ScannerScreenState extends ConsumerState<ScannerScreen> {
 
     return Container(
       color: Colors.black,
-      width: double.infinity,
-      height: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 32),
+      width: .infinity,
+      height: .infinity,
+      padding: const .symmetric(horizontal: 32),
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisAlignment: .center,
         children: [
           Icon(icon, color: Colors.white, size: 64),
           const SizedBox(height: 16),
@@ -276,9 +276,9 @@ class _ScannerScreenState extends ConsumerState<ScannerScreen> {
             style: const TextStyle(
               color: Colors.white,
               fontSize: 18,
-              fontWeight: FontWeight.bold,
+              fontWeight: .bold,
             ),
-            textAlign: TextAlign.center,
+            textAlign: .center,
           ),
           if (description != null) ...[
             const SizedBox(height: 8),
@@ -288,7 +288,7 @@ class _ScannerScreenState extends ConsumerState<ScannerScreen> {
                 color: Colors.white.withAlpha(200),
                 fontSize: 14,
               ),
-              textAlign: TextAlign.center,
+              textAlign: .center,
             ),
           ],
         ],

--- a/lib/screens/main/score/score_screen.dart
+++ b/lib/screens/main/score/score_screen.dart
@@ -236,7 +236,7 @@ class _SemesterScoreList extends StatelessWidget {
             ),
             if (hasScores)
               SliverPadding(
-                padding: EdgeInsets.fromLTRB(
+                padding: .fromLTRB(
                   16,
                   0,
                   16,

--- a/lib/screens/welcome/intro_screen.dart
+++ b/lib/screens/welcome/intro_screen.dart
@@ -53,9 +53,9 @@ class _IntroScreenState extends State<IntroScreen>
       icon: SvgPicture.asset(
         'assets/npc_horizontal.svg',
         height: 24,
-        colorFilter: ColorFilter.mode(
+        colorFilter: .mode(
           Colors.grey[600]!,
-          BlendMode.srcIn,
+          .srcIn,
         ),
       ),
       text: TextSpan(text: t.intro.developedBy),
@@ -80,8 +80,8 @@ class _IntroScreenState extends State<IntroScreen>
               child: SafeArea(
                 top: false,
                 child: Container(
-                  width: double.infinity,
-                  padding: const EdgeInsets.only(top: 16),
+                  width: .infinity,
+                  padding: const .only(top: 16),
                   decoration: BoxDecoration(
                     gradient: LinearGradient(
                       begin: Alignment.bottomCenter,
@@ -95,11 +95,11 @@ class _IntroScreenState extends State<IntroScreen>
                     ),
                   ),
                   child: Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                    padding: const .fromLTRB(16, 8, 16, 0),
                     child: FilledButton(
                       onPressed: () => context.push(AppRoutes.login),
                       child: Padding(
-                        padding: const EdgeInsets.all(6.0),
+                        padding: const .all(6.0),
                         child: Text(t.intro.kContinue),
                       ),
                     ),
@@ -129,23 +129,23 @@ class _FeatureCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Center(
       child: Container(
-        width: double.infinity,
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+        width: .infinity,
+        padding: const .symmetric(horizontal: 24, vertical: 12),
         child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
+          crossAxisAlignment: .center,
           spacing: 24,
           children: [
             Icon(icon, size: 28),
             Expanded(
               child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+                crossAxisAlignment: .start,
                 spacing: 4,
                 children: [
                   Text(
                     title,
                     style: TextStyle(
                       fontSize: 16,
-                      fontWeight: FontWeight.bold,
+                      fontWeight: .bold,
                     ),
                   ),
                   Text(

--- a/lib/screens/welcome/login_screen.dart
+++ b/lib/screens/welcome/login_screen.dart
@@ -165,21 +165,21 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       hintText: hintText,
       hintStyle: TextStyle(
         color: theme.textTheme.bodyMedium?.color?.withAlpha(150),
-        fontWeight: FontWeight.w500,
+        fontWeight: .w500,
       ),
-      border: OutlineInputBorder(borderRadius: BorderRadius.circular(50)),
+      border: OutlineInputBorder(borderRadius: .circular(50)),
       enabledBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(50),
+        borderRadius: .circular(50),
         borderSide: BorderSide(color: hasError ? errorColor : surfaceColor),
       ),
       focusedBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(50),
+        borderRadius: .circular(50),
         borderSide: BorderSide(
           color: hasError ? errorColor : primaryColor,
           width: 2,
         ),
       ),
-      contentPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+      contentPadding: const .symmetric(horizontal: 24, vertical: 16),
       filled: true,
       fillColor: surfaceColor,
     );
@@ -194,16 +194,16 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
         child: LayoutBuilder(
           builder: (context, constraints) {
             return GestureDetector(
-              behavior: HitTestBehavior.translucent,
+              behavior: .translucent,
               onTap: () => FocusScope.of(context).unfocus(),
               child: SingleChildScrollView(
                 child: ConstrainedBox(
                   constraints: BoxConstraints(minHeight: constraints.maxHeight),
                   child: Center(
                     child: Padding(
-                      padding: const EdgeInsets.all(16.0),
+                      padding: const .all(16.0),
                       child: Column(
-                        mainAxisSize: MainAxisSize.min,
+                        mainAxisSize: .min,
                         spacing: 24,
                         children: [
                           // Welcome title
@@ -221,10 +221,10 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                             ),
                             style: TextStyle(
                               fontSize: 48,
-                              fontWeight: FontWeight.w800,
+                              fontWeight: .w800,
                               color: theme.textTheme.bodyLarge?.color,
                             ),
-                            textAlign: TextAlign.center,
+                            textAlign: .center,
                           ),
 
                           // Login instruction
@@ -233,11 +233,11 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                               portalLink: (text) => TextSpan(
                                 text: text,
                                 style: const TextStyle(
-                                  decoration: TextDecoration.underline,
+                                  decoration: .underline,
                                 ),
                                 recognizer: TapGestureRecognizer()
                                   ..onTap = () => launchUrl(
-                                    Uri.parse('https://nportal.ntut.edu.tw'),
+                                    .parse('https://nportal.ntut.edu.tw'),
                                   ),
                               ),
                             ),
@@ -246,13 +246,13 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                               height: 1.6,
                               color: Colors.grey[600],
                             ),
-                            textAlign: TextAlign.center,
+                            textAlign: .center,
                           ),
 
                           // Login form
                           AutofillGroup(
                             child: Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
+                              mainAxisAlignment: .center,
                               spacing: 16,
                               children: [
                                 TextField(
@@ -265,7 +265,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                                     hasError: _usernameHasError,
                                   ),
                                   autofillHints: const [AutofillHints.username],
-                                  textInputAction: TextInputAction.next,
+                                  textInputAction: .next,
                                   onSubmitted: (_) =>
                                       _passwordFocusNode.requestFocus(),
                                   onChanged: (_) => _clearErrors(),
@@ -281,7 +281,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                                   ),
                                   autofillHints: const [AutofillHints.password],
                                   obscureText: true,
-                                  textInputAction: TextInputAction.done,
+                                  textInputAction: .done,
                                   onSubmitted: (_) => _attemptLogin(),
                                   onChanged: (_) => _clearErrors(),
                                 ),
@@ -293,16 +293,16 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                           if (_errorMessage case final errorMessage?)
                             Text(
                               errorMessage,
-                              textAlign: TextAlign.center,
+                              textAlign: .center,
                               style: TextStyle(
                                 color: theme.colorScheme.error,
-                                fontWeight: FontWeight.w600,
+                                fontWeight: .w600,
                               ),
                             ),
 
                           // Login button
                           SizedBox(
-                            width: double.infinity,
+                            width: .infinity,
                             child: ElevatedButton(
                               style: ElevatedButton.styleFrom(
                                 backgroundColor: theme.colorScheme.primary,
@@ -310,7 +310,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                               ),
                               onPressed: _isLoading ? null : _attemptLogin,
                               child: Padding(
-                                padding: const EdgeInsets.all(6.0),
+                                padding: const .all(6.0),
                                 child: _isLoading
                                     ? const SizedBox(
                                         height: 20,
@@ -331,11 +331,11 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                               privacyPolicy: (text) => TextSpan(
                                 text: text,
                                 style: const TextStyle(
-                                  decoration: TextDecoration.underline,
+                                  decoration: .underline,
                                 ),
                                 recognizer: TapGestureRecognizer()
                                   ..onTap = () => launchUrl(
-                                    Uri.parse(
+                                    .parse(
                                       t.about.privacyPolicyUrl,
                                     ),
                                   ),

--- a/lib/services/course/ntut_course_service.dart
+++ b/lib/services/course/ntut_course_service.dart
@@ -447,13 +447,13 @@ class NtutCourseService implements CourseService {
 
   DayOfWeek? _parseDayOfWeek(String code) {
     return switch (code.toLowerCase()) {
-      'sun' => DayOfWeek.sunday,
-      'mon' => DayOfWeek.monday,
-      'tue' => DayOfWeek.tuesday,
-      'wed' => DayOfWeek.wednesday,
-      'thu' => DayOfWeek.thursday,
-      'fri' => DayOfWeek.friday,
-      'sat' => DayOfWeek.saturday,
+      'sun' => .sunday,
+      'mon' => .monday,
+      'tue' => .tuesday,
+      'wed' => .wednesday,
+      'thu' => .thursday,
+      'fri' => .friday,
+      'sat' => .saturday,
       _ => null,
     };
   }

--- a/lib/services/firebase_service.dart
+++ b/lib/services/firebase_service.dart
@@ -5,7 +5,7 @@ import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 ///
 /// Defaults to `false` to avoid package name mismatch issues in debug mode
 /// (`club.ntut.tattoo.debug`). Override via: `--dart-define=USE_FIREBASE=true`
-const bool useFirebase = bool.fromEnvironment(
+const bool useFirebase = .fromEnvironment(
   'USE_FIREBASE',
   defaultValue: false,
 );
@@ -26,8 +26,7 @@ class FirebaseService {
   const FirebaseService();
 
   /// The [FirebaseAnalytics] instance, or `null` if Firebase is disabled.
-  FirebaseAnalytics? get analytics =>
-      useFirebase ? FirebaseAnalytics.instance : null;
+  FirebaseAnalytics? get analytics => useFirebase ? .instance : null;
 
   /// Returns a [FirebaseAnalyticsObserver] for use with navigation observers, or
   /// `null` if Firebase is disabled.
@@ -35,8 +34,7 @@ class FirebaseService {
       useFirebase ? FirebaseAnalyticsObserver(analytics: analytics!) : null;
 
   /// The [FirebaseCrashlytics] instance, or `null` if Firebase is disabled.
-  FirebaseCrashlytics? get crashlytics =>
-      useFirebase ? FirebaseCrashlytics.instance : null;
+  FirebaseCrashlytics? get crashlytics => useFirebase ? .instance : null;
 
   /// Logs a custom message to Firebase Crashlytics if enabled.
   ///
@@ -50,7 +48,7 @@ class FirebaseService {
   void recordNonFatal(String message) {
     crashlytics?.recordError(
       Exception(message),
-      StackTrace.current,
+      .current,
       fatal: false,
     );
   }

--- a/lib/services/portal/ntut_portal_service.dart
+++ b/lib/services/portal/ntut_portal_service.dart
@@ -92,7 +92,7 @@ class NtutPortalService implements PortalService {
     final response = await _portalDio.get(
       'photoView.do',
       queryParameters: {'realname': filename ?? ''},
-      options: Options(responseType: ResponseType.bytes),
+      options: Options(responseType: .bytes),
     );
 
     final contentType = response.headers.value('content-type') ?? '';

--- a/lib/services/student_query/ntut_student_query_service.dart
+++ b/lib/services/student_query/ntut_student_query_service.dart
@@ -53,9 +53,9 @@ class NtutStudentQueryService implements StudentQueryService {
     ).firstMatch(fields['Date of Birth'] ?? '');
     final dateOfBirth = dobMatch != null
         ? DateTime(
-            int.parse(dobMatch.group(1)!),
-            int.parse(dobMatch.group(2)!),
-            int.parse(dobMatch.group(3)!),
+            .parse(dobMatch.group(1)!),
+            .parse(dobMatch.group(2)!),
+            .parse(dobMatch.group(3)!),
           )
         : null;
 
@@ -381,9 +381,9 @@ class NtutStudentQueryService implements StudentQueryService {
   /// Maps enrollment status text to [EnrollmentStatus].
   EnrollmentStatus? _parseEnrollmentStatus(String? text) {
     return switch (text) {
-      '在學' => EnrollmentStatus.learning,
-      '休學' => EnrollmentStatus.leaveOfAbsence,
-      '退學' => EnrollmentStatus.droppedOut,
+      '在學' => .learning,
+      '休學' => .leaveOfAbsence,
+      '退學' => .droppedOut,
       _ => null,
     };
   }

--- a/lib/shells/animated_shell_container.dart
+++ b/lib/shells/animated_shell_container.dart
@@ -61,7 +61,7 @@ class _AnimatedShellContainerState extends State<AnimatedShellContainer>
     return AnimatedBuilder(
       animation: _controller,
       builder: (context, _) => Stack(
-        fit: StackFit.expand,
+        fit: .expand,
         children: [
           for (var i = 0; i < widget.children.length; i++) _buildBranch(i),
         ],

--- a/lib/shells/showcase_shell.dart
+++ b/lib/shells/showcase_shell.dart
@@ -48,13 +48,13 @@ class ShowcaseShell extends StatelessWidget {
     final verticalPadding = screenHeight * 0.1;
 
     return Padding(
-      padding: EdgeInsets.fromLTRB(8, 0, 8, 16),
+      padding: .fromLTRB(8, 0, 8, 16),
       child: CustomScrollView(
         slivers: [
           SliverFillRemaining(
             hasScrollBody: false,
             child: Padding(
-              padding: EdgeInsets.fromLTRB(
+              padding: .fromLTRB(
                 0,
                 verticalPadding,
                 0,
@@ -63,7 +63,7 @@ class ShowcaseShell extends StatelessWidget {
               ),
               child: Column(
                 spacing: 24,
-                crossAxisAlignment: CrossAxisAlignment.center,
+                crossAxisAlignment: .center,
                 children: [
                   Spacer(flex: 1),
 
@@ -75,9 +75,9 @@ class ShowcaseShell extends StatelessWidget {
                       Text(
                         title,
                         style: theme.textTheme.headlineLarge?.copyWith(
-                          fontWeight: FontWeight.bold,
+                          fontWeight: .bold,
                         ),
-                        textAlign: TextAlign.center,
+                        textAlign: .center,
                       ),
                       if (subtitle case final subtitle?)
                         Text(
@@ -85,7 +85,7 @@ class ShowcaseShell extends StatelessWidget {
                           style: theme.textTheme.bodyMedium?.copyWith(
                             color: Colors.grey[600],
                           ),
-                          textAlign: TextAlign.center,
+                          textAlign: .center,
                         ),
                     ],
                   ),

--- a/lib/utils/avatar_payload.dart
+++ b/lib/utils/avatar_payload.dart
@@ -43,7 +43,7 @@ decodeAvatarPayload(Uint8List bytes) {
     return (
       jpeg: jpeg,
       version: version,
-      data: Map<String, dynamic>.from(data as Map),
+      data: .from(data as Map),
     );
   } catch (_) {
     return (jpeg: jpeg, version: null, data: null);

--- a/lib/utils/http.dart
+++ b/lib/utils/http.dart
@@ -81,13 +81,13 @@ class PlainTextTransformer extends BackgroundTransformer {
     ResponseBody responseBody,
   ) async {
     // Return streams and bytes as-is
-    if (options.responseType == ResponseType.stream) {
+    if (options.responseType == .stream) {
       return responseBody;
     }
 
     final responseBytes = await consolidateBytes(responseBody.stream);
 
-    if (options.responseType == ResponseType.bytes) {
+    if (options.responseType == .bytes) {
       return responseBytes;
     }
 

--- a/lib/utils/localized.dart
+++ b/lib/utils/localized.dart
@@ -5,7 +5,7 @@ import 'package:tattoo/i18n/strings.g.dart';
 /// NTUT services return Chinese (always) and English (sometimes). For Chinese
 /// locales, prefers [zh]; all other locales prefer [en], falling back to [zh].
 String localized(String? zh, String? en) {
-  if (LocaleSettings.currentLocale == AppLocale.zhTw) {
+  if (LocaleSettings.currentLocale == .zhTw) {
     return zh ?? en ?? '';
   }
   return en ?? zh ?? '';

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -17,8 +17,8 @@ import 'package:flutter_test/flutter_test.dart';
 /// flutter test --dart-define-from-file=test/test_config.json
 /// ```
 class TestCredentials {
-  static const String username = String.fromEnvironment('NTUT_TEST_USERNAME');
-  static const String password = String.fromEnvironment('NTUT_TEST_PASSWORD');
+  static const String username = .fromEnvironment('NTUT_TEST_USERNAME');
+  static const String password = .fromEnvironment('NTUT_TEST_PASSWORD');
 
   static void validate() {
     if (username.isEmpty || password.isEmpty) {

--- a/test/utils/localized_test.dart
+++ b/test/utils/localized_test.dart
@@ -5,7 +5,7 @@ import 'package:tattoo/utils/localized.dart';
 void main() {
   group('localized', () {
     group('when locale is zhTw', () {
-      setUp(() async => LocaleSettings.setLocale(AppLocale.zhTw));
+      setUp(() async => LocaleSettings.setLocale(.zhTw));
 
       test('returns zh when both provided', () {
         expect(localized('中文', 'English'), '中文');
@@ -21,7 +21,7 @@ void main() {
     });
 
     group('when locale is en', () {
-      setUp(() async => LocaleSettings.setLocale(AppLocale.enUs));
+      setUp(() async => LocaleSettings.setLocale(.enUs));
 
       test('returns en when both provided', () {
         expect(localized('中文', 'English'), 'English');

--- a/tool/credentials.dart
+++ b/tool/credentials.dart
@@ -166,7 +166,7 @@ Uint8List encryptBytes(Uint8List plaintext, String matchPassword) {
   final password = _deriveKeyPassword(matchPassword);
   final random = Random.secure();
   final salt = Uint8List.fromList(
-    List.generate(8, (_) => random.nextInt(256)),
+    .generate(8, (_) => random.nextInt(256)),
   );
 
   final keyIv = _pbkdf2(password, salt, _keyLength + _ivLength);
@@ -187,7 +187,7 @@ Uint8List encryptBytes(Uint8List plaintext, String matchPassword) {
     cipher.processBlock(padded, offset, ciphertext, offset);
   }
 
-  return Uint8List.fromList([
+  return .fromList([
     ...utf8.encode(_saltHeader),
     ...salt,
     ...ciphertext,


### PR DESCRIPTION
## Summary

- Add the [`prefer_shorthands`](https://pub.dev/packages/prefer_shorthands) analyzer plugin (pinned to `0.4.7`) alongside `riverpod_lint` in `analysis_options.yaml`.
- Rewrite all `Type.member` and `Type<args>.member` sites flagged by the new lint to dot shorthand form across `lib/`, `test/`, and `tool/`. Net: 275 insertions / 280 deletions across 40 files.
- Drop two now-unused imports of `package:tattoo/models/user.dart` whose only references (`EnrollmentStatus.learning`) became `.learning`.

## Notes

- `prefer_shorthands` is a young, single-author analyzer plugin (first published 2025-11-14, ~6 months old, MIT). Pinned to an exact version to avoid surprise updates. Worth keeping an eye on — if it breaks on a future Dart SDK bump, dropping it is a one-line revert.
- Quick-fixes only surface in the IDE (it's not a `custom_lint` plugin, so `dart fix` doesn't apply them). The migration here was scripted with a small Python helper that strips `Type` (and any generic args) before the leading `.`.

## Test plan

- [x] `flutter analyze` clean (no remaining `prefer_shorthands` infos, no new warnings).
- [x] `dart format` applied (2 files reformatted post-migration).
- [x] `flutter test` with each available `test/test_config*.json`: all suites green (81/81).