### PR TITLE
chore: migrate daily android builds to google play

### DIFF
--- a/.github/actions/android-summary/action.yml
+++ b/.github/actions/android-summary/action.yml
@@ -36,7 +36,6 @@ runs:
         2. Select "Project Tattoo"
         3. Install or update to the latest build
 
-        > **Note:** Manual build selection is not available in Google Play, so the latest approved build will be installed.
-        > **Note:** It may take ~15 minutes for the build to appear in the Play Store after upload.
+        > **Note:** It may take ~30 minutes for the build to appear in the Play Store after upload.
         EOF
         fi

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -14,7 +14,7 @@ on:
         required: false
         type: string
       include_public_testers:
-        description: 'Upload to external public testers (TestFlight/Firebase)'
+        description: 'Upload to external public testers (TestFlight)'
         required: false
         type: boolean
         default: false
@@ -153,7 +153,6 @@ jobs:
       PR_TITLE: "Daily Build ${{ needs.prepare.outputs.date }}"
       COMMIT_SHA: ${{ needs.prepare.outputs.commit_sha }}
       COMMIT_MESSAGE: ${{ needs.prepare.outputs.commit_message }}
-      PUBLIC_TESTERS: ${{ github.event_name == 'schedule' || inputs.include_public_testers }}
       FIREBASEAPPDISTRO_APP: ${{ secrets.FIREBASEAPPDISTRO_APP }}
     timeout-minutes: 30
     steps:
@@ -195,16 +194,17 @@ jobs:
           body: |
             ### Android
             You can join the testing program here:
-            [Join Firebase App Distribution](${{ vars.FIREBASE_PUBLIC_LINK }})
 
-            [Install build ${{ needs.prepare.outputs.build_number }} in Firebase App Distribution](${{ steps.build.outputs.testing_uri }})
+            - **Google Play (Recommended):** [Join the testing program](https://play.google.com/apps/testing/club.ntut.tattoo)
+            - **Firebase App Distribution (For Internal Testers):** [Join the program](${{ vars.FIREBASE_PUBLIC_LINK }})
 
-            1. Open the Firebase App Distribution app on your Android device
-            2. Select "Project Tattoo"
-            3. Install or update to the latest build
+            [Install build ${{ needs.prepare.outputs.build_number }} in Firebase](${{ steps.build.outputs.testing_uri }})
 
-            > If you cannot find the new release in Firebase App Distribution, navigate to the home page and back.
-            > Installing the App Distribution app is optional but recommended.
+            > [!NOTE]
+            > We are migrating our daily build distribution to Google Play.
+            > The build will be available on Google Play within 30 minutes after the Google Play review process.
+            > Please use Google Play for the best experience and automatic updates.
+            > Firebase remains available for internal testers.
 
   ios:
     runs-on: macos-26
@@ -270,5 +270,6 @@ jobs:
             2. Select "Project Tattoo"
             3. Install build ${{ needs.prepare.outputs.build_number }}
 
+            > [!TIP]
             > Install TestFlight app from App Store if you don't have it (required iOS 16.0 or later)
-            > TestFlight app is blocked by NTUT Wi-Fi, please use your own mobile data or other networks to install.
+            > TestFlight is unstable on NTUT Wi-Fi. If you encounter issues installing or updating, please switch to mobile data or a different network.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -128,12 +128,10 @@ platform :android do
     pr_title = options[:pr_title] || ENV["PR_TITLE"] || "manual build"
     commit_sha = options[:commit_sha] || ENV["COMMIT_SHA"] || "manual build"
     commit_message = options[:commit_message] || ENV["COMMIT_MESSAGE"] || "This is a manual build without PR information"
-    include_public_testers = options[:include_public_testers].to_s == "true" || ENV["PUBLIC_TESTERS"].to_s == "true"
-
     changelog_text = changelog(pr_number, pr_title, commit_sha, commit_message)
     aab_path = options[:aab] || File.expand_path("../build/app/outputs/bundle/release/app-release.aab", __dir__)
 
-    target_groups = include_public_testers ? "pub-tester,dev-tester" : "dev-tester"
+    target_groups = "dev-tester"
 
     release = firebase_app_distribution(
       groups: target_groups,
@@ -165,16 +163,19 @@ platform :android do
     end
 
     aab_path = options[:aab] || File.expand_path("../build/app/outputs/bundle/release/app-release.aab", __dir__)
+    track = options[:track] || "internal"
 
     upload_to_play_store(
       package_name: ENV["FASTLANE_APP_IDENTIFIER"],
-      track: "internal",
+      track: track,
       aab: aab_path,
       json_key: File.expand_path("../service-account.json", __dir__),
       skip_upload_metadata: false,
       skip_upload_images: true,
       skip_upload_screenshots: true,
-      skip_upload_changelogs: false
+      skip_upload_changelogs: false,
+      release_status: "completed",
+      changes_not_sent_for_review: false
     )
   end
 
@@ -189,7 +190,7 @@ platform :android do
   lane :release do |options|
     aab = options[:aab]
     aab ||= build_appbundle(options) unless options[:skip_build].to_s == "true"
-    upload_playstore(options.merge(aab: aab)) unless options[:skip_upload_playstore].to_s == "true"
+    upload_playstore(options.merge(aab: aab, track: "beta")) unless options[:skip_upload_playstore].to_s == "true"
     upload_firebase(options.merge(aab: aab)) unless options[:skip_upload_firebase].to_s == "true"
   end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -15,14 +15,6 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 ## iOS
 
-### ios device
-
-```sh
-[bundle exec] fastlane ios device
-```
-
-Build, install on connected device, and upload dSYMs
-
 ### ios upload_testflight
 
 ```sh
@@ -36,21 +28,21 @@ Build and upload to TestFlight
 
 ## Android
 
-### android build
+### android build_apk
 
 ```sh
-[bundle exec] fastlane android build
+[bundle exec] fastlane android build_apk
 ```
 
-Build the APK
 
-### android device
+
+### android build_appbundle
 
 ```sh
-[bundle exec] fastlane android device
+[bundle exec] fastlane android build_appbundle
 ```
 
-Build and install on connected Android device
+
 
 ### android preview
 


### PR DESCRIPTION
This PR migrates the daily Android build distribution from Firebase App Distribution to Google Play Console (Beta track) for public users. Internal testers will continue to receive builds via Firebase.

### Key Changes:
- **Fastlane**: 
    - Updated `release` lane to always target the `beta` track on Google Play.
    - Restricted `upload_firebase` to the `dev-tester` group only (internal).
    - Added support for dynamic tracks in `upload_playstore`.
- **GitHub Workflows**: 
    - Updated `daily-release.yaml` to include Google Play joining link.
    - Removed redundant `include_public_testers` toggles as public distribution is now the default.
    - Added modern GitHub callouts (`[!NOTE]`, `[!TIP]`).
    - Adjusted estimated Play Store processing time to 30 minutes.
- **Documentation**: Cleaned up obsolete Fastlane actions in `README.md`.