### PR TITLE
feat: add course roster repository methods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ MVVM pattern with Riverpod for DI and reactive state (manual providers, no codeg
 
 - AuthRepository — User identity, session, profile. Lazy auth via `withAuth<T>()` with SSO and re-auth coalescing (Completer pattern). Session persistence via flutter_secure_storage. Never-completing future on auth failure (harmless — session-scoped providers are already being disposed).
 - PreferencesRepository — Typed `PrefKey<T>` enum with SharedPreferencesAsync. Cloud sync via avatar payload.
-- CourseRepository — Course catalog, schedules, and offering details. Normalizes bilingual names from multiple sources (catalog vs offering). Layout computation for course table grid (multi-period spans, noon-crossing, unscheduled courses).
+- CourseRepository — Course catalog, schedules, offering details, and related I-School Plus data. Normalizes bilingual names from multiple sources (catalog vs offering). Layout computation for course table grid (multi-period spans, noon-crossing, unscheduled courses).
 - CalendarRepository — Academic calendar events from NTUT portal. Sliding window caching keyed to enrolled semesters.
 - StudentRepository — Academic records, GPA, rankings. Parallel course code resolution via CourseRepository.getCourse().
 - **Method pattern:** `watchX()` returns a `Stream` backed by Drift `.watch()` — emits cached data immediately, then background-fetches if empty or stale (each method has its own hard-coded TTL `const`). Network errors are absorbed (stale data preferred over errors). `refreshX()` is the imperative counterpart for pull-to-refresh — fetches from network, writes to DB, and lets the stream re-emit.
@@ -146,4 +146,4 @@ These apOu codes are the SSO target identifiers used by PortalService to obtain 
 
 ## Backlog
 
-Open work is tracked in [GitHub Issues](https://github.com/NTUT-NPC/tattoo/issues). Key areas: remaining NTUT service methods (ISchoolPlus announcements, StudentQuery extensions), repository layer gaps (materials, rosters), and file download infrastructure.
+Open work is tracked in [GitHub Issues](https://github.com/NTUT-NPC/tattoo/issues). Key areas: remaining NTUT service methods (ISchoolPlus announcements, StudentQuery extensions), repository layer gaps (materials), and file download infrastructure.

--- a/lib/database/actions.dart
+++ b/lib/database/actions.dart
@@ -251,4 +251,24 @@ extension DatabaseActions on AppDatabase {
       ),
     )).id;
   }
+
+  /// Returns the ID of an existing student row, or creates/updates one.
+  ///
+  /// A null [name] never overwrites a previously recorded name — some
+  /// I-School Plus rosters omit the name for certain students.
+  Future<int> upsertStudent({
+    required String studentId,
+    String? name,
+  }) async {
+    return (await into(students).insertReturning(
+      StudentsCompanion.insert(
+        studentId: studentId,
+        name: Value(name),
+      ),
+      onConflict: DoUpdate(
+        (old) => StudentsCompanion(name: .absentIfNull(name)),
+        target: [students.studentId],
+      ),
+    )).id;
+  }
 }

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -3950,6 +3950,18 @@ class $CourseOfferingsTable extends CourseOfferings
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _rosterFetchedAtMeta = const VerificationMeta(
+    'rosterFetchedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> rosterFetchedAt =
+      GeneratedColumn<DateTime>(
+        'roster_fetched_at',
+        aliasedName,
+        true,
+        type: DriftSqlType.dateTime,
+        requiredDuringInsert: false,
+      );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -3975,6 +3987,7 @@ class $CourseOfferingsTable extends CourseOfferings
     evaluation,
     textbooks,
     syllabusRemarks,
+    rosterFetchedAt,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -4127,6 +4140,15 @@ class $CourseOfferingsTable extends CourseOfferings
         ),
       );
     }
+    if (data.containsKey('roster_fetched_at')) {
+      context.handle(
+        _rosterFetchedAtMeta,
+        rosterFetchedAt.isAcceptableOrUnknown(
+          data['roster_fetched_at']!,
+          _rosterFetchedAtMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -4233,6 +4255,10 @@ class $CourseOfferingsTable extends CourseOfferings
       syllabusRemarks: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}syllabus_remarks'],
+      ),
+      rosterFetchedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}roster_fetched_at'],
       ),
     );
   }
@@ -4359,6 +4385,10 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
 
   /// Teacher-authored remarks from the syllabus page (備註).
   final String? syllabusRemarks;
