### PR TITLE
ci: update Xcode to 26.5

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -76,7 +76,7 @@ runs:
     - name: Select Xcode version
       if: ${{ inputs.platform == 'ios' }}
       shell: bash
-      run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
 
     - name: Setup CocoaPods cache
       if: ${{ inputs.platform == 'ios' }}


### PR DESCRIPTION
## Summary

- Bump the iOS setup action to select `Xcode_26.5.app` instead of `Xcode_26.4.app`.

## Test plan

- [x] iOS CI job builds successfully on the runner with Xcode 26.5 installed.