### PR TITLE
docs: add flutter-upgrade skill, improve e2e skill

### DIFF
--- a/.agents/skills/e2e/SKILL.md
+++ b/.agents/skills/e2e/SKILL.md
@@ -8,8 +8,11 @@ description: Drive the app in an Android emulator for manual E2E testing
 ### Android emulator
 
 - Launch the app with `flutter run` (in the background) so logs are inspectable and the running build reflects the current code
-- If `adb devices` lists more than one device, pick the emulator and pass `-s <serial>` to every `adb` call
-- Screen resolution: `adb -s <serial> shell wm size`
+- Run `adb devices` once to see what's attached:
+  - **One device:** plain `adb` and the helper scripts below work as-is.
+  - **Multiple devices:** target the emulator on every call. Use `adb -s <serial> ...` for raw `adb`, and prefix `ANDROID_SERIAL=<serial>` on the same command line for the helper scripts (e.g. `ANDROID_SERIAL=emulator-5554 .agents/skills/e2e/scripts/screencap.sh`). `export ANDROID_SERIAL=<serial>` only works *within a single persistent shell session* — it does not carry across separate shell tool calls, so don't use it as your default targeting strategy.
+  - All `adb …` examples below assume the single-device case; in the multi-device case, add `-s <serial>` (or the equivalent helper-script prefix) to each one.
+- Screen resolution: `adb shell wm size`
 
 ### Login credentials
 
@@ -19,27 +22,27 @@ If a flow needs login, look for project-local Dart test credentials in `test/tes
 
 ### Screenshots
 
-Some AI image APIs reject screenshots with any side longer than 2000px, so always clamp the long edge before reading.
+Use the helper script — it captures, resizes, and writes the PNG in one call:
 
 ```bash
-adb exec-out screencap -p | magick - -resize '1999x1999>' /tmp/android_screen.png
+.agents/skills/e2e/scripts/screencap.sh             # writes /tmp/screen.png
+.agents/skills/e2e/scripts/screencap.sh /tmp/x.png  # custom output path
 ```
 
 Then read the PNG with the agent's image tool.
 
 ### UI hierarchy
 
-`adb shell uiautomator dump` produces an XML accessibility tree with exact pixel bounds and `content-desc` for every element. This is the primary way to find tap coordinates — do not guess from screenshots.
+The UI accessibility tree gives exact pixel bounds and `content-desc` for every element. This is the primary way to find tap coordinates — do not guess from screenshots.
 
 ```bash
-adb shell uiautomator dump /sdcard/ui.xml && adb pull /sdcard/ui.xml /tmp/ui.xml
+.agents/skills/e2e/scripts/uidump.sh             # writes /tmp/ui.xml, prints element summary
+.agents/skills/e2e/scripts/uidump.sh /tmp/x.xml  # custom output path
 ```
 
-Then extract elements:
+The script streams `uiautomator dump /dev/tty` over `adb exec-out` and writes the full XML to the output path. It then prints a compact one-line-per-element summary of the nodes worth tapping or reading: any node with non-empty `text` or `content-desc`, or with any of `clickable` / `scrollable` / `selected` / `focused` / `password` set to `true`. Each line shows `bounds`, the short class name, `text="..."` and/or `desc="..."` when present, and the list of true states. Long values are whitespace-collapsed and truncated to ~120 chars.
 
-```bash
-grep -oE 'content-desc="[^"]*"[^/]*bounds="[^"]*"' /tmp/ui.xml
-```
+Use the printed summary as the primary input for choosing tap coordinates — it covers the vast majority of cases. Fall back to searching `/tmp/ui.xml` directly (e.g. with `grep`) when you need parent/child structure or attributes the summary doesn't include (`resource-id`, `package`, `checked`, `enabled`, etc.).
 
 Flutter widgets with `Semantics` labels appear as `content-desc`. The bounds format is `[left,top][right,bottom]` in pixels. Tap the center: `x = (left+right)/2`, `y = (top+bottom)/2`.
 
@@ -59,17 +62,25 @@ Flutter widgets with `Semantics` labels appear as `content-desc`. The bounds for
 adb shell input text "$PASSWORD"
 
 # Right — single-quote on the device side so the device shell treats the value literally
+# (assumes the value contains no single quotes; if it does, replace each ' with '\'' or use a different quoting strategy)
 adb shell "input text '$PASSWORD'"
 ```
 