+
+  /// When the I-School Plus roster (classmates) was last fetched for this
+  /// offering. Null until the first roster fetch.
+  final DateTime? rosterFetchedAt;
   const CourseOffering({
     required this.id,
     this.fetchedAt,
@@ -4383,6 +4413,7 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
     this.evaluation,
     this.textbooks,
     this.syllabusRemarks,
+    this.rosterFetchedAt,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -4452,6 +4483,9 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
     if (!nullToAbsent || syllabusRemarks != null) {
       map['syllabus_remarks'] = Variable<String>(syllabusRemarks);
     }
+    if (!nullToAbsent || rosterFetchedAt != null) {
+      map['roster_fetched_at'] = Variable<DateTime>(rosterFetchedAt);
+    }
     return map;
   }
 
@@ -4520,6 +4554,9 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
       syllabusRemarks: syllabusRemarks == null && nullToAbsent
           ? const Value.absent()
           : Value(syllabusRemarks),
+      rosterFetchedAt: rosterFetchedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(rosterFetchedAt),
     );
   }
 
@@ -4556,6 +4593,7 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
       evaluation: serializer.fromJson<String?>(json['evaluation']),
       textbooks: serializer.fromJson<String?>(json['textbooks']),
       syllabusRemarks: serializer.fromJson<String?>(json['syllabusRemarks']),
+      rosterFetchedAt: serializer.fromJson<DateTime?>(json['rosterFetchedAt']),
     );
   }
   @override
@@ -4587,6 +4625,7 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
       'evaluation': serializer.toJson<String?>(evaluation),
       'textbooks': serializer.toJson<String?>(textbooks),
       'syllabusRemarks': serializer.toJson<String?>(syllabusRemarks),
+      'rosterFetchedAt': serializer.toJson<DateTime?>(rosterFetchedAt),
     };
   }
 
@@ -4614,6 +4653,7 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
     Value<String?> evaluation = const Value.absent(),
     Value<String?> textbooks = const Value.absent(),
     Value<String?> syllabusRemarks = const Value.absent(),
+    Value<DateTime?> rosterFetchedAt = const Value.absent(),
   }) => CourseOffering(
     id: id ?? this.id,
     fetchedAt: fetchedAt.present ? fetchedAt.value : this.fetchedAt,
@@ -4642,6 +4682,9 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
     syllabusRemarks: syllabusRemarks.present
         ? syllabusRemarks.value
         : this.syllabusRemarks,
+    rosterFetchedAt: rosterFetchedAt.present
+        ? rosterFetchedAt.value
+        : this.rosterFetchedAt,
   );
   CourseOffering copyWithCompanion(CourseOfferingsCompanion data) {
     return CourseOffering(
@@ -4682,6 +4725,9 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
       syllabusRemarks: data.syllabusRemarks.present
           ? data.syllabusRemarks.value
           : this.syllabusRemarks,
+      rosterFetchedAt: data.rosterFetchedAt.present
+          ? data.rosterFetchedAt.value
+          : this.rosterFetchedAt,
     );
   }
 
@@ -4710,7 +4756,8 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
           ..write('weeklyPlan: $weeklyPlan, ')
           ..write('evaluation: $evaluation, ')
           ..write('textbooks: $textbooks, ')
-          ..write('syllabusRemarks: $syllabusRemarks')
+          ..write('syllabusRemarks: $syllabusRemarks, ')
+          ..write('rosterFetchedAt: $rosterFetchedAt')
           ..write(')'))
         .toString();
   }
@@ -4740,6 +4787,7 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
     evaluation,
     textbooks,
     syllabusRemarks,
+    rosterFetchedAt,
   ]);
   @override
   bool operator ==(Object other) =>
@@ -4767,7 +4815,8 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
           other.weeklyPlan == this.weeklyPlan &&
           other.evaluation == this.evaluation &&
           other.textbooks == this.textbooks &&
-          other.syllabusRemarks == this.syllabusRemarks);
+          other.syllabusRemarks == this.syllabusRemarks &&
+          other.rosterFetchedAt == this.rosterFetchedAt);
 }
 
 class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
@@ -4794,6 +4843,7 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
   final Value<String?> evaluation;
   final Value<String?> textbooks;
   final Value<String?> syllabusRemarks;
