### PR TITLE
feat: add course offering detail API (watch/refresh)

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -51,6 +51,7 @@ final databaseProvider = Provider<AppDatabase>((ref) {
     CalendarEvents,
   ],
   views: [
+    CourseOfferingOverviews,
     CourseTableSlots,
     ScoreDetails,
     UserAcademicSummaries,

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -10518,6 +10518,13 @@ class CourseOfferingOverview extends DataClass {
   final String? remarks;
   final int? enrolled;
   final int? withdrawn;
+  final DateTime? fetchedAt;
+  final DateTime? syllabusUpdatedAt;
+  final String? objective;
+  final String? weeklyPlan;
+  final String? evaluation;
+  final String? textbooks;
+  final String? syllabusRemarks;
   const CourseOfferingOverview({
     required this.id,
     this.courseCode,
@@ -10534,6 +10541,13 @@ class CourseOfferingOverview extends DataClass {
     this.remarks,
     this.enrolled,
     this.withdrawn,
+    this.fetchedAt,
+    this.syllabusUpdatedAt,
+    this.objective,
+    this.weeklyPlan,
+    this.evaluation,
+    this.textbooks,
+    this.syllabusRemarks,
   });
   factory CourseOfferingOverview.fromJson(
     Map<String, dynamic> json, {
@@ -10558,6 +10572,15 @@ class CourseOfferingOverview extends DataClass {
       remarks: serializer.fromJson<String?>(json['remarks']),
       enrolled: serializer.fromJson<int?>(json['enrolled']),
       withdrawn: serializer.fromJson<int?>(json['withdrawn']),
+      fetchedAt: serializer.fromJson<DateTime?>(json['fetchedAt']),
+      syllabusUpdatedAt: serializer.fromJson<DateTime?>(
+        json['syllabusUpdatedAt'],
+      ),
+      objective: serializer.fromJson<String?>(json['objective']),
+      weeklyPlan: serializer.fromJson<String?>(json['weeklyPlan']),
+      evaluation: serializer.fromJson<String?>(json['evaluation']),
+      textbooks: serializer.fromJson<String?>(json['textbooks']),
+      syllabusRemarks: serializer.fromJson<String?>(json['syllabusRemarks']),
     );
   }
   @override
@@ -10581,6 +10604,13 @@ class CourseOfferingOverview extends DataClass {
       'remarks': serializer.toJson<String?>(remarks),
       'enrolled': serializer.toJson<int?>(enrolled),
       'withdrawn': serializer.toJson<int?>(withdrawn),
+      'fetchedAt': serializer.toJson<DateTime?>(fetchedAt),
+      'syllabusUpdatedAt': serializer.toJson<DateTime?>(syllabusUpdatedAt),
+      'objective': serializer.toJson<String?>(objective),
+      'weeklyPlan': serializer.toJson<String?>(weeklyPlan),
+      'evaluation': serializer.toJson<String?>(evaluation),
+      'textbooks': serializer.toJson<String?>(textbooks),
+      'syllabusRemarks': serializer.toJson<String?>(syllabusRemarks),
     };
   }
 
@@ -10600,6 +10630,13 @@ class CourseOfferingOverview extends DataClass {
     Value<String?> remarks = const Value.absent(),
     Value<int?> enrolled = const Value.absent(),
     Value<int?> withdrawn = const Value.absent(),
+    Value<DateTime?> fetchedAt = const Value.absent(),
+    Value<DateTime?> syllabusUpdatedAt = const Value.absent(),
+    Value<String?> objective = const Value.absent(),
+    Value<String?> weeklyPlan = const Value.absent(),
+    Value<String?> evaluation = const Value.absent(),
+    Value<String?> textbooks = const Value.absent(),
+    Value<String?> syllabusRemarks = const Value.absent(),
   }) => CourseOfferingOverview(
     id: id ?? this.id,
     courseCode: courseCode.present ? courseCode.value : this.courseCode,
@@ -10616,6 +10653,17 @@ class CourseOfferingOverview extends DataClass {
     remarks: remarks.present ? remarks.value : this.remarks,
     enrolled: enrolled.present ? enrolled.value : this.enrolled,
     withdrawn: withdrawn.present ? withdrawn.value : this.withdrawn,
+    fetchedAt: fetchedAt.present ? fetchedAt.value : this.fetchedAt,
+    syllabusUpdatedAt: syllabusUpdatedAt.present
+        ? syllabusUpdatedAt.value
+        : this.syllabusUpdatedAt,
+    objective: objective.present ? objective.value : this.objective,
+    weeklyPlan: weeklyPlan.present ? weeklyPlan.value : this.weeklyPlan,
+    evaluation: evaluation.present ? evaluation.value : this.evaluation,
+    textbooks: textbooks.present ? textbooks.value : this.textbooks,
+    syllabusRemarks: syllabusRemarks.present
+        ? syllabusRemarks.value
+        : this.syllabusRemarks,
   );
   @override
   String toString() {
@@ -10634,13 +10682,20 @@ class CourseOfferingOverview extends DataClass {
           ..write('language: $language, ')
           ..write('remarks: $remarks, ')
           ..write('enrolled: $enrolled, ')
-          ..write('withdrawn: $withdrawn')
+          ..write('withdrawn: $withdrawn, ')
+          ..write('fetchedAt: $fetchedAt, ')
+          ..write('syllabusUpdatedAt: $syllabusUpdatedAt, ')
+          ..write('objective: $objective, ')
+          ..write('weeklyPlan: $weeklyPlan, ')
+          ..write('evaluation: $evaluation, ')
+          ..write('textbooks: $textbooks, ')
+          ..write('syllabusRemarks: $syllabusRemarks')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode => Object.hashAll([
     id,
     courseCode,
     semester,
@@ -10656,7 +10711,14 @@ class CourseOfferingOverview extends DataClass {
     remarks,
     enrolled,
     withdrawn,
-  );
+    fetchedAt,
+    syllabusUpdatedAt,
+    objective,
+    weeklyPlan,
+    evaluation,
+    textbooks,
+    syllabusRemarks,
+  ]);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -10675,7 +10737,14 @@ class CourseOfferingOverview extends DataClass {
           other.language == this.language &&
           other.remarks == this.remarks &&
           other.enrolled == this.enrolled &&
-          other.withdrawn == this.withdrawn);
+          other.withdrawn == this.withdrawn &&
+          other.fetchedAt == this.fetchedAt &&
+          other.syllabusUpdatedAt == this.syllabusUpdatedAt &&
+          other.objective == this.objective &&
+          other.weeklyPlan == this.weeklyPlan &&
+          other.evaluation == this.evaluation &&
+          other.textbooks == this.textbooks &&
+          other.syllabusRemarks == this.syllabusRemarks);
 }
 
 class $CourseOfferingOverviewsView
@@ -10705,6 +10774,13 @@ class $CourseOfferingOverviewsView
     remarks,
     enrolled,
     withdrawn,
+    fetchedAt,
+    syllabusUpdatedAt,
+    objective,
+    weeklyPlan,
+    evaluation,
+    textbooks,
+    syllabusRemarks,
   ];
   @override
   String get aliasedName => _alias ?? entityName;
@@ -10779,6 +10855,34 @@ class $CourseOfferingOverviewsView
       withdrawn: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}withdrawn'],
+      ),
+      fetchedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}fetched_at'],
+      ),
+      syllabusUpdatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}syllabus_updated_at'],
+      ),
+      objective: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}objective'],
+      ),
+      weeklyPlan: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}weekly_plan'],
+      ),
+      evaluation: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}evaluation'],
+      ),
+      textbooks: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}textbooks'],
+      ),
+      syllabusRemarks: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}syllabus_remarks'],
       ),
     );
   }