-Tapping a non-empty field places the cursor at the end, so the next `input text` appends rather than replaces. Clear the field first:
+Tapping a non-empty field places the cursor somewhere inside the existing text — usually but not always at the end. The next `input text` appends rather than replaces. Move the cursor explicitly, backspace, then re-dump the XML to confirm the field is empty before typing:
 
 ```bash
 adb shell input tap <x> <y>
-for i in $(seq 1 50); do adb shell input keyevent 67; done  # 67 = DEL/backspace
+adb shell input keyevent 123                                # 123 = MOVE_END (cursor to end of field)
+for i in $(seq 1 50); do adb shell input keyevent 67; done  # 67  = DEL/backspace
+.agents/skills/e2e/scripts/uidump.sh                        # verify the field is empty
 ```
 
-Password fields hide their contents, so the only way to verify what was typed is the dot count — count it against the expected length before submitting.
+Password fields hide their contents, so the only way to verify what was typed is the bullet count — count it against the expected length before submitting.
+
+### Keyboard and focus shifts
+
+- The soft keyboard pushes the layout, so bounds dumped before it opens are stale. Re-dump the UI hierarchy after focusing a text field, after dismissing the keyboard, or after any visible layout change — don't reuse coordinates from across a keyboard transition.
+- `keyevent 4` (BACK) is context-dependent: it dismisses the keyboard if open, then closes the topmost picker/dialog, then pops the current route, then exits to the launcher from the root route. Don't chain BACK presses blindly — verify the resulting state (UI dump or screenshot) between presses.
 
 ### Scrollable containers
 
