### PR TITLE
fix: bypass campus Wi-Fi TLS DPI and BigIP Cookie: null rejection

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -18,15 +18,14 @@ Install recommended extensions (VS Code will prompt you, or search `@recommended
 Shared launch configurations for the project:
 
 | Configuration | Mode | Flags |
-|---|---|---|
-| Debug | debug | `ALLOW_BAD_CERTIFICATES=true` |
-| Debug with Firebase | debug | `ALLOW_BAD_CERTIFICATES=true`, `USE_FIREBASE=true` |
+| --- | --- | --- |
+| Debug | debug | — |
+| Debug with Firebase | debug | `USE_FIREBASE=true` |
 | Profile | profile | — |
 | Profile with Firebase | profile | `USE_FIREBASE=true` |
 | Release | release | — |
 | Release with Firebase | release | `USE_FIREBASE=true` |
 
-- **`ALLOW_BAD_CERTIFICATES`** — allows self-signed certificates for MITM proxy debugging (e.g., Proxyman, Charles)
 - **`USE_FIREBASE`** — enables Firebase Analytics and Crashlytics (requires Firebase configs from `tool/credentials.dart`)
 
 ## Optional Configuration

--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -19,14 +19,15 @@ Shared launch configurations for the project:
 
 | Configuration | Mode | Flags |
 | --- | --- | --- |
-| Debug | debug | — |
-| Debug with Firebase | debug | `USE_FIREBASE=true` |
-| Profile | profile | — |
-| Profile with Firebase | profile | `USE_FIREBASE=true` |
-| Release | release | — |
-| Release with Firebase | release | `USE_FIREBASE=true` |
+| Debug | debug | `cronetHttpNoPlay=true` |
+| Debug with Firebase | debug | `USE_FIREBASE=true`, `cronetHttpNoPlay=true` |
+| Profile | profile | `cronetHttpNoPlay=true` |
+| Profile with Firebase | profile | `USE_FIREBASE=true`, `cronetHttpNoPlay=true` |
+| Release | release | `cronetHttpNoPlay=true` |
+| Release with Firebase | release | `USE_FIREBASE=true`, `cronetHttpNoPlay=true` |
 
 - **`USE_FIREBASE`** — enables Firebase Analytics and Crashlytics (requires Firebase configs from `tool/credentials.dart`)
+- **`cronetHttpNoPlay`** — bundles Cronet directly instead of using Google Play Services (~2MB APK increase), so AOSP devices (e.g., GrapheneOS) work on campus Wi-Fi
 
 ## Optional Configuration
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,17 @@
       "name": "Debug",
       "request": "launch",
       "type": "dart",
+      "toolArgs": [
+        "--dart-define=cronetHttpNoPlay=true"
+      ],
     },
-    { 
+    {
       "name": "Debug with Firebase",
       "request": "launch",
       "type": "dart",
       "toolArgs": [
-        "--dart-define=USE_FIREBASE=true"
+        "--dart-define=USE_FIREBASE=true",
+        "--dart-define=cronetHttpNoPlay=true"
       ],
     },
     {
@@ -19,14 +23,18 @@
       "request": "launch",
       "type": "dart",
       "flutterMode": "profile",
+      "toolArgs": [
+        "--dart-define=cronetHttpNoPlay=true"
+      ],
     },
-    { 
+    {
       "name": "Profile with Firebase",
       "request": "launch",
       "type": "dart",
       "flutterMode": "profile",
       "toolArgs": [
-        "--dart-define=USE_FIREBASE=true"
+        "--dart-define=USE_FIREBASE=true",
+        "--dart-define=cronetHttpNoPlay=true"
       ],
     },
     {
@@ -34,14 +42,18 @@
       "request": "launch",
       "type": "dart",
       "flutterMode": "release",
+      "toolArgs": [
+        "--dart-define=cronetHttpNoPlay=true"
+      ],
     },
-    { 
+    {
       "name": "Release with Firebase",
       "request": "launch",
       "type": "dart",
       "flutterMode": "release",
       "toolArgs": [
-        "--dart-define=USE_FIREBASE=true"
+        "--dart-define=USE_FIREBASE=true",
+        "--dart-define=cronetHttpNoPlay=true"
       ],
     },
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,16 +5,12 @@
       "name": "Debug",
       "request": "launch",
       "type": "dart",
-      "toolArgs": [
-        "--dart-define=ALLOW_BAD_CERTIFICATES=true"
-      ],
     },
     { 
       "name": "Debug with Firebase",
       "request": "launch",
       "type": "dart",
       "toolArgs": [
-        "--dart-define=ALLOW_BAD_CERTIFICATES=true",
         "--dart-define=USE_FIREBASE=true"
       ],
     },

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -4,4 +4,5 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <application android:networkSecurityConfig="@xml/network_security_config" />
 </manifest>

--- a/android/app/src/debug/res/xml/network_security_config.xml
+++ b/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -104,7 +104,8 @@ platform :android do
       build_number: settings[:build_number],
       build_args: [
         "--dart-define=USE_FIREBASE=true",
-        "--dart-define=VERSION_SUFFIX=#{settings[:version_suffix]}"
+        "--dart-define=VERSION_SUFFIX=#{settings[:version_suffix]}",
+        "--dart-define=cronetHttpNoPlay=true"
       ],
     )
   end
@@ -118,7 +119,8 @@ platform :android do
       build_number: settings[:build_number],
       build_args: [
         "--dart-define=USE_FIREBASE=true",
-        "--dart-define=VERSION_SUFFIX=#{settings[:version_suffix]}"
+        "--dart-define=VERSION_SUFFIX=#{settings[:version_suffix]}",
+        "--dart-define=cronetHttpNoPlay=true"
       ],
     )
   end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,7 @@
 PODS:
+  - cupertino_http (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - Firebase/CoreOnly (12.12.0):
     - FirebaseCore (~> 12.12.0)
   - Firebase/Crashlytics (12.12.0):
@@ -174,6 +177,7 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - cupertino_http (from `.symlinks/plugins/cupertino_http/darwin`)
   - firebase_analytics (from `.symlinks/plugins/firebase_analytics/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_crashlytics (from `.symlinks/plugins/firebase_crashlytics/ios`)
@@ -210,6 +214,8 @@ SPEC REPOS:
     - SDWebImageWebPCoder
 
 EXTERNAL SOURCES:
+  cupertino_http:
+    :path: ".symlinks/plugins/cupertino_http/darwin"
   firebase_analytics:
     :path: ".symlinks/plugins/firebase_analytics/ios"
   firebase_core:
@@ -234,6 +240,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
+  cupertino_http: 94ac07f5ff090b8effa6c5e2c47871d48ab7c86c
   Firebase: aa154fee4e9b8eac17aa42344988865b3e857d33
   firebase_analytics: e5f4faccf1f7040d3788e835b7eb7b57dc84a911
   firebase_core: 9156a152117c843440b0b990c785aa0259bc5447

--- a/lib/utils/http.dart
+++ b/lib/utils/http.dart
@@ -101,27 +101,28 @@ class PlainTextTransformer extends BackgroundTransformer {
 /// Logs to both `dart:developer` and Firebase Crashlytics for breadcrumb
 /// context in crash reports.
 class LogInterceptor extends Interceptor {
-  @override
-  void onResponse(Response response, ResponseInterceptorHandler handler) {
-    final compactFormat = NumberFormat.compact().format;
+  static final _compactFormat = NumberFormat.compact().format;
 
-    final method = response.requestOptions.method;
-    final uri = response.requestOptions.uri;
-    final parameters = response.requestOptions.queryParameters.length;
-    final requestBodyLength = switch (response.requestOptions.data) {
+    static String _requestLog(RequestOptions options) {
+    final parameters = options.queryParameters.length;
+    final requestBodyLength = switch (options.data) {
       String s => s.length,
       List l => l.length,
       FormData f => f.length,
       Map m => m.length,
       _ => null,
     };
-
-    final requestLog = [
-      method,
-      "${uri.origin}${uri.path}",
+return [
+      options.method,
+      '${options.uri.origin}${options.uri.path}',
       if (parameters > 0) "$parameters param${parameters != 1 ? 's' : ''}",
-      if (requestBodyLength case final l?) "${compactFormat(l)}B",
+      if (requestBodyLength case final l?) '${_compactFormat(l)}B',
     ].join(' ');
+}
+
+  @override
+  void onResponse(Response response, ResponseInterceptorHandler handler) {
+    final requestLog = _requestLog(response.requestOptions);
 
     final statusCode = response.statusCode;
     final contentType = response.headers
@@ -144,14 +145,28 @@ class LogInterceptor extends Interceptor {
     final responseLog = [
       statusCode,
       if (contentType case final t) t,
-      if (responseBodyLength case final l?) '${compactFormat(l)}B',
+      if (responseBodyLength case final l?) '${_compactFormat(l)}B',
       if (cookies case final c? when c > 0) "$c cookie${c != 1 ? 's' : ''}",
     ].join(' ');
 
-    final message = "$requestLog => $responseLog";
+    final message = '$requestLog => $responseLog';
     log(message, name: 'HTTP');
     firebaseService.log(message);
     handler.next(response);
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    final requestLog = _requestLog(err.requestOptions);
+    final errorLog = [
+      err.type,
+      ?err.response?.statusCode,
+    ].join(' ');
+
+    final message = '$requestLog => $errorLog';
+    log(message, name: 'HTTP');
+    firebaseService.log(message);
+    handler.next(err);
   }
 }
 

--- a/lib/utils/http.dart
+++ b/lib/utils/http.dart
@@ -4,12 +4,11 @@ import 'dart:io';
 
 import 'package:cookie_jar/cookie_jar.dart';
 import 'package:dio/dio.dart';
-import 'package:dio/io.dart';
-// ignore: implementation_imports
-import 'package:dio/src/transformers/util/consolidate_bytes.dart';
+import 'package:dio/src/transformers/util/consolidate_bytes.dart'; // ignore: implementation_imports
 import 'package:dio_cookie_manager/dio_cookie_manager.dart';
 import 'package:dio_redirect_interceptor/dio_redirect_interceptor.dart';
 import 'package:intl/intl.dart';
+import 'package:native_dio_adapter/native_dio_adapter.dart';
 import 'package:tattoo/services/firebase_service.dart';
 
 export 'package:dio/dio.dart';
@@ -103,7 +102,7 @@ class PlainTextTransformer extends BackgroundTransformer {
 class LogInterceptor extends Interceptor {
   static final _compactFormat = NumberFormat.compact().format;
 
-    static String _requestLog(RequestOptions options) {
+  static String _requestLog(RequestOptions options) {
     final parameters = options.queryParameters.length;
     final requestBodyLength = switch (options.data) {
       String s => s.length,
@@ -112,13 +111,13 @@ class LogInterceptor extends Interceptor {
       Map m => m.length,
       _ => null,
     };
-return [
+    return [
       options.method,
       '${options.uri.origin}${options.uri.path}',
       if (parameters > 0) "$parameters param${parameters != 1 ? 's' : ''}",
       if (requestBodyLength case final l?) '${_compactFormat(l)}B',
     ].join(' ');
-}
+  }
 
   @override
   void onResponse(Response response, ResponseInterceptorHandler handler) {
@@ -175,10 +174,27 @@ CookieJar? _cookieJar;
 /// Shared CookieJar instance for maintaining session across clients.
 CookieJar get cookieJar => _cookieJar ??= CookieJar();
 
+/// Strips null-valued headers that [CookieManager] injects.
+///
+/// `dio_cookie_manager` explicitly sets `Cookie: null` when no cookies exist
+/// for a URL. Native HTTP adapters forward this as the literal header
+/// `Cookie: null`, which NTUT's BigIP ASM flags as bot behavior (HTTP 403).
+class NullHeaderInterceptor extends Interceptor {
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    options.headers.removeWhere(
+      (_, value) => value == null || value.toString() == 'null',
+    );
+    handler.next(options);
+  }
+}
+
 /// Creates a new Dio instance with configured interceptors.
 ///
-/// To debug with a self-signed certificate, pass
-/// --dart-define=ALLOW_BAD_CERTIFICATES=true to flutter run.
+/// On Android and iOS, HTTPS requests ride on the platform's native TLS stack
+/// via [NativeAdapter] (Cronet on Android, URLSession on iOS). Campus Wi-Fi
+/// has a TLS DPI that RSTs connections whose ClientHello fingerprint isn't on
+/// its allowlist; dart:io's BoringSSL fails, but Cronet and URLSession pass.
 ///
 /// Cookies are shared across all clients via the global [cookieJar].
 Dio createDio() {
@@ -188,17 +204,13 @@ Dio createDio() {
       followRedirects: false,
     );
 
-  const allowBadCertificates = bool.fromEnvironment('ALLOW_BAD_CERTIFICATES');
-  if (allowBadCertificates) {
-    dio.httpClientAdapter = IOHttpClientAdapter(
-      createHttpClient: () => HttpClient()
-        ..badCertificateCallback =
-            (X509Certificate cert, String host, int port) => true,
-    );
+  if (Platform.isAndroid || Platform.isIOS) {
+    dio.httpClientAdapter = NativeAdapter();
   }
 
   dio.interceptors.addAll([
     CookieManager(cookieJar), // Store cookies
+    NullHeaderInterceptor(), // Strip Cookie: null from dio_cookie_manager
     HttpsInterceptor(), // Enforce HTTPS
     RedirectInterceptor(() => dio), // Handle redirects within this Dio instance
     LogInterceptor(), // Log requests and responses

--- a/lib/utils/http.dart
+++ b/lib/utils/http.dart
@@ -158,7 +158,7 @@ class LogInterceptor extends Interceptor {
   void onError(DioException err, ErrorInterceptorHandler handler) {
     final requestLog = _requestLog(err.requestOptions);
     final errorLog = [
-      err.type,
+      err.type.name,
       ?err.response?.statusCode,
     ].join(' ');
 

--- a/lib/utils/http.dart
+++ b/lib/utils/http.dart
@@ -205,7 +205,11 @@ Dio createDio() {
     );
 
   if (Platform.isAndroid || Platform.isIOS) {
-    dio.httpClientAdapter = NativeAdapter();
+    dio.httpClientAdapter = NativeAdapter(
+      createCupertinoConfiguration: () =>
+          URLSessionConfiguration.defaultSessionConfiguration()
+            ..httpShouldSetCookies = false,
+    );
   }
 
   dio.interceptors.addAll([

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -201,6 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  cronet_http:
+    dependency: transitive
+    description:
+      name: cronet_http
+      sha256: "8e77bc6f203e0bc9126e6a9092508a3435dbcb04da3b53ed1a358909385c5e0e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.8.0"
   cross_file:
     dependency: transitive
     description:
@@ -225,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  cupertino_http:
+    dependency: transitive
+    description:
+      name: cupertino_http
+      sha256: "82cbec60c90bf785a047a9525688b6dacac444e177e1d5a5876963d3c50369e8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -653,6 +669,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  http_profile:
+    dependency: transitive
+    description:
+      name: http_profile
+      sha256: "7e679e355b09aaee2ab5010915c932cce3f2d1c11c3b2dc177891687014ffa78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   image_picker:
     dependency: "direct main"
     description:
@@ -733,6 +757,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: "8706a77e94c76fe9ec9315e18949cc9479cc03af97085ca9c1077b61323ea12d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.2"
   json_annotation:
     dependency: transitive
     description:
@@ -837,6 +869,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  native_dio_adapter:
+    dependency: "direct main"
+    description:
+      name: native_dio_adapter
+      sha256: "9bbfa5221fd287eb063962bbe6534290e5f87933e576fac210149fb80253b89a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.1"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -1462,10 +1502,10 @@ packages:
     dependency: transitive
     description:
       name: web_socket
-      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "0.1.6"
   web_socket_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
 
   cupertino_icons: ^1.0.9
   dio: ^5.9.2
+  native_dio_adapter: ^1.5.1
   cookie_jar: ^4.0.9
   dio_cookie_manager: ^3.4.0
   html: ^0.15.6


### PR DESCRIPTION
## Summary

- **Campus Wi-Fi TLS DPI bypass**: `native_dio_adapter` routes HTTPS through Cronet (Android) and URLSession (iOS), whose TLS fingerprints pass the campus DPI that RSTs dart:io's BoringSSL.
- **BigIP 403 fix**: `dio_cookie_manager` sets `Cookie: null` (literal string) when no cookies exist. BigIP ASM flags this as bot behavior. A `NullHeaderInterceptor` strips null-valued headers before they reach the adapter.
- **Removes `ALLOW_BAD_CERTIFICATES`**: Debug builds now trust user-installed CAs via `network_security_config.xml` for Proxyman/mitmproxy MITM debugging without falling back to dart:io.

Supersedes #307 — same TLS bypass with fewer lines, plus the Cookie: null fix that #307 doesn't address.

## Test plan

- [x] Login on Pixel 7 (Android 16) on campus Wi-Fi
- [x] Login on Sony Walkman NW-ZX500 (Android 9) on campus Wi-Fi
- [x] Login on iPhone XR (iOS 18.7.9) on campus Wi-Fi
- [x] Verify Proxyman MITM works on Android debug build with user CA installed
- [x] Verify no regression on SSO flows (course, student query, iSchool+)