### PR TITLE
refactor: align inCourseSemesterList/inScoreSemesterList demotion

### DIFF
--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -1455,13 +1455,15 @@ class Semester extends DataClass implements Insertable<Semester> {
   /// Term number within the year (0=Pre-study, 1=Fall, 2=Spring, 3=Summer).
   final int term;
 
-  /// Whether this semester appeared in the course semester list API response.
+  /// Whether this semester is currently in the course semester list API
+  /// response.
   ///
-  /// Distinguishes semesters fetched by [CourseRepository.getSemesters] from
-  /// those created as side effects by other flows (e.g., auth, scores).
+  /// Distinguishes semesters fetched by [CourseRepository.refreshSemesters]
+  /// from those created as side effects by other flows (e.g., auth, scores).
   final bool inCourseSemesterList;
 
-  /// Whether this semester appeared in the score semester list API response.
+  /// Whether this semester is currently in the score semester list API
+  /// response.
   ///
   /// Distinguishes semesters fetched by [StudentRepository.refreshSemesterRecords]
   /// from those created as side effects by other flows (e.g., auth, courses).

--- a/lib/database/schema.dart
+++ b/lib/database/schema.dart
@@ -125,13 +125,15 @@ class Semesters extends Table with AutoIncrementId {
   /// Term number within the year (0=Pre-study, 1=Fall, 2=Spring, 3=Summer).
   late final term = integer()();
 
-  /// Whether this semester appeared in the course semester list API response.
+  /// Whether this semester is currently in the course semester list API
+  /// response.
   ///
-  /// Distinguishes semesters fetched by [CourseRepository.getSemesters] from
-  /// those created as side effects by other flows (e.g., auth, scores).
+  /// Distinguishes semesters fetched by [CourseRepository.refreshSemesters]
+  /// from those created as side effects by other flows (e.g., auth, scores).
   late final inCourseSemesterList = boolean().withDefault(Constant(false))();
 
-  /// Whether this semester appeared in the score semester list API response.
+  /// Whether this semester is currently in the score semester list API
+  /// response.
   ///
   /// Distinguishes semesters fetched by [StudentRepository.refreshSemesterRecords]
   /// from those created as side effects by other flows (e.g., auth, courses).

--- a/lib/repositories/course_repository.dart
+++ b/lib/repositories/course_repository.dart
@@ -209,14 +209,29 @@ class CourseRepository {
     );
 
     await _database.transaction(() async {
+      final fetchedSemesterIds = <int>{};
       for (final dto in dtos) {
         if (dto case (year: final year?, term: final term?)) {
-          await _database.getOrCreateSemester(
+          final semester = await _database.getOrCreateSemester(
             year,
             term,
             inCourseSemesterList: true,
           );
+          fetchedSemesterIds.add(semester.id);
         }
+      }
+
+      // Keep membership flag in sync with the latest course semester response.
+      // Skip on empty.
+      if (fetchedSemesterIds.isNotEmpty) {
+        await (_database.update(_database.semesters)..where(
+              (s) =>
+                  s.inCourseSemesterList.equals(true) &
+                  s.id.isNotIn(fetchedSemesterIds),
+            ))
+            .write(
+              const SemestersCompanion(inCourseSemesterList: Value(false)),
+            );
       }
 
       await (_database.update(_database.users)).write(

--- a/lib/repositories/student_repository.dart
+++ b/lib/repositories/student_repository.dart
@@ -331,15 +331,9 @@ class StudentRepository {
         }
       }
 
-      // Keep membership flag in sync with the latest score semester response.
-      if (fetchedSemesterIds.isEmpty) {
-        await (_database.update(_database.semesters)..where(
-              (s) => s.inScoreSemesterList.equals(true),
-            ))
-            .write(
-              const SemestersCompanion(inScoreSemesterList: Value(false)),
-            );
-      } else {
+      // Keep membership flag in sync with the latest score semester response,
+      // and drop scores for semesters that fell out of it. Skip on empty.
+      if (fetchedSemesterIds.isNotEmpty) {
         await (_database.update(_database.semesters)..where(
               (s) =>
                   s.inScoreSemesterList.equals(true) &
@@ -348,14 +342,7 @@ class StudentRepository {
             .write(
               const SemestersCompanion(inScoreSemesterList: Value(false)),
             );
-      }
 
-      // Remove scores for semesters no longer in the response
-      if (fetchedSemesterIds.isEmpty) {
-        await (_database.delete(
-          _database.scores,
-        )..where((t) => t.user.equals(userId))).go();
-      } else {
         await (_database.delete(_database.scores)..where(
               (t) =>
                   t.user.equals(userId) &


### PR DESCRIPTION
Closes #273.

## Summary

- `CourseRepository.refreshSemesters` now collects fetched semester IDs and demotes any stale `inCourseSemesterList=true` rows that fell out of the response within the same transaction — matching the pattern `StudentRepository._refreshSemesterRecords` already used for `inScoreSemesterList`.
- Both demotion branches now **skip on empty response** instead of wiping the cached set. A transient API hiccup (NTUT returning an empty list) leaves cached membership intact rather than blanking the UI. The cache timestamp (`semestersFetchedAt` / `scoreDataFetchedAt`) still updates either way.
- For symmetry, `_refreshSemesterRecords` no longer wipes all scores on empty — orphaned-score deletion now also runs only when the response is non-empty.
- Dartdocs on both `Semesters.inCourseSemesterList` and `inScoreSemesterList` updated from "appeared in" → "currently in", and the broken `CourseRepository.getSemesters` link is fixed to `refreshSemesters`.

## Notes

- Per the discussion on #273, this answers Baconsun0909's concern by applying the "skip on empty" guard to both flags — defensive against API outages while keeping the two flags semantically symmetric.

## Test plan

- [x] `dart analyze` clean on touched files
- [x] Manual smoke on emulator: log in, observe Courses tab populates semester picker (114-2 / 114-1 / 113-2 / 113-1 / …), Scores tab populates picker and per-semester scores. Both refresh paths exercised the non-empty demote branch; no semesters dropped unexpectedly.