### PR TITLE
fix: notify Drift watchers when resetting the database cache

### DIFF
--- a/lib/database/actions.dart
+++ b/lib/database/actions.dart
@@ -3,15 +3,18 @@ import 'package:tattoo/database/database.dart';
 
 /// Reusable database operations shared across repositories.
 extension DatabaseActions on AppDatabase {
-  /// Drops and recreates all tables, fully resetting the database.
+  /// Deletes all rows from every table, fully resetting the database.
+  ///
+  /// Uses Drift's row-level deletes (not drop/createAll) so reactive
+  /// `.watch()` streams are notified of the change. Migrator-based drops
+  /// bypass change tracking and would leave watchers serving stale data.
   Future<void> deleteEverything() async {
     await transaction(() async {
-      final m = Migrator(this);
-      final reversed = allSchemaEntities.toList().reversed;
-      for (final entity in reversed) {
-        await m.drop(entity);
+      for (final entity in allSchemaEntities.toList().reversed) {
+        if (entity is TableInfo) {
+          await delete(entity).go();
+        }
       }
-      await m.createAll();
     });
   }
 

--- a/lib/repositories/course_repository.dart
+++ b/lib/repositories/course_repository.dart
@@ -269,7 +269,9 @@ class CourseRepository {
 
       final semesterRow = await (_database.select(
         _database.semesters,
-      )..where((s) => s.id.equals(semesterId))).getSingle();
+      )..where((s) => s.id.equals(semesterId))).getSingleOrNull();
+      if (semesterRow == null) return;
+
       final age = switch (semesterRow.courseTableFetchedAt) {
         final t? => DateTime.now().difference(t),
         null => ttl,


### PR DESCRIPTION
## Summary

- `deleteEverything()` 改用 row-level `delete(entity).go()`。原本的 `Migrator.drop`/`createAll` 會跳過 Drift 變更追蹤，導致登出後重新登入時 `.watch()` 仍持續發出上一個帳號的快取資料。
- `watchCourseTable` 中改用 `getSingleOrNull` 並提早 return：session 切換瞬間 semester row 可能短暫消失，原本的 `getSingle()` 會把 `Bad state: No element` 漏到 UI。

Refs #233

## Test plan

- [x] Android emulator：登出 demo 帳號後以實際帳號登入，課表正確顯示新使用者資料而非殘留的 demo 課程
- [x] Android emulator：清除應用資料後重新登入，課表/成績頁的 loading skeleton 仍正常顯示