### PR TITLE
Lock Portrait Orientation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,12 +10,14 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:localeConfig="@xml/locales_config">
+        <!-- TODO: Remove orientation restriction after responsive layouts are complete. -->
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
             android:taskAffinity=""
             android:theme="@style/LaunchTheme"
+            android:screenOrientation="portrait"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -35,6 +35,7 @@
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<!-- TODO: Remove orientation restriction after responsive layouts are complete. -->
+	<!-- iPad must declare all four orientations to satisfy App Store multitasking requirements (error 90474); runtime SystemChrome.setPreferredOrientations locks the actual orientation. -->
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -42,6 +43,9 @@
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -34,18 +34,14 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<!-- TODO: Remove orientation restriction after responsive layouts are complete. -->
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,11 @@ enum ErrorType {
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
+  // TODO: Remove orientation restriction after responsive layouts are complete.
+  await SystemChrome.setPreferredOrientations([
+    .portraitUp,
+  ]);
+
   if (useFirebase) {
     try {
       await Firebase.initializeApp(


### PR DESCRIPTION
## 變更

鎖定 Android 與 iPhone 的支援方向為直向。
iPad 因為蘋果的政策，暫時無法鎖定。