### PR TITLE
Use ListTile for option entry text

### DIFF
--- a/lib/components/option_entry_tile.dart
+++ b/lib/components/option_entry_tile.dart
@@ -149,7 +149,7 @@ class OptionEntryTile extends StatelessWidget {
             ),
           ),
           child: Padding(
-            padding: const .symmetric(horizontal: 12, vertical: 12),
+            padding: const .symmetric(horizontal: 12, vertical: 4),
             child: Row(
               spacing: 12,
               children: [
@@ -158,24 +158,22 @@ class OptionEntryTile extends StatelessWidget {
                 ),
 
                 Expanded(
-                  child: Column(
-                    mainAxisAlignment: .center,
-                    crossAxisAlignment: .start,
-                    spacing: 4,
-                    children: [
-                      Text(
-                        title,
-                        style: theme.textTheme.titleMedium,
-                      ),
-                      if (description case final description?) ...[
-                        Text(
-                          description,
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            color: colorScheme.onSurfaceVariant,
+                  child: ListTile(
+                    visualDensity: .compact,
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(
+                      title,
+                      style: theme.textTheme.titleMedium,
+                    ),
+                    subtitle: description == null
+                        ? null
+                        : Text(
+                            description!,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                            ),
                           ),
-                        ),
-                      ],
-                    ],
                   ),
                 ),
 


### PR DESCRIPTION
# 替換 option entry tile 中的文字 ListTile

目前的 option entry tile 是本專案開發早期設計的元件，在文字上採用自訂樣式的標題與副標題。
這與 ListTile 的功能相似，但是其除了更符合 Material 設計以外，還有更好的相容性與無障礙特性。
並且因為 ListTIle 有自己的 Padding，所以在方塊的 Padding 上也做了一些調整。


<img height="300" alt="Screenshot_20260527_152544" src="https://github.com/user-attachments/assets/d2177cc1-cb88-4515-883f-b5cc6f59554e" />
<img height="300" alt="Screenshot_20260527_152712" src="https://github.com/user-attachments/assets/532fbc1d-d1b7-4806-a003-500f7fc4cebb" />
<img height="300" alt="image" src="https://github.com/user-attachments/assets/ee15a6cf-81a5-4b56-ae85-eccf7341493e" />
<img height="300" alt="Screenshot_20260527_152533" src="https://github.com/user-attachments/assets/b85a1c54-8a9e-4002-b43d-8998aaa50d8d" />
