### PR TITLE
fix: add client identifier and login timestamp for campus network

### DIFF
--- a/lib/services/portal/ntut_portal_service.dart
+++ b/lib/services/portal/ntut_portal_service.dart
@@ -28,7 +28,11 @@ class NtutPortalService implements PortalService {
   Future<UserDto> login(String username, String password) async {
     final response = await _portalDio.post(
       'login.do',
-      queryParameters: {'muid': username, 'mpassword': password},
+      queryParameters: {
+        'muid': username,
+        'mpassword': password,
+        'thetime': DateTime.now().millisecondsSinceEpoch.toString(),
+      },
     );
 
     final body = jsonDecode(response.data);

--- a/lib/utils/http.dart
+++ b/lib/utils/http.dart
@@ -183,6 +183,19 @@ CookieJar? _cookieJar;
 /// Shared CookieJar instance for maintaining session across clients.
 CookieJar get cookieJar => _cookieJar ??= CookieJar();
 
+/// Adds an `X-Client` header identifying this app on campus Wi-Fi.
+///
+/// NTUT campus network (SSID: NTUT, NTUT-802.1X) requires client identification
+/// like the official app does in requests.
+class ClientIdentifierInterceptor extends Interceptor {
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    options.headers['X-Client'] =
+        'f39e5855ffb05dd0030e6cdd6b7b27f45303aa96dd5439f5021171b714afd755';
+    handler.next(options);
+  }
+}
+
 /// Strips null-valued headers that [CookieManager] injects.
 ///
 /// `dio_cookie_manager` explicitly sets `Cookie: null` when no cookies exist
@@ -224,6 +237,7 @@ Dio createDio() {
   dio.interceptors.addAll([
     CookieManager(cookieJar), // Store cookies
     NullHeaderInterceptor(), // Strip Cookie: null from dio_cookie_manager
+    ClientIdentifierInterceptor(), // Identify app on campus Wi-Fi
     HttpsInterceptor(), // Enforce HTTPS
     RedirectInterceptor(() => dio), // Handle redirects within this Dio instance
     LogInterceptor(), // Log requests and responses


### PR DESCRIPTION
## Summary

Follow-up hotfix to #309 — completes the campus Wi-Fi bypass by adding two
identifiers that NTUT's network blockade checks beyond TLS fingerprint:

- **`X-Client` header**: `ClientIdentifierInterceptor` sends a SHA-256 hash of the
  app bundle ID on all requests, mirroring what the official NTUT app does.
- **`thetime` query parameter**: Adds a Unix-millis timestamp to the login request,
  matching `nportal.ntut.edu.tw` portal behavior.

Without these, campus Wi-Fi can still block or reject requests even after the
TLS DPI and BigIP fixes from #309.

See https://t.me/c/3800117244/2453 for internal discussion.

## Test plan

- [x] Login on campus Wi-Fi (Android + iOS)
- [x] Verify SSO flows (course, student query, iSchool+) still work
- [x] Verify login off-campus is unaffected