### PR TITLE
Add open source license page

### DIFF
--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -214,4 +214,6 @@ about:
   privacyPolicy: Privacy Policy
   privacyPolicyUrl: https://github.com/NTUT-NPC/tattoo/blob/main/PRIVACY.md
   viewPrivacyPolicy: View our privacy policy
+  openSourceLicenses: Open Source Licenses
+  viewOpenSourceLicenses: TAT's implementation is made possible by the open source community
   copyright: "© 2025 NTUT Programming Club\nLicensed under the GNU GPL v3.0"

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 354 (177 per locale)
+/// Strings: 358 (179 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -291,6 +291,8 @@ class _TranslationsAboutEnUs extends TranslationsAboutZhTw {
 	@override String get privacyPolicy => 'Privacy Policy';
 	@override String get privacyPolicyUrl => 'https://github.com/NTUT-NPC/tattoo/blob/main/PRIVACY.md';
 	@override String get viewPrivacyPolicy => 'View our privacy policy';
+	@override String get openSourceLicenses => 'Open Source Licenses';
+	@override String get viewOpenSourceLicenses => 'TAT\'s implementation is made possible by the open source community';
 	@override String get copyright => '© 2025 NTUT Programming Club\nLicensed under the GNU GPL v3.0';
 }
 
@@ -759,6 +761,8 @@ extension on TranslationsEnUs {
 			'about.privacyPolicy' => 'Privacy Policy',
 			'about.privacyPolicyUrl' => 'https://github.com/NTUT-NPC/tattoo/blob/main/PRIVACY.md',
 			'about.viewPrivacyPolicy' => 'View our privacy policy',
+			'about.openSourceLicenses' => 'Open Source Licenses',
+			'about.viewOpenSourceLicenses' => 'TAT\'s implementation is made possible by the open source community',
 			'about.copyright' => '© 2025 NTUT Programming Club\nLicensed under the GNU GPL v3.0',
 			_ => null,
 		};

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -438,6 +438,12 @@ class TranslationsAboutZhTw {
 	/// zh-TW: '查看隱私權政策'
 	String get viewPrivacyPolicy => '查看隱私權政策';
 
+	/// zh-TW: '開放原始碼授權'
+	String get openSourceLicenses => '開放原始碼授權';
+
+	/// zh-TW: 'TAT的實作歸功於開放原始碼社群'
+	String get viewOpenSourceLicenses => 'TAT的實作歸功於開放原始碼社群';
+
 	/// zh-TW: '© 2025北科程式設計研究社\n以GNU GPL v3.0授權條款釋出'
 	String get copyright => '© 2025北科程式設計研究社\n以GNU GPL v3.0授權條款釋出';
 }
@@ -1073,6 +1079,8 @@ extension on Translations {
 			'about.privacyPolicy' => '隱私權政策',
 			'about.privacyPolicyUrl' => 'https://github.com/NTUT-NPC/tattoo/blob/main/PRIVACY.zh-TW.md',
 			'about.viewPrivacyPolicy' => '查看隱私權政策',
+			'about.openSourceLicenses' => '開放原始碼授權',
+			'about.viewOpenSourceLicenses' => 'TAT的實作歸功於開放原始碼社群',
 			'about.copyright' => '© 2025北科程式設計研究社\n以GNU GPL v3.0授權條款釋出',
 			_ => null,
 		};

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -214,4 +214,6 @@ about:
   privacyPolicy: 隱私權政策
   privacyPolicyUrl: https://github.com/NTUT-NPC/tattoo/blob/main/PRIVACY.zh-TW.md
   viewPrivacyPolicy: 查看隱私權政策
+  openSourceLicenses: 開放原始碼授權
+  viewOpenSourceLicenses: TAT的實作歸功於開放原始碼社群
   copyright: © 2025北科程式設計研究社\n以GNU GPL v3.0授權條款釋出

--- a/lib/screens/main/profile/about_screen.dart
+++ b/lib/screens/main/profile/about_screen.dart
@@ -135,7 +135,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                             context: context,
                             applicationLegalese: t.about.copyright,
                             applicationName: t.general.appTitle,
-                            applicationVersion: packageInfoAsync.value,
+                            applicationVersion: packageInfoAsync.value ?? '...',
                           ),
                         ),
                         OptionEntryTile.icon(

--- a/lib/screens/main/profile/about_screen.dart
+++ b/lib/screens/main/profile/about_screen.dart
@@ -128,6 +128,17 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                           ),
                         ),
                         OptionEntryTile.icon(
+                          icon: Icons.article_outlined,
+                          title: t.about.openSourceLicenses,
+                          description: t.about.viewOpenSourceLicenses,
+                          onTap: () => showLicensePage(
+                            context: context,
+                            applicationLegalese: t.about.copyright,
+                            applicationName: t.general.appTitle,
+                            applicationVersion: packageInfoAsync.value,
+                          ),
+                        ),
+                        OptionEntryTile.icon(
                           icon: Icons.translate,
                           title: 'Crowdin',
                           description: t.about.helpTranslate,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+    - assets/fonts/
   fonts:
     - family: NotoSansTC
       fonts:


### PR DESCRIPTION
# 新增開放原始碼授權頁面

## 總覽

在 PR #310 中我們將 Noto Sans 字體打包進去，並且已經在 `main.dart` 中將其加入 Flutter 內建的 License 管理工具。
於 ISSUE #311 中 Follw-up，開放原始碼授權應該在 App 內出現。

## 改動

- 在 `about_screen.dart` 中，於關於我們頁面加入了開放原始碼授權的入口
- 由於 Flutter 的 assets register 無法 recursive，在 `pubspec.yaml` 中，將 `assets/fonts/` 加入列表，以順利載入 OFL 檔案 

<img height="250" alt="Screenshot_20260527_143329" src="https://github.com/user-attachments/assets/6eaa0ac2-f537-4a8c-b2f0-ce059bdf0a40" />
<img height="250" alt="Screenshot_20260527_143338" src="https://github.com/user-attachments/assets/86a376dd-5d5a-4b00-ad4e-4b19d95e4d34" />
<img height="250" alt="Screenshot_20260527_143400" src="https://github.com/user-attachments/assets/80dbcb39-857f-4df9-88ba-9aefef3eb009" />