+  final Value<DateTime?> rosterFetchedAt;
   const CourseOfferingsCompanion({
     this.id = const Value.absent(),
     this.fetchedAt = const Value.absent(),
@@ -4818,6 +4868,7 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
     this.evaluation = const Value.absent(),
     this.textbooks = const Value.absent(),
     this.syllabusRemarks = const Value.absent(),
+    this.rosterFetchedAt = const Value.absent(),
   });
   CourseOfferingsCompanion.insert({
     this.id = const Value.absent(),
@@ -4843,6 +4894,7 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
     this.evaluation = const Value.absent(),
     this.textbooks = const Value.absent(),
     this.syllabusRemarks = const Value.absent(),
+    this.rosterFetchedAt = const Value.absent(),
   }) : semester = Value(semester),
        nameZh = Value(nameZh);
   static Insertable<CourseOffering> custom({
@@ -4869,6 +4921,7 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
     Expression<String>? evaluation,
     Expression<String>? textbooks,
     Expression<String>? syllabusRemarks,
+    Expression<DateTime>? rosterFetchedAt,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -4894,6 +4947,7 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
       if (evaluation != null) 'evaluation': evaluation,
       if (textbooks != null) 'textbooks': textbooks,
       if (syllabusRemarks != null) 'syllabus_remarks': syllabusRemarks,
+      if (rosterFetchedAt != null) 'roster_fetched_at': rosterFetchedAt,
     });
   }
 
@@ -4921,6 +4975,7 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
     Value<String?>? evaluation,
     Value<String?>? textbooks,
     Value<String?>? syllabusRemarks,
+    Value<DateTime?>? rosterFetchedAt,
   }) {
     return CourseOfferingsCompanion(
       id: id ?? this.id,
@@ -4946,6 +5001,7 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
       evaluation: evaluation ?? this.evaluation,
       textbooks: textbooks ?? this.textbooks,
       syllabusRemarks: syllabusRemarks ?? this.syllabusRemarks,
+      rosterFetchedAt: rosterFetchedAt ?? this.rosterFetchedAt,
     );
   }
 
@@ -5023,6 +5079,9 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
     if (syllabusRemarks.present) {
       map['syllabus_remarks'] = Variable<String>(syllabusRemarks.value);
     }
+    if (rosterFetchedAt.present) {
+      map['roster_fetched_at'] = Variable<DateTime>(rosterFetchedAt.value);
+    }
     return map;
   }
 
@@ -5051,7 +5110,8 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
           ..write('weeklyPlan: $weeklyPlan, ')
           ..write('evaluation: $evaluation, ')
           ..write('textbooks: $textbooks, ')
-          ..write('syllabusRemarks: $syllabusRemarks')
+          ..write('syllabusRemarks: $syllabusRemarks, ')
+          ..write('rosterFetchedAt: $rosterFetchedAt')
           ..write(')'))
         .toString();
   }
@@ -15726,6 +15786,7 @@ typedef $$CourseOfferingsTableCreateCompanionBuilder =
       Value<String?> evaluation,
       Value<String?> textbooks,
       Value<String?> syllabusRemarks,
+      Value<DateTime?> rosterFetchedAt,
     });
 typedef $$CourseOfferingsTableUpdateCompanionBuilder =
     CourseOfferingsCompanion Function({
@@ -15752,6 +15813,7 @@ typedef $$CourseOfferingsTableUpdateCompanionBuilder =
       Value<String?> evaluation,
       Value<String?> textbooks,
       Value<String?> syllabusRemarks,
+      Value<DateTime?> rosterFetchedAt,
     });
 
 final class $$CourseOfferingsTableReferences