@@ -10900,6 +11004,56 @@ class $CourseOfferingOverviewsView
     true,
     generatedAs: GeneratedAs(courseOfferings.withdrawn, false),
     type: DriftSqlType.int,
+  );
+  late final GeneratedColumn<DateTime> fetchedAt = GeneratedColumn<DateTime>(
+    'fetched_at',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(courseOfferings.fetchedAt, false),
+    type: DriftSqlType.dateTime,
+  );
+  late final GeneratedColumn<DateTime> syllabusUpdatedAt =
+      GeneratedColumn<DateTime>(
+        'syllabus_updated_at',
+        aliasedName,
+        true,
+        generatedAs: GeneratedAs(courseOfferings.syllabusUpdatedAt, false),
+        type: DriftSqlType.dateTime,
+      );
+  late final GeneratedColumn<String> objective = GeneratedColumn<String>(
+    'objective',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(courseOfferings.objective, false),
+    type: DriftSqlType.string,
+  );
+  late final GeneratedColumn<String> weeklyPlan = GeneratedColumn<String>(
+    'weekly_plan',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(courseOfferings.weeklyPlan, false),
+    type: DriftSqlType.string,
+  );
+  late final GeneratedColumn<String> evaluation = GeneratedColumn<String>(
+    'evaluation',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(courseOfferings.evaluation, false),
+    type: DriftSqlType.string,
+  );
+  late final GeneratedColumn<String> textbooks = GeneratedColumn<String>(
+    'textbooks',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(courseOfferings.textbooks, false),
+    type: DriftSqlType.string,
+  );
+  late final GeneratedColumn<String> syllabusRemarks = GeneratedColumn<String>(
+    'syllabus_remarks',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(courseOfferings.syllabusRemarks, false),
+    type: DriftSqlType.string,
   );
   @override
   $CourseOfferingOverviewsView createAlias(String alias) {

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -10502,6 +10502,424 @@ class CalendarEventsCompanion extends UpdateCompanion<CalendarEvent> {
   }
 }
 