@@ -80,7 +91,16 @@ Swiping on a `TabBarView` body switches tabs. Swiping on a `SingleChildScrollVie
 1. **Dump UI hierarchy** with `uiautomator` to get element bounds
 2. **Find the target element** by `content-desc` or position in the tree
 3. **Calculate center coordinates** from bounds and tap
-4. **Screenshot** to confirm the resulting state
+4. **Verify the resulting state** — UI dump or screenshot, depending on what changed (see below)
 5. Repeat until the task is complete
 
-Bounds in the XML are exact pixels — that's where tap coordinates come from. Screenshots are best used as a state check between actions: confirming a screen rendered, an error appeared, or content updated. Re-dump after each navigation since bounds change between screens.
+Bounds in the XML are exact pixels — that's where tap coordinates come from. Re-dump after each navigation since bounds change between screens.
+
+**XML vs screenshot for verification.** Default to a fresh UI dump — it's cheaper and exact. Reach for a screenshot only when the change is genuinely visual:
+
+- Use the **XML dump** to confirm: which elements are tappable and where, snackbar/dialog text, selected state of a picker or toggle, password bullet count, whether a field is empty.
+- Use a **screenshot** to confirm: image/avatar content, overlay or bottom-sheet stacking, anything where the XML reads "fine" but the visual state is in doubt, and final verification once the goal is met.
+
+**Don't be misled by unrelated dialogs.** In debug builds, async failures (e.g. Google Fonts network errors) can pop a Flutter error dialog on top of an otherwise-successful flow — the underlying state may have updated correctly behind it. Read the dialog text before treating it as a failure of the current step.
+
+**Stop when the goal is achieved.** Don't keep tapping to tidy up UI state (closing menus, navigating back to a home screen) unless the user asked for that — extra taps risk breaking the verified end state.

--- a/.agents/skills/e2e/scripts/screencap.sh
+++ b/.agents/skills/e2e/scripts/screencap.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Capture the connected Android device's screen and resize so the longest edge
+# is <= 1999 px (Claude's image API rejects anything larger).
+#
+# Usage: screencap.sh [output_path]
+#   default output: /tmp/screen.png
+#   set ANDROID_SERIAL=<serial> when more than one device is attached
+set -euo pipefail
+
+if ! command -v magick >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+screencap.sh: `magick` (ImageMagick) not found on PATH.
+Install it:
+  macOS:    brew install imagemagick
+  Debian:   sudo apt install imagemagick
+  Windows:  winget install ImageMagick.ImageMagick
+EOF
+  exit 1
+fi
+
+out="${1:-/tmp/screen.png}"
+adb exec-out screencap -p | magick - -resize '1999x1999>' "$out"
+echo "$out"

--- a/.agents/skills/e2e/scripts/uidump.sh
+++ b/.agents/skills/e2e/scripts/uidump.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Dump the connected Android device's UI accessibility tree to an XML file
+# and print a compact summary of the elements worth tapping or reading.
+# Streams via `exec-out` so no /sdcard round-trip + adb pull is needed.
+#
+# Usage: uidump.sh [output_path]
+#   default output: /tmp/ui.xml
+#   set ANDROID_SERIAL=<serial> when more than one device is attached
+set -euo pipefail
+
+out="${1:-/tmp/ui.xml}"
+# `uiautomator dump /dev/tty` writes the XML to stdout but appends a status
+# line ("UI hierchary dumped to: /dev/tty" — typo is upstream in AOSP).
+adb exec-out uiautomator dump /dev/tty \
+  | sed 's|UI hierchary dumped to: /dev/tty||' \
+  > "$out"
+
+echo "wrote: $out"
+echo "elements:"
+awk '
+  function compact(s) {
+    gsub(/[[:space:]]+/, " ", s)
+    sub(/^ /, "", s); sub(/ $/, "", s)
+    if (length(s) > 120) s = substr(s, 1, 117) "..."
+    return s
+  }
+  function decode(s) {
+    gsub(/&lt;/, "<", s)
+    gsub(/&gt;/, ">", s)
+    gsub(/&quot;/, "\"", s)
+    gsub(/&apos;/, "'\''", s)
+    gsub(/&amp;/, "\\&", s)  # must be last
+    return s
+  }
+  # Escape backslash and double-quote so values stay unambiguous when wrapped
+  # in `text="..."` / `desc="..."`. Char-by-char to avoid gsub backslash soup.
+  function escape(s,   out, i, c) {
+    out = ""
+    for (i = 1; i <= length(s); i++) {
+      c = substr(s, i, 1)
+      if (c == "\\")      out = out "\\\\"
+      else if (c == "\"") out = out "\\\""
+      else                out = out c
+    }
+    return out
+  }
+  # Extract attribute value; matches " name=\"...\"" with a leading space so
+  # short names like "text" or "clickable" do not match inside "content-desc"
+  # or "long-clickable".
+  function attr(name,   pat, val, head) {
+    pat = "[[:space:]]" name "=\"[^\"]*\""
+    if (match($0, pat)) {
+      head = length(name) + 3                    # space + name + ="
+      val = substr($0, RSTART + head, RLENGTH - head - 1)
+      return val
+    }
+    return ""
+  }
+  { buf = buf $0 }
+  END {
+    gsub(/<node /, "\n<node ", buf)
+    m = split(buf, lines, "\n")
+    nstates = split("clickable scrollable selected focused password", state_names, " ")
+    for (i = 1; i <= m; i++) {
+      $0 = lines[i]
+      if ($0 !~ /^<node /) continue
+
+      text = decode(attr("text"))
+      desc = decode(attr("content-desc"))
+      bounds = attr("bounds")
+      cls = attr("class")
+      np = split(cls, parts, ".")
+      cls = parts[np]
+
+      states = ""
+      for (j = 1; j <= nstates; j++) {
+        if (index($0, " " state_names[j] "=\"true\"")) {
+          states = states (states ? " " : "") state_names[j]
+        }
+      }
+
+      if (text == "" && desc == "" && states == "") continue
+
+      line = "  " bounds " " cls
+      if (text != "")   line = line " text=\"" escape(compact(text)) "\""
+      if (desc != "")   line = line " desc=\"" escape(compact(desc)) "\""
+      if (states != "") line = line " " states
+      print line
+    }
+  }
+' "$out"

--- a/.agents/skills/flutter-upgrade/SKILL.md
+++ b/.agents/skills/flutter-upgrade/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: flutter-upgrade
+description: Finish the migration commit on a Renovate-generated Flutter version PR — patch, minor, or major bumps. Use whenever a `renovate/flutter-*` PR appears, when the user says things like "do the flutter upgrade" or "bump flutter X to Y", or any time `mise.toml`'s `flutter = "X.Y.Z"` value changes.
+---
+
+## 1. Check out the PR
+
+```bash
+gh pr checkout <PR>
+mise trust ./mise.toml         # mise.toml on a Renovate branch is not yet trusted
+```
+
+Use `gh pr checkout`, not `git worktree add origin/renovate/flutter-3.x` — the latter creates a parallel local branch that won't push back to the PR.
+
+Read `mise.toml` to find the new Flutter version (the value of the `flutter` key). Use that version everywhere `<new-version>` appears below.
+
+## 2. Update the hardcoded version references
+
+Renovate only edits `mise.toml`. Two other files hardcode the same version and need to match — edit each one:
+
+- **`.github/actions/setup-project/action.yml`** — find the version-guard line `if [ "$FLUTTER_VERSION" != "X.Y.Z" ]; then` and replace `X.Y.Z` with `<new-version>`. The line exists specifically to fail CI when these refs go out of sync.
+- **`.github/renovate.json`** — under `"constraints"`, set `"flutter"` to `<new-version>`. Drives Renovate's pub-version resolution (<https://docs.renovatebot.com/configuration-options/#constraints>).
+
+## 3. Reconcile Android NDK / CMake / SDK with runner image and Flutter
+
+The Android SDK cache in `setup-project/action.yml` (currently keyed at `/usr/local/lib/android/sdk/cmake/3.22.1`) only works when three sources agree:
+
+1. **Flutter's expected versions** at the new tag — read `FlutterExtension.kt`:
+
+   ```bash
+   gh api -H "Accept: application/vnd.github.raw" \
+     "repos/flutter/flutter/contents/packages/flutter_tools/gradle/src/main/kotlin/FlutterExtension.kt?ref=<new-version>"
+   ```
+
+   Look for `compileSdkVersion`, `minSdkVersion`, `targetSdkVersion`, `ndkVersion`. The CMake version comes from the project's `android/app/build.gradle.kts` or Flutter's gradle plugin defaults.
+
+2. **What the runner image ships** — the Android SDK section of the runner README lists every preinstalled NDK and CMake version:
+   - `ubuntu-latest` (currently Ubuntu 24.04): <https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md>
+   - `macos-26`: <https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md>
+
+3. **What the project pins** — read `android/app/build.gradle.kts`, `android/build.gradle.kts`, `android/settings.gradle.kts`, and the cache path in `.github/actions/setup-project/action.yml`. Look for `ndkVersion`, `compileSdk`, `minSdk`, `targetSdk`, and `cmake`.
+
+If the runner image already ships the version Flutter expects, drop that path from the cache list in `action.yml` — caching what's preinstalled is wasted work. If the runner image doesn't ship it, keep or update the cache entry at the new path so Flutter's on-demand download persists between runs.
+
+## 4. Diff against a fresh template
+
+Generate a clean Flutter project from the new SDK and look for adoptable changes (gradle wrapper version, AGP/Kotlin pins, Podfile boilerplate, `MainActivity.kt`/`AppDelegate.swift` regen, etc.):
+
+```bash
+cd /tmp
+rm -rf flutter_template_check
+flutter create --org com.example --platforms android,ios flutter_template_check
+diff -ruN flutter_template_check/ "$OLDPWD/" \
+  | grep -vE '^Only in|\.dart_tool|/build/|\.lock$|\.g\.dart|\.firebase|GeneratedPluginRegistrant|test_config' \
+  | less
+```
+
+Adopt template-driven updates selectively — never overwrite project files wholesale. Common things worth picking up: `android/gradle/wrapper/gradle-wrapper.properties` version, AGP version in `android/settings.gradle.kts` `plugins` block, `ios/Podfile` `platform :ios` floor.
+
+List the upstream template content at the new tag:
+
+```bash
+gh api "repos/flutter/flutter/contents/packages/flutter_tools/templates/app?ref=<new-version>"
+```
+
+## 5. Update all lockfiles
+
+```bash
+flutter pub get
+( cd ios && pod install )
+git diff pubspec.yaml pubspec.lock ios/Podfile.lock
+```
+
+- `pubspec.yaml` — bump `environment.sdk` if the new Flutter's bundled Dart minor exceeds the current floor. Find the bundled Dart in the Flutter release notes (<https://docs.flutter.dev/install/archive>) or by reading `bin/cache/dart-sdk/version` after running any `flutter` command at the new version.
+- `pubspec.lock` — `flutter pub get` rewrites this. The `sdks: dart:` line tracks `pubspec.yaml`.
+- `ios/Podfile.lock` — `pod install` rewrites this. CI's `ios-drift` step (`flutter build ios --config-only --no-pub --no-codesign` then `git diff --quiet ios/`) is the source of truth; if you can't run `pod install` locally with the same Xcode CI uses (`Xcode_26.4.app`), let CI report drift via the `ios-drift.patch` artifact and apply it:
+
+  ```bash
+  gh run download <run-id> -n ios-drift.patch && git apply ios-drift.patch
+  ```
+
+## 6. Commit, push, watch CI
+
+Per `CONTRIBUTING.md`: type `chore` for dependency/config bumps. One follow-up commit on the Renovate branch — leave Renovate's `mise.toml` commit intact.
+
+Stage `.github/actions/setup-project/action.yml` and `.github/renovate.json`. Also stage `pubspec.yaml`, `pubspec.lock`, and `ios/Podfile.lock` if step 5 produced diffs, plus any `android/` or `ios/` changes from step 4.
+
+Commit message: `chore: update hardcoded Flutter version references` — or, when the Dart SDK constraint also moves, `chore: update hardcoded Flutter version references and Dart SDK constraint`.
+
+```bash
+git push
+gh pr checks <PR>
+```
+
+The CI matrix is `prepare`, `analyze`, `android`, `ios`. Wait for all four to pass.


### PR DESCRIPTION
## Summary

- **`e2e` (improved)** — moves the inlined `adb exec-out screencap | magick ...` and `uiautomator dump` + `adb pull` pair into `scripts/screencap.sh` and `scripts/uidump.sh`, with default output paths and `exec-out` streaming so the UI XML never round-trips through `/sdcard`. `uidump.sh` also prints a compact element summary (bounds, class, text/desc, true states), so most tap targeting can skip ad-hoc grepping. `screencap.sh` preflight-checks `magick` with install hints. Multi-device guidance prefers inline `ANDROID_SERIAL=<serial>` or `adb -s <serial>` over `export ANDROID_SERIAL=...`, since env vars don't persist across separate shell tool calls. The skill also collects pitfalls from real runs: keyboard layout shifts invalidate cached bounds, BACK is context-dependent, debug-only async error dialogs can be unrelated to the flow, and `input text` needs device-side single-quoting for values containing `$` or special characters. `.gitattributes` already enforces LF and the exec bit is tracked, so the scripts run unchanged in Git Bash on Windows.

- **`flutter-upgrade` (new)** — finishes the migration commit on a Renovate-generated Flutter version PR (patch, minor, or major). Captures the workflow followed for prior bumps (PR #253, #281): check out the PR branch, sync the two hardcoded version refs Renovate misses (\`.github/actions/setup-project/action.yml\`, \`.github/renovate.json\`), reconcile Android NDK / CMake / SDK across Flutter, the runner image, and the project's pins, diff against a fresh \`flutter create --platforms android,ios\` template, refresh \`pubspec.lock\` and \`ios/Podfile.lock\`, then commit and watch CI.
