### PR TITLE
fix: split comma-joined Set-Cookie before filtering invalid cookies

### DIFF
--- a/lib/utils/http.dart
+++ b/lib/utils/http.dart
@@ -48,7 +48,7 @@ class HttpsInterceptor extends Interceptor {
 /// into a single header entry. This interceptor splits them before validation
 /// so that one invalid cookie doesn't take down the entire Set-Cookie header.
 class InvalidCookieFilter extends Interceptor {
-  static final _setCookieReg = RegExp(r',(?=[^;]+?=)');
+  static final _setCookieReg = RegExp(r',(?=[^;,]+?=)');
 
   @override
   void onResponse(Response response, ResponseInterceptorHandler handler) {

--- a/lib/utils/http.dart
+++ b/lib/utils/http.dart
@@ -48,7 +48,7 @@ class HttpsInterceptor extends Interceptor {
 /// into a single header entry. This interceptor splits them before validation
 /// so that one invalid cookie doesn't take down the entire Set-Cookie header.
 class InvalidCookieFilter extends Interceptor {
-  static final _setCookieReg = RegExp('(?<=)(,)(?=[^;]+?=)');
+  static final _setCookieReg = RegExp(r',(?=[^;]+?=)');
 
   @override
   void onResponse(Response response, ResponseInterceptorHandler handler) {

--- a/lib/utils/http.dart
+++ b/lib/utils/http.dart
@@ -43,7 +43,13 @@ class HttpsInterceptor extends Interceptor {
 /// [Interceptor] to filter out invalid Set-Cookie headers from responses.
 ///
 /// [ISchoolPlusService] sets cookies with invalid names, causing parsing errors.
+///
+/// [NativeAdapter] (Cronet/URLSession) comma-joins multiple Set-Cookie values
+/// into a single header entry. This interceptor splits them before validation
+/// so that one invalid cookie doesn't take down the entire Set-Cookie header.
 class InvalidCookieFilter extends Interceptor {
+  static final _setCookieReg = RegExp('(?<=)(,)(?=[^;]+?=)');
+
   @override
   void onResponse(Response response, ResponseInterceptorHandler handler) {
     final setCookieHeaders = response.headers[HttpHeaders.setCookieHeader];
@@ -53,13 +59,16 @@ class InvalidCookieFilter extends Interceptor {
     }
 
     final validCookies = <String>[];
-    for (final header in setCookieHeaders) {
+    for (final cookie in setCookieHeaders.expand(
+      (h) => h.split(_setCookieReg),
+    )) {
+      if (cookie.isEmpty) continue;
+      final trimmed = cookie.trimLeft();
       try {
-        Cookie.fromSetCookieValue(header);
-        validCookies.add(header);
+        Cookie.fromSetCookieValue(trimmed);
+        validCookies.add(trimmed);
       } on FormatException {
-        // Ignore invalid cookie
-        log('Filtered invalid Set-Cookie header: $header', name: 'HTTP');
+        log('Filtered invalid Set-Cookie header: $trimmed', name: 'HTTP');
       }
     }
     response.headers.set(HttpHeaders.setCookieHeader, validCookies);


### PR DESCRIPTION
## Summary

- NativeAdapter (Cronet/URLSession) comma-joins multiple `Set-Cookie` values into a single header entry. `InvalidCookieFilter` treated each entry as one cookie, so the joined string passed validation (first cookie was valid) while hiding invalid iSchool+ cookies inside. `CookieManager` later split and re-parsed them, hitting unhandled `FormatException`s that broke the request — failing QR scanner login.
- Split comma-joined values with the same regex `CookieManager` uses before validating each cookie individually.

## Test plan

- [x] QR scanner login to iStudy works end-to-end

Closes #313