+class CourseOfferingOverview extends DataClass {
+  final int id;
+  final String? courseCode;
+  final int semester;
+  final String? number;
+  final String? nameZh;
+  final String? nameEn;
+  final double? credits;
+  final int? hours;
+  final int? phase;
+  final CourseType? courseType;
+  final String? status;
+  final String? language;
+  final String? remarks;
+  final int? enrolled;
+  final int? withdrawn;
+  const CourseOfferingOverview({
+    required this.id,
+    this.courseCode,
+    required this.semester,
+    this.number,
+    this.nameZh,
+    this.nameEn,
+    this.credits,
+    this.hours,
+    this.phase,
+    this.courseType,
+    this.status,
+    this.language,
+    this.remarks,
+    this.enrolled,
+    this.withdrawn,
+  });
+  factory CourseOfferingOverview.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return CourseOfferingOverview(
+      id: serializer.fromJson<int>(json['id']),
+      courseCode: serializer.fromJson<String?>(json['courseCode']),
+      semester: serializer.fromJson<int>(json['semester']),
+      number: serializer.fromJson<String?>(json['number']),
+      nameZh: serializer.fromJson<String?>(json['nameZh']),
+      nameEn: serializer.fromJson<String?>(json['nameEn']),
+      credits: serializer.fromJson<double?>(json['credits']),
+      hours: serializer.fromJson<int?>(json['hours']),
+      phase: serializer.fromJson<int?>(json['phase']),
+      courseType: $CourseOfferingsTable.$convertercourseTypen.fromJson(
+        serializer.fromJson<String?>(json['courseType']),
+      ),
+      status: serializer.fromJson<String?>(json['status']),
+      language: serializer.fromJson<String?>(json['language']),
+      remarks: serializer.fromJson<String?>(json['remarks']),
+      enrolled: serializer.fromJson<int?>(json['enrolled']),
+      withdrawn: serializer.fromJson<int?>(json['withdrawn']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'courseCode': serializer.toJson<String?>(courseCode),
+      'semester': serializer.toJson<int>(semester),
+      'number': serializer.toJson<String?>(number),
+      'nameZh': serializer.toJson<String?>(nameZh),
+      'nameEn': serializer.toJson<String?>(nameEn),
+      'credits': serializer.toJson<double?>(credits),
+      'hours': serializer.toJson<int?>(hours),
+      'phase': serializer.toJson<int?>(phase),
+      'courseType': serializer.toJson<String?>(
+        $CourseOfferingsTable.$convertercourseTypen.toJson(courseType),
+      ),
+      'status': serializer.toJson<String?>(status),
+      'language': serializer.toJson<String?>(language),
+      'remarks': serializer.toJson<String?>(remarks),
+      'enrolled': serializer.toJson<int?>(enrolled),
+      'withdrawn': serializer.toJson<int?>(withdrawn),
+    };
+  }
+
+  CourseOfferingOverview copyWith({
+    int? id,
+    Value<String?> courseCode = const Value.absent(),
+    int? semester,
+    Value<String?> number = const Value.absent(),
+    Value<String?> nameZh = const Value.absent(),
+    Value<String?> nameEn = const Value.absent(),
+    Value<double?> credits = const Value.absent(),
+    Value<int?> hours = const Value.absent(),
+    Value<int?> phase = const Value.absent(),
+    Value<CourseType?> courseType = const Value.absent(),
+    Value<String?> status = const Value.absent(),
+    Value<String?> language = const Value.absent(),
+    Value<String?> remarks = const Value.absent(),
+    Value<int?> enrolled = const Value.absent(),
+    Value<int?> withdrawn = const Value.absent(),
+  }) => CourseOfferingOverview(
+    id: id ?? this.id,
+    courseCode: courseCode.present ? courseCode.value : this.courseCode,
+    semester: semester ?? this.semester,
+    number: number.present ? number.value : this.number,
+    nameZh: nameZh.present ? nameZh.value : this.nameZh,
+    nameEn: nameEn.present ? nameEn.value : this.nameEn,
+    credits: credits.present ? credits.value : this.credits,
+    hours: hours.present ? hours.value : this.hours,
+    phase: phase.present ? phase.value : this.phase,
+    courseType: courseType.present ? courseType.value : this.courseType,
+    status: status.present ? status.value : this.status,
+    language: language.present ? language.value : this.language,
+    remarks: remarks.present ? remarks.value : this.remarks,
+    enrolled: enrolled.present ? enrolled.value : this.enrolled,
+    withdrawn: withdrawn.present ? withdrawn.value : this.withdrawn,
+  );
+  @override
+  String toString() {
+    return (StringBuffer('CourseOfferingOverview(')
+          ..write('id: $id, ')
+          ..write('courseCode: $courseCode, ')
+          ..write('semester: $semester, ')
+          ..write('number: $number, ')
+          ..write('nameZh: $nameZh, ')
+          ..write('nameEn: $nameEn, ')
+          ..write('credits: $credits, ')
+          ..write('hours: $hours, ')
+          ..write('phase: $phase, ')
+          ..write('courseType: $courseType, ')
+          ..write('status: $status, ')
+          ..write('language: $language, ')
+          ..write('remarks: $remarks, ')
+          ..write('enrolled: $enrolled, ')
+          ..write('withdrawn: $withdrawn')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    courseCode,
+    semester,
+    number,
+    nameZh,
+    nameEn,
+    credits,
+    hours,
+    phase,
+    courseType,
+    status,
+    language,
+    remarks,
+    enrolled,
+    withdrawn,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CourseOfferingOverview &&
+          other.id == this.id &&
+          other.courseCode == this.courseCode &&
+          other.semester == this.semester &&
+          other.number == this.number &&
+          other.nameZh == this.nameZh &&
+          other.nameEn == this.nameEn &&
+          other.credits == this.credits &&
+          other.hours == this.hours &&
+          other.phase == this.phase &&
+          other.courseType == this.courseType &&
+          other.status == this.status &&
+          other.language == this.language &&
+          other.remarks == this.remarks &&
+          other.enrolled == this.enrolled &&
+          other.withdrawn == this.withdrawn);
+}
+
+class $CourseOfferingOverviewsView
+    extends ViewInfo<$CourseOfferingOverviewsView, CourseOfferingOverview>
+    implements HasResultSet {
+  final String? _alias;
+  @override
+  final _$AppDatabase attachedDatabase;
+  $CourseOfferingOverviewsView(this.attachedDatabase, [this._alias]);
+  $CourseOfferingsTable get courseOfferings =>
+      attachedDatabase.courseOfferings.createAlias('t0');
+  $CoursesTable get courses => attachedDatabase.courses.createAlias('t1');
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    courseCode,
+    semester,
+    number,
+    nameZh,
+    nameEn,
+    credits,
+    hours,
+    phase,
+    courseType,
+    status,
+    language,
+    remarks,
+    enrolled,
+    withdrawn,
+  ];
+  @override
+  String get aliasedName => _alias ?? entityName;
+  @override
+  String get entityName => 'course_offering_overviews';
+  @override
+  Map<SqlDialect, String>? get createViewStatements => null;
+  @override
+  $CourseOfferingOverviewsView get asDslTable => this;
+  @override
+  CourseOfferingOverview map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return CourseOfferingOverview(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      courseCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}course_code'],
+      ),
+      semester: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}semester'],
+      )!,
+      number: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}number'],
+      ),
+      nameZh: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name_zh'],
+      ),
+      nameEn: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name_en'],
+      ),
+      credits: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}credits'],
+      ),
+      hours: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}hours'],
+      ),
+      phase: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}phase'],
+      ),
+      courseType: $CourseOfferingsTable.$convertercourseTypen.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}course_type'],
+        ),
+      ),
+      status: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}status'],
+      ),
+      language: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}language'],
+      ),
+      remarks: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}remarks'],
+      ),
+      enrolled: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}enrolled'],
+      ),
+      withdrawn: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}withdrawn'],
+      ),
+    );
+  }
+
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    generatedAs: GeneratedAs(courseOfferings.id, false),
+    type: DriftSqlType.int,
+  );
+  late final GeneratedColumn<String> courseCode = GeneratedColumn<String>(
+    'course_code',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(courseOfferings.courseCode, false),
+    type: DriftSqlType.string,
+  );
+  late final GeneratedColumn<int> semester = GeneratedColumn<int>(
+    'semester',
+    aliasedName,
+    false,
+    generatedAs: GeneratedAs(courseOfferings.semester, false),
+    type: DriftSqlType.int,
+  );
+  late final GeneratedColumn<String> number = GeneratedColumn<String>(
+    'number',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(courseOfferings.number, false),
+    type: DriftSqlType.string,
+  );
+  late final GeneratedColumn<String> nameZh = GeneratedColumn<String>(
+    'name_zh',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(
+      coalesce([courseOfferings.nameZh, courses.nameZh]),
+      false,
+    ),
+    type: DriftSqlType.string,
+  );
+  late final GeneratedColumn<String> nameEn = GeneratedColumn<String>(
+    'name_en',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(
+      coalesce([courseOfferings.nameEn, courses.nameEn]),
+      false,
+    ),
+    type: DriftSqlType.string,
+  );
+  late final GeneratedColumn<double> credits = GeneratedColumn<double>(
+    'credits',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(
+      coalesce([courseOfferings.credits, courses.credits]),
+      false,
+    ),
+    type: DriftSqlType.double,
+  );
+  late final GeneratedColumn<int> hours = GeneratedColumn<int>(
+    'hours',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(
+      coalesce([courseOfferings.hours, courses.hours]),
+      false,
+    ),
+    type: DriftSqlType.int,
+  );
+  late final GeneratedColumn<int> phase = GeneratedColumn<int>(
+    'phase',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(courseOfferings.phase, false),
+    type: DriftSqlType.int,
+  );
+  late final GeneratedColumnWithTypeConverter<CourseType?, String> courseType =
+      GeneratedColumn<String>(
+        'course_type',
+        aliasedName,
+        true,
+        generatedAs: GeneratedAs(courseOfferings.courseType, false),
+        type: DriftSqlType.string,
+      ).withConverter<CourseType?>($CourseOfferingsTable.$convertercourseTypen);
+  late final GeneratedColumn<String> status = GeneratedColumn<String>(
+    'status',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(courseOfferings.status, false),
+    type: DriftSqlType.string,
+  );
+  late final GeneratedColumn<String> language = GeneratedColumn<String>(
+    'language',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(courseOfferings.language, false),
+    type: DriftSqlType.string,
+  );
+  late final GeneratedColumn<String> remarks = GeneratedColumn<String>(
+    'remarks',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(courseOfferings.remarks, false),
+    type: DriftSqlType.string,
+  );
+  late final GeneratedColumn<int> enrolled = GeneratedColumn<int>(
+    'enrolled',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(courseOfferings.enrolled, false),
+    type: DriftSqlType.int,
+  );
+  late final GeneratedColumn<int> withdrawn = GeneratedColumn<int>(
+    'withdrawn',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(courseOfferings.withdrawn, false),
+    type: DriftSqlType.int,
+  );
+  @override
+  $CourseOfferingOverviewsView createAlias(String alias) {
+    return $CourseOfferingOverviewsView(attachedDatabase, alias);
+  }
+
+  @override
+  Query? get query =>
+      (attachedDatabase.selectOnly(courseOfferings)..addColumns($columns)).join(
+        [
+          leftOuterJoin(
+            courses,
+            courses.code.equalsExp(courseOfferings.courseCode),
+          ),
+        ],
+      );
+  @override
+  Set<String> get readTables => const {'course_offerings', 'courses'};
+}
+
 class CourseTableSlot extends DataClass {
   final int id;
   final String? number;
@@ -11674,6 +12092,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $UserSemesterRankingsTable userSemesterRankings =
       $UserSemesterRankingsTable(this);
   late final $CalendarEventsTable calendarEvents = $CalendarEventsTable(this);
+  late final $CourseOfferingOverviewsView courseOfferingOverviews =
+      $CourseOfferingOverviewsView(this);
   late final $CourseTableSlotsView courseTableSlots = $CourseTableSlotsView(
     this,
   );
@@ -11746,6 +12166,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     userSemesterSummaryCadreRoles,
     userSemesterRankings,
     calendarEvents,
+    courseOfferingOverviews,
     courseTableSlots,
     scoreDetails,
     userAcademicSummaries,

--- a/lib/database/views.dart
+++ b/lib/database/views.dart
@@ -89,15 +89,16 @@ abstract class ScoreDetails extends View {
 
 /// Flat view of a course offering joined with its catalog entry.
 ///
-/// One row per [CourseOfferings] row. Falls back to catalog values for
-/// name/credits/hours when the offering's own values are null, matching
-/// [CourseTableSlots]. The repository composes this row with separate
-/// queries for the offering's many-side relations (schedule slots,
+/// One row per [CourseOfferings] row. The repository composes this row with
+/// separate queries for the offering's many-side relations (schedule slots,
 /// teachers, classes) into a full detail record.
 abstract class CourseOfferingOverviews extends View {
   CourseOfferings get courseOfferings;
   Courses get courses;
 
+  /// Prefers the offering's timetable value; falls back to the catalog value
+  /// when the offering's value is null. Always returns the offering's name in
+  /// Chinese, since [CourseOfferings.nameZh] is NOT NULL.
   Expression<String> get nameZh =>
       coalesce([courseOfferings.nameZh, courses.nameZh]);
   Expression<String> get nameEn =>

--- a/lib/database/views.dart
+++ b/lib/database/views.dart
@@ -125,6 +125,13 @@ abstract class CourseOfferingOverviews extends View {
         courseOfferings.remarks,
         courseOfferings.enrolled,
         courseOfferings.withdrawn,
+        courseOfferings.fetchedAt,
+        courseOfferings.syllabusUpdatedAt,
+        courseOfferings.objective,
+        courseOfferings.weeklyPlan,
+        courseOfferings.evaluation,
+        courseOfferings.textbooks,
+        courseOfferings.syllabusRemarks,
       ]).from(courseOfferings).join([
         leftOuterJoin(
           courses,

--- a/lib/database/views.dart
+++ b/lib/database/views.dart
@@ -87,6 +87,51 @@ abstract class ScoreDetails extends View {
       ]);
 }
 
+/// Flat view of a course offering joined with its catalog entry.
+///
+/// One row per [CourseOfferings] row. Falls back to catalog values for
+/// name/credits/hours when the offering's own values are null, matching
+/// [CourseTableSlots]. The repository composes this row with separate
+/// queries for the offering's many-side relations (schedule slots,
+/// teachers, classes) into a full detail record.
+abstract class CourseOfferingOverviews extends View {
+  CourseOfferings get courseOfferings;
+  Courses get courses;
+
+  Expression<String> get nameZh =>
+      coalesce([courseOfferings.nameZh, courses.nameZh]);
+  Expression<String> get nameEn =>
+      coalesce([courseOfferings.nameEn, courses.nameEn]);
+  Expression<double> get credits =>
+      coalesce([courseOfferings.credits, courses.credits]);
+  Expression<int> get hours => coalesce([courseOfferings.hours, courses.hours]);
+
+  @override
+  Query as() =>
+      select([
+        courseOfferings.id,
+        courseOfferings.courseCode,
+        courseOfferings.semester,
+        courseOfferings.number,
+        nameZh,
+        nameEn,
+        credits,
+        hours,
+        courseOfferings.phase,
+        courseOfferings.courseType,
+        courseOfferings.status,
+        courseOfferings.language,
+        courseOfferings.remarks,
+        courseOfferings.enrolled,
+        courseOfferings.withdrawn,
+      ]).from(courseOfferings).join([
+        leftOuterJoin(
+          courses,
+          courses.code.equalsExp(courseOfferings.courseCode),
+        ),
+      ]);
+}
+
 /// Flat view of schedule slots with course offering and course metadata.
 ///
 /// One row per `(dayOfWeek, period)` slot. Repository groups these rows

--- a/lib/repositories/course_repository.dart
+++ b/lib/repositories/course_repository.dart
@@ -628,41 +628,59 @@ class CourseRepository {
   /// junctions. Emits `null` when the offering is missing; the stream stays
   /// open so a later insert can surface it.
   ///
-  /// Refresh behavior, gated by [CourseOfferings.fetchedAt]:
+  /// Refresh behavior on the first non-null emission, gated by
+  /// [CourseOfferings.fetchedAt]:
   /// - **Never fetched** (`fetchedAt == null`): blocks on [refreshCourseOffering]
-  ///   before the first emission so consumers don't render null syllabus fields
-  ///   (`courseType`, `enrolled`, `withdrawn`, `remarks`, …). If the refresh
-  ///   fails, falls through and emits the cached row (with whatever's there).
-  /// - **Previously fetched**: emits cached data immediately and fires
+  ///   before yielding so consumers don't render null syllabus fields
+  ///   (`courseType`, `enrolled`, `withdrawn`, `syllabusRemarks`, …). If the
+  ///   refresh fails, falls through and emits the cached row (with whatever's
+  ///   there).
+  /// - **Previously fetched**: yields cached data immediately and fires
   ///   [refreshCourseOffering] in the background. When that write lands, the
   ///   view's `.watch()` re-emits with fresh fields.
+  ///
+  /// The refresh decision happens inside the stream loop (rather than as a
+  /// pre-check), so an offering that is inserted *after* subscription still
+  /// gets the blocking first-load behavior on its first appearance.
   Stream<CourseOfferingDetail?> watchCourseOffering(int id) async* {
-    final raw = await (_database.select(
-      _database.courseOfferings,
-    )..where((o) => o.id.equals(id))).getSingleOrNull();
-    if (raw?.fetchedAt == null) {
-      try {
-        await refreshCourseOffering(id);
-      } catch (_) {
-        // Absorb: fall through and emit whatever's in the DB.
-      }
-    } else {
-      unawaited(refreshCourseOffering(id).catchError((_) {}));
-    }
-
     final query = _database.select(_database.courseOfferingOverviews)
       ..where((o) => o.id.equals(id));
 
+    var refreshTriggered = false;
     await for (final overview in query.watchSingleOrNull()) {
       if (overview == null) {
         yield null;
         continue;
       }
+
+      if (!refreshTriggered) {
+        refreshTriggered = true;
+        final raw = await (_database.select(
+          _database.courseOfferings,
+        )..where((o) => o.id.equals(id))).getSingleOrNull();
+        if (raw?.fetchedAt == null) {
+          try {
+            await refreshCourseOffering(id);
+            // Wait for the resulting DB write to re-emit a populated row.
+            continue;
+          } catch (_) {
+            // Absorb: fall through and emit the cached row below.
+          }
+        } else {
+          unawaited(refreshCourseOffering(id).catchError((_) {}));
+        }
+      }
+
+      final (schedule, teachers, classes) = await (
+        _readOfferingSchedule(id),
+        _readOfferingTeachers(id),
+        _readOfferingClasses(id),
+      ).wait;
       yield (
         overview: overview,
-        schedule: await _readOfferingSchedule(id),
-        teachers: await _readOfferingTeachers(id),
-        classes: await _readOfferingClasses(id),
+        schedule: schedule,
+        teachers: teachers,
+        classes: classes,
       );
     }
   }

--- a/lib/repositories/course_repository.dart
+++ b/lib/repositories/course_repository.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: unused_field
 
+import 'dart:async';
 import 'dart:math';
 
 import 'package:drift/drift.dart';
@@ -253,7 +254,7 @@ class CourseRepository {
   /// if data is empty or stale. The stream re-emits automatically when the
   /// DB is updated.
   ///
-  /// Use [getCourseOffering] for related data (teachers, classrooms, schedules).
+  /// Use [watchCourseOffering] for related data (teachers, classrooms, schedules).
   Stream<CourseTableData> watchCourseTable({required int semesterId}) async* {
     const ttl = Duration(days: 3);
 
@@ -620,67 +621,103 @@ class CourseRepository {
     );
   }
 
-  /// Gets a course offering with related data (teachers, classrooms, schedules).
+  /// Watches a course offering's joined detail (overview + schedule + teachers
+  /// + classes).
   ///
   /// Assumes [refreshCourseTable] has already populated the offering and its
-  /// junctions. Returns `null` if not found.
+  /// junctions. Emits `null` when the offering is missing; the stream stays
+  /// open so a later insert can surface it.
   ///
-  /// If the offering has a `syllabusId` and its syllabus fields are missing or
-  /// stale (TTL 3 days, tracked via [CourseOfferings]'s `fetchedAt` from
-  /// [Fetchable]), this lazily fetches the syllabus through
-  /// [CourseService.getSyllabus] and persists `courseType` / `enrolled` /
-  /// `withdrawn` / syllabus content fields. Network errors are absorbed —
-  /// whatever's in the DB is still returned.
-  Future<CourseOfferingDetail?> getCourseOffering(int id) async {
-    const syllabusTtl = Duration(days: 3);
-
+  /// Refresh behavior, gated by [CourseOfferings.fetchedAt]:
+  /// - **Never fetched** (`fetchedAt == null`): blocks on [refreshCourseOffering]
+  ///   before the first emission so consumers don't render null syllabus fields
+  ///   (`courseType`, `enrolled`, `withdrawn`, `remarks`, …). If the refresh
+  ///   fails, falls through and emits the cached row (with whatever's there).
+  /// - **Previously fetched**: emits cached data immediately and fires
+  ///   [refreshCourseOffering] in the background. When that write lands, the
+  ///   view's `.watch()` re-emits with fresh fields.
+  Stream<CourseOfferingDetail?> watchCourseOffering(int id) async* {
     final raw = await (_database.select(
       _database.courseOfferings,
     )..where((o) => o.id.equals(id))).getSingleOrNull();
-    if (raw == null) return null;
-
-    final syllabusAge = switch (raw.fetchedAt) {
-      final t? => DateTime.now().difference(t),
-      null => syllabusTtl,
-    };
-    if (raw.syllabusId case final syllabusId?
-        when raw.number != null && syllabusAge >= syllabusTtl) {
+    if (raw?.fetchedAt == null) {
       try {
-        final syllabus = await _authRepository.withAuth(
-          () => _courseService.getSyllabus(
-            courseNumber: raw.number!,
-            syllabusId: syllabusId,
-          ),
-          sso: [.courseService],
-        );
-        await (_database.update(
-          _database.courseOfferings,
-        )..where((o) => o.id.equals(id))).write(
-          CourseOfferingsCompanion(
-            courseType: Value(syllabus.type),
-            enrolled: Value(syllabus.enrolled),
-            withdrawn: Value(syllabus.withdrawn),
-            syllabusUpdatedAt: Value(syllabus.lastUpdated),
-            objective: Value(syllabus.objective),
-            weeklyPlan: Value(syllabus.weeklyPlan),
-            evaluation: Value(syllabus.evaluation),
-            textbooks: Value(syllabus.materials),
-            syllabusRemarks: Value(syllabus.remarks),
-            fetchedAt: Value(DateTime.now()),
-          ),
-        );
+        await refreshCourseOffering(id);
       } catch (_) {
-        // Absorb: stale or empty syllabus data is preferable to failing the
-        // whole detail load (network errors, parse failures, etc.).
+        // Absorb: fall through and emit whatever's in the DB.
       }
+    } else {
+      unawaited(refreshCourseOffering(id).catchError((_) {}));
     }
 
-    final overview = await (_database.select(
-      _database.courseOfferingOverviews,
-    )..where((o) => o.id.equals(id))).getSingleOrNull();
-    if (overview == null) return null;
+    final query = _database.select(_database.courseOfferingOverviews)
+      ..where((o) => o.id.equals(id));
 
-    final scheduleRows =
+    await for (final overview in query.watchSingleOrNull()) {
+      if (overview == null) {
+        yield null;
+        continue;
+      }
+      yield (
+        overview: overview,
+        schedule: await _readOfferingSchedule(id),
+        teachers: await _readOfferingTeachers(id),
+        classes: await _readOfferingClasses(id),
+      );
+    }
+  }
+
+  /// Fetches a course offering's syllabus from the network and writes it to
+  /// the [CourseOfferings] row.
+  ///
+  /// The [watchCourseOffering] stream automatically emits the updated value.
+  /// Network errors propagate to the caller. No-ops when the offering is
+  /// missing or has no `syllabusId` / `number`.
+  Future<void> refreshCourseOffering(int id) async {
+    final raw = await (_database.select(
+      _database.courseOfferings,
+    )..where((o) => o.id.equals(id))).getSingleOrNull();
+    if (raw == null) return;
+    if (raw.syllabusId == null || raw.number == null) return;
+
+    final syllabus = await _authRepository.withAuth(
+      () => _courseService.getSyllabus(
+        courseNumber: raw.number!,
+        syllabusId: raw.syllabusId!,
+      ),
+      sso: [.courseService],
+    );
+
+    await (_database.update(
+      _database.courseOfferings,
+    )..where((o) => o.id.equals(id))).write(
+      CourseOfferingsCompanion(
+        courseType: Value(syllabus.type),
+        enrolled: Value(syllabus.enrolled),
+        withdrawn: Value(syllabus.withdrawn),
+        syllabusUpdatedAt: Value(syllabus.lastUpdated),
+        objective: Value(syllabus.objective),
+        weeklyPlan: Value(syllabus.weeklyPlan),
+        evaluation: Value(syllabus.evaluation),
+        textbooks: Value(syllabus.materials),
+        syllabusRemarks: Value(syllabus.remarks),
+        fetchedAt: Value(DateTime.now()),
+      ),
+    );
+  }
+
+  Future<
+    List<
+      ({
+        DayOfWeek day,
+        Period period,
+        String? classroomNameZh,
+        String? classroomNameEn,
+      })
+    >
+  >
+  _readOfferingSchedule(int id) async {
+    final rows =
         await (_database.select(_database.schedules).join([
                 leftOuterJoin(
                   _database.classrooms,
@@ -695,8 +732,20 @@ class CourseRepository {
                 OrderingTerm.asc(_database.schedules.period),
               ]))
             .get();
+    return [
+      for (final row in rows)
+        (
+          day: row.readTable(_database.schedules).dayOfWeek,
+          period: row.readTable(_database.schedules).period,
+          classroomNameZh: row.readTableOrNull(_database.classrooms)?.nameZh,
+          classroomNameEn: row.readTableOrNull(_database.classrooms)?.nameEn,
+        ),
+    ];
+  }
 
-    final teacherRows =
+  Future<List<({String code, String nameZh, String? nameEn})>>
+  _readOfferingTeachers(int id) async {
+    final rows =
         await (_database.select(_database.courseOfferingTeachers).join([
               innerJoin(
                 _database.teacherSemesters,
@@ -714,8 +763,19 @@ class CourseRepository {
               _database.courseOfferingTeachers.courseOffering.equals(id),
             ))
             .get();
+    return [
+      for (final row in rows)
+        (
+          code: row.readTable(_database.teachers).code,
+          nameZh: row.readTable(_database.teachers).nameZh,
+          nameEn: row.readTable(_database.teachers).nameEn,
+        ),
+    ];
+  }
 
-    final classRows =
+  Future<List<({String code, String nameZh, String? nameEn})>>
+  _readOfferingClasses(int id) async {
+    final rows =
         await (_database.select(_database.courseOfferingClasses).join([
                 innerJoin(
                   _database.classes,
@@ -727,35 +787,14 @@ class CourseRepository {
               ..where(_database.courseOfferingClasses.courseOffering.equals(id))
               ..orderBy([OrderingTerm.asc(_database.classes.code)]))
             .get();
-
-    return (
-      overview: overview,
-      schedule: [
-        for (final row in scheduleRows)
-          (
-            day: row.readTable(_database.schedules).dayOfWeek,
-            period: row.readTable(_database.schedules).period,
-            classroomNameZh: row.readTableOrNull(_database.classrooms)?.nameZh,
-            classroomNameEn: row.readTableOrNull(_database.classrooms)?.nameEn,
-          ),
-      ],
-      teachers: [
-        for (final row in teacherRows)
-          (
-            code: row.readTable(_database.teachers).code,
-            nameZh: row.readTable(_database.teachers).nameZh,
-            nameEn: row.readTable(_database.teachers).nameEn,
-          ),
-      ],
-      classes: [
-        for (final row in classRows)
-          (
-            code: row.readTable(_database.classes).code,
-            nameZh: row.readTable(_database.classes).nameZh,
-            nameEn: row.readTable(_database.classes).nameEn,
-          ),
-      ],
-    );
+    return [
+      for (final row in rows)
+        (
+          code: row.readTable(_database.classes).code,
+          nameZh: row.readTable(_database.classes).nameZh,
+          nameEn: row.readTable(_database.classes).nameEn,
+        ),
+    ];
   }
 
   /// Gets course catalog information by code.

--- a/lib/repositories/course_repository.dart
+++ b/lib/repositories/course_repository.dart
@@ -14,6 +14,28 @@ import 'package:tattoo/services/i_school_plus/i_school_plus_service.dart';
 import 'package:tattoo/services/portal/portal_service.dart';
 import 'package:tattoo/utils/localized.dart';
 
+/// Detailed data for a single course offering, sufficient to populate the
+/// course-table detail bottom sheet. Composes the [CourseOfferingOverview]
+/// view row (single-value offering+catalog fields) with the offering's
+/// many-side relations (schedule slots, teachers, classes).
+///
+/// Future iSchool-sourced lists (roster, assignments) will be added as
+/// additional fields on this record.
+typedef CourseOfferingDetail = ({
+  CourseOfferingOverview overview,
+  List<
+    ({
+      DayOfWeek day,
+      Period period,
+      String? classroomNameZh,
+      String? classroomNameEn,
+    })
+  >
+  schedule,
+  List<({String code, String nameZh, String? nameEn})> teachers,
+  List<({String code, String nameZh, String? nameEn})> classes,
+});
+
 /// Data for a single cell in the course table grid.
 typedef CourseTableCellData = ({
   /// [CourseOfferings] primary key, for navigating to detail view.
@@ -600,9 +622,140 @@ class CourseRepository {
 
   /// Gets a course offering with related data (teachers, classrooms, schedules).
   ///
-  /// Returns `null` if not found.
-  Future<CourseOffering?> getCourseOffering(int id) async {
-    throw UnimplementedError();
+  /// Assumes [refreshCourseTable] has already populated the offering and its
+  /// junctions. Returns `null` if not found.
+  ///
+  /// If the offering has a `syllabusId` and its syllabus fields are missing or
+  /// stale (TTL 3 days, tracked via [CourseOfferings]'s `fetchedAt` from
+  /// [Fetchable]), this lazily fetches the syllabus through
+  /// [CourseService.getSyllabus] and persists `courseType` / `enrolled` /
+  /// `withdrawn` / syllabus content fields. Network errors are absorbed —
+  /// whatever's in the DB is still returned.
+  Future<CourseOfferingDetail?> getCourseOffering(int id) async {
+    const syllabusTtl = Duration(days: 3);
+
+    final raw = await (_database.select(
+      _database.courseOfferings,
+    )..where((o) => o.id.equals(id))).getSingleOrNull();
+    if (raw == null) return null;
+
+    final syllabusAge = switch (raw.fetchedAt) {
+      final t? => DateTime.now().difference(t),
+      null => syllabusTtl,
+    };
+    if (raw.syllabusId case final syllabusId?
+        when raw.number != null && syllabusAge >= syllabusTtl) {
+      try {
+        final syllabus = await _authRepository.withAuth(
+          () => _courseService.getSyllabus(
+            courseNumber: raw.number!,
+            syllabusId: syllabusId,
+          ),
+          sso: [.courseService],
+        );
+        await (_database.update(
+          _database.courseOfferings,
+        )..where((o) => o.id.equals(id))).write(
+          CourseOfferingsCompanion(
+            courseType: Value(syllabus.type),
+            enrolled: Value(syllabus.enrolled),
+            withdrawn: Value(syllabus.withdrawn),
+            syllabusUpdatedAt: Value(syllabus.lastUpdated),
+            objective: Value(syllabus.objective),
+            weeklyPlan: Value(syllabus.weeklyPlan),
+            evaluation: Value(syllabus.evaluation),
+            textbooks: Value(syllabus.materials),
+            syllabusRemarks: Value(syllabus.remarks),
+            fetchedAt: Value(DateTime.now()),
+          ),
+        );
+      } catch (_) {
+        // Absorb: stale or empty syllabus data is preferable to failing the
+        // whole detail load (network errors, parse failures, etc.).
+      }
+    }
+
+    final overview = await (_database.select(
+      _database.courseOfferingOverviews,
+    )..where((o) => o.id.equals(id))).getSingleOrNull();
+    if (overview == null) return null;
+
+    final scheduleRows =
+        await (_database.select(_database.schedules).join([
+                leftOuterJoin(
+                  _database.classrooms,
+                  _database.classrooms.id.equalsExp(
+                    _database.schedules.classroom,
+                  ),
+                ),
+              ])
+              ..where(_database.schedules.courseOffering.equals(id))
+              ..orderBy([
+                OrderingTerm.asc(_database.schedules.dayOfWeek),
+                OrderingTerm.asc(_database.schedules.period),
+              ]))
+            .get();
+
+    final teacherRows =
+        await (_database.select(_database.courseOfferingTeachers).join([
+              innerJoin(
+                _database.teacherSemesters,
+                _database.teacherSemesters.id.equalsExp(
+                  _database.courseOfferingTeachers.teacherSemester,
+                ),
+              ),
+              innerJoin(
+                _database.teachers,
+                _database.teachers.id.equalsExp(
+                  _database.teacherSemesters.teacher,
+                ),
+              ),
+            ])..where(
+              _database.courseOfferingTeachers.courseOffering.equals(id),
+            ))
+            .get();
+
+    final classRows =
+        await (_database.select(_database.courseOfferingClasses).join([
+                innerJoin(
+                  _database.classes,
+                  _database.classes.id.equalsExp(
+                    _database.courseOfferingClasses.classEntity,
+                  ),
+                ),
+              ])
+              ..where(_database.courseOfferingClasses.courseOffering.equals(id))
+              ..orderBy([OrderingTerm.asc(_database.classes.code)]))
+            .get();
+
+    return (
+      overview: overview,
+      schedule: [
+        for (final row in scheduleRows)
+          (
+            day: row.readTable(_database.schedules).dayOfWeek,
+            period: row.readTable(_database.schedules).period,
+            classroomNameZh: row.readTableOrNull(_database.classrooms)?.nameZh,
+            classroomNameEn: row.readTableOrNull(_database.classrooms)?.nameEn,
+          ),
+      ],
+      teachers: [
+        for (final row in teacherRows)
+          (
+            code: row.readTable(_database.teachers).code,
+            nameZh: row.readTable(_database.teachers).nameZh,
+            nameEn: row.readTable(_database.teachers).nameEn,
+          ),
+      ],
+      classes: [
+        for (final row in classRows)
+          (
+            code: row.readTable(_database.classes).code,
+            nameZh: row.readTable(_database.classes).nameZh,
+            nameEn: row.readTable(_database.classes).nameEn,
+          ),
+      ],
+    );
   }
 
   /// Gets course catalog information by code.
@@ -659,13 +812,6 @@ class CourseRepository {
     return (_database.select(
       _database.courses,
     )..where((c) => c.id.equals(courseId))).getSingle();
-  }
-
-  /// Gets detailed course catalog information.
-  ///
-  /// Throws [Exception] on network failure.
-  Future<Course> getCourseDetails(String courseId) async {
-    throw UnimplementedError();
   }
 
   /// Gets course materials (files, recordings, etc.) from I-School Plus.

--- a/lib/screens/main/course_table/course_table_providers.dart
+++ b/lib/screens/main/course_table/course_table_providers.dart
@@ -28,8 +28,10 @@ final courseTableProvider = StreamProvider.autoDispose
 
 /// Provides the detailed data for a single course offering.
 ///
-/// Emits cached DB data immediately, then re-emits when the background
-/// syllabus refresh lands. Errors during the background refresh are absorbed
+/// On a previously-fetched offering, emits cached DB data immediately and
+/// re-emits when the background syllabus refresh lands. On an offering with
+/// no syllabus cached yet, awaits the first refresh before emitting (to
+/// avoid rendering null syllabus fields). Errors during refresh are absorbed
 /// — the stream stays on cached data.
 final courseOfferingProvider = StreamProvider.autoDispose
     .family<CourseOfferingDetail?, int>((ref, offeringId) {

--- a/lib/screens/main/course_table/course_table_providers.dart
+++ b/lib/screens/main/course_table/course_table_providers.dart
@@ -25,3 +25,15 @@ final courseTableProvider = StreamProvider.autoDispose
           .watch(courseRepositoryProvider)
           .watchCourseTable(semesterId: semesterId);
     });
+
+/// Provides the detailed data for a single course offering.
+///
+/// Emits cached DB data immediately, then re-emits when the background
+/// syllabus refresh lands. Errors during the background refresh are absorbed
+/// — the stream stays on cached data.
+final courseOfferingProvider = StreamProvider.autoDispose
+    .family<CourseOfferingDetail?, int>((ref, offeringId) {
+      return ref
+          .watch(courseRepositoryProvider)
+          .watchCourseOffering(offeringId);
+    });


### PR DESCRIPTION
Closes #228.

## Summary

- Replace the redundant `getCourseDetails(String)` stub (overlapped with `getCourse` in everything but name) with a streaming `watchCourseOffering(int id)` / `refreshCourseOffering(int id)` pair — the offering-keyed entry point the course-table detail bottom sheet needs. Matches the existing `watchX`/`refreshX` convention on `CourseRepository`.
- `watchCourseOffering` emits a `CourseOfferingDetail` record composed of a new `CourseOfferingOverviews` Drift view row (flat offering ⟕ catalog) plus separate lists for schedule slots, teachers, and classes (1-to-many sides). Future iSchool-sourced lists (roster, assignments) slot in alongside without changing the view.
- Refresh behaviour gated on `CourseOfferings.fetchedAt`:
  - **Never fetched** → the stream blocks on `refreshCourseOffering` before its first emission so consumers don't see null syllabus fields.
  - **Previously fetched** → cached data emits immediately and `refreshCourseOffering` runs in the background; the view's `.watch()` re-emits when the new write lands.
- `refreshCourseOffering` calls `CourseService.getSyllabus` and persists `courseType` / `enrolled` / `withdrawn` / syllabus content to `CourseOfferings`. Errors propagate to explicit callers (parallels `refreshCourseTable`); the auto-trigger inside `watchCourseOffering` absorbs them.
- Adds `courseOfferingProvider` (`StreamProvider.autoDispose.family<CourseOfferingDetail?, int>`) alongside `courseTableProvider`.

## Notes

- Bottom-sheet UI is **not** updated in this PR — that follow-up wires `cell.id` → `ref.watch(courseOfferingProvider(cell.id))`.
- No TTL gate on the background refresh: every sheet open triggers one syllabus fetch. Trade-off chosen for simplicity over request volume.

## Test plan

- [x] `dart analyze` clean
- [x] `flutter test` (offline unit suites) green
- [x] Manual smoke test in the running app: open the course-table detail sheet on a known offering, verify
  - **Fresh load** (DB-wiped syllabus): stream emits a single `AsyncData` with populated syllabus fields after the refresh completes — no intermediate null-fields emission.
  - **Repeat load**: stream emits cached `AsyncData` immediately, then re-emits after the background refresh writes.