### PR TITLE
fix: show blocking dialogs for JS alert/confirm/prompt in webview

### DIFF
--- a/lib/components/webview_sheet.dart
+++ b/lib/components/webview_sheet.dart
@@ -101,18 +101,69 @@ class _WebviewSheetState extends State<WebviewSheet> {
       )
       ..setOnConsoleMessage((message) {})
       ..setOnJavaScriptAlertDialog((request) async {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(request.message),
-              behavior: .floating,
-            ),
-          );
-          if (request.message.contains('登入失敗：取得的字串為空白或null') ||
-              request.message.contains('登入失敗：找不到使用者')) {
-            Navigator.of(context).pop();
-          }
+        if (!mounted) return;
+        await showDialog<void>(
+          context: context,
+          builder: (context) => AlertDialog(
+            content: Text(request.message),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('確定'),
+              ),
+            ],
+          ),
+        );
+        if (mounted &&
+            (request.message.contains('登入失敗：取得的字串為空白或null') ||
+                request.message.contains('登入失敗：找不到使用者'))) {
+          Navigator.of(context).pop();
         }
+      })
+      ..setOnJavaScriptConfirmDialog((request) async {
+        if (!mounted) return false;
+        final result = await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            content: Text(request.message),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('取消'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('確定'),
+              ),
+            ],
+          ),
+        );
+        return result ?? false;
+      })
+      ..setOnJavaScriptTextInputDialog((request) async {
+        if (!mounted) return request.defaultText ?? '';
+        final controller = TextEditingController(text: request.defaultText);
+        final result = await showDialog<String>(
+          context: context,
+          builder: (context) => AlertDialog(
+            content: TextField(
+              controller: controller,
+              autofocus: true,
+              decoration: InputDecoration(hintText: request.message),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('取消'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(controller.text),
+                child: const Text('確定'),
+              ),
+            ],
+          ),
+        );
+        return result ?? request.defaultText ?? '';
       })
       ..loadRequest(widget.url);
 


### PR DESCRIPTION
## Summary

iOS WKWebView suppresses `alert()`, `confirm()`, and `prompt()` by default. The previous handler showed a non-blocking snackbar for `alert()` and left `confirm()`/`prompt()` unhandled, so the voting site's confirm flows silently failed on iOS.

- Replace the alert snackbar with a real blocking `AlertDialog`
- Add `setOnJavaScriptConfirmDialog` (確定/取消)
- Add `setOnJavaScriptTextInputDialog` (text input with default value)

Preserves the existing login-failure auto-close behavior.

## Test plan

- [ ] iOS: trigger a voting action that calls `alert()` — dialog shows and blocks JS
- [ ] iOS: trigger a `confirm()` flow — choosing 確定 proceeds, 取消 cancels
- [ ] Android: regression check — dialogs still appear correctly