@@ -16051,6 +16113,11 @@ class $$CourseOfferingsTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<DateTime> get rosterFetchedAt => $composableBuilder(
+    column: $table.rosterFetchedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
   $$SemestersTableFilterComposer get semester {
     final $$SemestersTableFilterComposer composer = $composerBuilder(
       composer: this,
@@ -16347,6 +16414,11 @@ class $$CourseOfferingsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<DateTime> get rosterFetchedAt => $composableBuilder(
+    column: $table.rosterFetchedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   $$SemestersTableOrderingComposer get semester {
     final $$SemestersTableOrderingComposer composer = $composerBuilder(
       composer: this,
@@ -16458,6 +16530,11 @@ class $$CourseOfferingsTableAnnotationComposer
 
   GeneratedColumn<String> get syllabusRemarks => $composableBuilder(
     column: $table.syllabusRemarks,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get rosterFetchedAt => $composableBuilder(
+    column: $table.rosterFetchedAt,
     builder: (column) => column,
   );
 
@@ -16699,6 +16776,7 @@ class $$CourseOfferingsTableTableManager
                 Value<String?> evaluation = const Value.absent(),
                 Value<String?> textbooks = const Value.absent(),
                 Value<String?> syllabusRemarks = const Value.absent(),
+                Value<DateTime?> rosterFetchedAt = const Value.absent(),
               }) => CourseOfferingsCompanion(
                 id: id,
                 fetchedAt: fetchedAt,
@@ -16723,6 +16801,7 @@ class $$CourseOfferingsTableTableManager
                 evaluation: evaluation,
                 textbooks: textbooks,
                 syllabusRemarks: syllabusRemarks,
+                rosterFetchedAt: rosterFetchedAt,
               ),
           createCompanionCallback:
               ({
@@ -16749,6 +16828,7 @@ class $$CourseOfferingsTableTableManager
                 Value<String?> evaluation = const Value.absent(),
                 Value<String?> textbooks = const Value.absent(),
                 Value<String?> syllabusRemarks = const Value.absent(),
+                Value<DateTime?> rosterFetchedAt = const Value.absent(),
               }) => CourseOfferingsCompanion.insert(
                 id: id,
                 fetchedAt: fetchedAt,
@@ -16773,6 +16853,7 @@ class $$CourseOfferingsTableTableManager
                 evaluation: evaluation,
                 textbooks: textbooks,
                 syllabusRemarks: syllabusRemarks,
+                rosterFetchedAt: rosterFetchedAt,
               ),
           withReferenceMapper: (p0) => p0
               .map(

--- a/lib/database/schema.dart
+++ b/lib/database/schema.dart
@@ -425,6 +425,10 @@ class CourseOfferings extends Table with AutoIncrementId, Fetchable {
   /// Teacher-authored remarks from the syllabus page (備註).
   late final syllabusRemarks = text().nullable()();
 
+  /// When the I-School Plus roster (classmates) was last fetched for this
+  /// offering. Null until the first roster fetch.
+  late final rosterFetchedAt = dateTime().nullable()();
+
   @override
   List<Set<Column>> get uniqueKeys => [
     {semester, number},

--- a/lib/repositories/course_repository.dart
+++ b/lib/repositories/course_repository.dart
@@ -906,10 +906,126 @@ class CourseRepository {
     throw UnimplementedError();
   }
 
-  /// Gets students enrolled in a course from I-School Plus.
+  /// Watches the I-School Plus roster (classmates) for a course offering.
   ///
-  /// Throws [Exception] on network failure.
-  Future<List<Student>> getStudents(CourseOffering courseOffering) async {
-    throw UnimplementedError();
+  /// Emits the cached roster immediately (ordered by student ID), then triggers
+  /// a background network fetch if the roster is empty or stale. The stream
+  /// re-emits automatically when the DB is updated.
+  ///
+  /// Network errors during background refresh are absorbed — the stream
+  /// continues showing stale (or empty) data rather than erroring.
+  Stream<List<Student>> watchStudents(int courseOfferingId) async* {
+    const ttl = Duration(days: 1);
+
+    final query =
+        _database.select(_database.courseOfferingStudents).join([
+            innerJoin(
+              _database.students,
+              _database.students.id.equalsExp(
+                _database.courseOfferingStudents.student,
+              ),
+            ),
+          ])
+          ..where(
+            _database.courseOfferingStudents.courseOffering.equals(
+              courseOfferingId,
+            ),
+          )
+          ..orderBy([OrderingTerm.asc(_database.students.studentId)]);
+
+    await for (final rows in query.watch()) {
+      final students = [
+        for (final row in rows) row.readTable(_database.students),
+      ];
+
+      if (students.isEmpty) {
+        try {
+          await refreshStudents(courseOfferingId);
+        } catch (_) {
+          // Absorb: yield empty below so UI exits loading state
+        }
+      }
+
+      yield students;
+
+      final offering = await (_database.select(
+        _database.courseOfferings,
+      )..where((o) => o.id.equals(courseOfferingId))).getSingleOrNull();
+      if (offering == null) return;
+
+      final age = switch (offering.rosterFetchedAt) {
+        final t? => DateTime.now().difference(t),
+        null => ttl,
+      };
+      if (age >= ttl) {
+        try {
+          await refreshStudents(courseOfferingId);
+        } catch (_) {
+          // Absorb: stale data is shown via stream
+        }
+      }
+    }
+  }
+
+  /// Fetches the fresh roster from I-School Plus and writes it to the DB.
+  ///
+  /// The [watchStudents] stream automatically emits the updated value.
+  /// Network errors propagate to the caller.
+  ///
+  /// Not every course-system offering exists on I-School Plus (e.g.
+  /// internships, or special entries with no offering number) — these resolve
+  /// to an empty roster. The fetch timestamp is recorded either way.
+  Future<void> refreshStudents(int courseOfferingId) async {
+    final offering = await (_database.select(
+      _database.courseOfferings,
+    )..where((o) => o.id.equals(courseOfferingId))).getSingleOrNull();
+    if (offering == null) return;
+
+    final number = offering.number;
+    final dtos = number == null
+        ? const <StudentDto>[]
+        : await _authRepository.withAuth(() async {
+            // Resolve the offering number to its internal I-School Plus handle.
+            final courses = await _iSchoolPlusService.getCourseList();
+            for (final course in courses) {
+              if (course.courseNumber == number) {
+                return _iSchoolPlusService.getStudents(course);
+              }
+            }
+            // Offering not available on I-School Plus.
+            return <StudentDto>[];
+          }, sso: [.iSchoolPlusService]);
+
+    await _database.transaction(() async {
+      // Replace the roster for this offering.
+      await (_database.delete(
+        _database.courseOfferingStudents,
+      )..where((s) => s.courseOffering.equals(courseOfferingId))).go();
+
+      for (final dto in dtos) {
+        // Students are keyed by their ID; skip rows missing one.
+        if (dto.id case final studentId?) {
+          final studentRowId = await _database.upsertStudent(
+            studentId: studentId,
+            name: dto.name,
+          );
+          await _database
+              .into(_database.courseOfferingStudents)
+              .insert(
+                CourseOfferingStudentsCompanion.insert(
+                  courseOffering: courseOfferingId,
+                  student: studentRowId,
+                ),
+                mode: .insertOrIgnore,
+              );
+        }
+      }
+
+      await (_database.update(
+        _database.courseOfferings,
+      )..where((o) => o.id.equals(courseOfferingId))).write(
+        CourseOfferingsCompanion(rosterFetchedAt: Value(DateTime.now())),
+      );
+    });
   }
 }


### PR DESCRIPTION
## Summary

Wires `CourseRepository` to the I-School Plus roster (classmates), implementing the previously-stubbed `getStudents`. This is the **repository/data layer** for course rosters — part of #226's "more query features (大綱、同學、教材、公告)" line.

- **`watchStudents(int courseOfferingId)`** → `Stream<List<Student>>`. Backed by a Drift `.watch()` join over `CourseOfferingStudents`/`Students`, ordered by student ID. Emits the cached roster immediately, then background-fetches when empty or stale. Follows the repo's standard `watchX`/`refreshX` pattern; refresh errors are absorbed (stale data preferred).
- **`refreshStudents(int courseOfferingId)`** → imperative counterpart. Resolves the offering number → I-School Plus handle, fetches the roster, replaces the junction rows, and stamps the new `CourseOfferings.rosterFetchedAt` cache timestamp.
- **`upsertStudent`** DB action keyed on the unique `studentId` (a null name never overwrites a known one).
- **`CourseOfferings.rosterFetchedAt`** cache column (1-day TTL), following the documented parent-row cache-timestamp convention.

## Behavior notes

- Offerings absent from I-School Plus (internships, special entries with no number) resolve to an empty roster; the timestamp is recorded either way, so an empty/off-platform roster doesn't re-fetch on every stream emission.
- Students with a null ID are skipped (can't key them without the unique `studentId`).
- Demo mode works end-to-end — the mock course numbers in `mock_course_service.dart` match the mock roster handles.

## Not in this PR

- **UI**: the course-table detail sheet wiring (provider + i18n + sheet rendering) is intentionally left out — these methods aren't consumed yet. It'll follow in a separate PR so the data layer can be reviewed on its own.
- **Caching/index**: querying *courses-for-a-student* (the reverse junction lookup) still needs the `course_offering_student_student` index per AGENTS.md; not added since this PR only does *students-in-a-course*.

## Docs

- AGENTS.md: CourseRepository now described as serving "related I-School Plus data"; dropped rosters from the repository-layer backlog gaps.