### PR TITLE
Generate an AI-summarized changelog for daily release notes

### DIFF
--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -1,5 +1,5 @@
 name: Generate Changelog
-description: Summarize merged PR bodies between two refs into a bilingual changelog via GitHub Models, with commit-subject fallback
+description: Summarize merged PR bodies between two refs into bilingual release notes via GitHub Models, with commit-subject fallback
 
 inputs:
   github_token:
@@ -21,8 +21,11 @@ inputs:
 
 outputs:
   changelog:
-    description: 'Markdown changelog (always non-empty; falls back to fallback_message)'
+    description: 'Bilingual Markdown changelog for the GitHub release body (always non-empty; falls back to fallback_message)'
     value: ${{ steps.generate.outputs.changelog }}
+  store_changelog:
+    description: 'Plain-text zh-TW release notes for store submissions, capped for Google Play (always non-empty; falls back to fallback_message)'
+    value: ${{ steps.generate.outputs.store_changelog }}
 
 runs:
   using: composite
@@ -39,23 +42,34 @@ runs:
       run: |
         set -uo pipefail
 
-        emit_changelog() {            # multiline-safe $GITHUB_OUTPUT
-          local delim="EOF_changelog_$RANDOM"  # unique to guard against delimiter injection
+        emit_output() {               # multiline-safe $GITHUB_OUTPUT
+          local name="$1"
+          local delim="EOF_${name}_$RANDOM"  # unique to guard against delimiter injection
           {
-            echo "changelog<<$delim"
-            printf '%s\n' "$1"
+            echo "${name}<<$delim"
+            printf '%s\n' "$2"
             echo "$delim"
           } >> "$GITHUB_OUTPUT"
         }
 
+        emit_all() {                  # $1=github markdown, $2=store plain text (pre-cap)
+          emit_output changelog "$1"
+          # Google Play allows up to 500 Unicode characters per language. jq slices by
+          # codepoint (unlike bash ${#}, which counts bytes under a C locale).
+          local store
+          store=$(printf '%s' "$2" | jq -Rrs '.[0:500]')
+          emit_output store_changelog "$store"
+        }
+
+        fallback() { emit_all "$FALLBACK" "$FALLBACK"; exit 0; }
+
         # Any unexpected non-zero exit still produces the fallback and succeeds.
-        trap 'rc=$?; if [ "$rc" -ne 0 ]; then emit_changelog "$FALLBACK"; exit 0; fi' EXIT
+        trap 'rc=$?; if [ "$rc" -ne 0 ]; then emit_all "$FALLBACK" "$FALLBACK"; exit 0; fi' EXIT
 
         # No baseline (first release, or force_build short-circuit) -> fallback.
         if [ -z "$BASE" ]; then
           echo "No baseline commit; falling back."
-          emit_changelog "$FALLBACK"
-          exit 0
+          fallback
         fi
 
         # Enumerate PRs via ONE compare call; pull #<n> from merge-commit subjects.
@@ -64,32 +78,36 @@ runs:
                 | capture("Merge pull request #(?<n>[0-9]+)").n' 2>/dev/null | sort -un)
         if [ -z "$PR_NUMBERS" ]; then
           echo "No merged PRs in range; falling back."
-          emit_changelog "$FALLBACK"
-          exit 0
+          fallback
         fi
 
-        # Fetch title+body only (no diff/stats/comments).
+        # Fetch title + author; include the body only for human PRs. Bot PRs (renovate,
+        # dependabot) attach long dependency changelogs that drown out user-facing changes
+        # — keep the title for context, omit the body. gh reports bots via author.is_bot
+        # (the login is "app/renovate", with no "[bot]" suffix to match on).
         PR_BODIES=""
         for n in $PR_NUMBERS; do
-          BLOCK=$(gh pr view "$n" --repo "$REPO" --json title,body \
-            --jq '"### " + .title + "\n\n" + (.body // "")' 2>/dev/null) || continue
+          BLOCK=$(gh pr view "$n" --repo "$REPO" --json title,body,author \
+            --jq '"===== PR: " + .title + " =====\n\n"
+                  + (if (.author.is_bot // false) then "" else (.body // "") end)' 2>/dev/null) || continue
           PR_BODIES+="$BLOCK"$'\n\n'
         done
 
-        # Clean: HTML comments, md images, md links (keep text), HTML tags, bare URLs; collapse blanks.
+        # Clean: HTML comments, md images, md links (keep text), HTML tags, bare URLs,
+        # heading markers (so no body heading rivals the ===== PR boundary); collapse blanks.
         CLEANED=$(printf '%s' "$PR_BODIES" | perl -0777 -pe '
           s/<!--.*?-->//gs;
           s/!\[[^\]]*\]\([^)]*\)//g;
           s/\[([^\]]*)\]\([^)]*\)/$1/g;
           s/<[^>]+>//g;
           s{https?://\S+}{}g;
+          s/^[ \t]*#{1,6}[ \t]+//mg;
           s/\n{3,}/\n\n/g;')
 
         # Nothing meaningful left -> fallback.
         if ! printf '%s' "$CLEANED" | grep -q '[^[:space:]]'; then
           echo "No PR content to summarize; falling back."
-          emit_changelog "$FALLBACK"
-          exit 0
+          fallback
         fi
 
         # Guard size (rarely hit for a daily delta).
@@ -100,27 +118,44 @@ runs:
 
         SYSTEM='You write release notes for a Flutter app used by NTUT student testers.
         Summarize the merged pull request descriptions into a short, user-facing changelog.
-        Output GitHub-flavored Markdown with EXACTLY two labeled groups, in this order:
-        a plain line "繁體中文：" then a bullet list, a blank line, then a plain line
-        "English:" then a bullet list.
-        Both lists describe the SAME changes (translations of each other), max 6 bullets each.
+        Return two bullet lists, "zh" (繁體中文) and "en" (English), that describe the SAME
+        changes (translations of each other), max 6 bullets each. Each bullet is one concise
+        sentence with no leading marker or numbering.
         A change is user-facing ONLY if a tester would notice it while using the app:
         new screens or features, visible UI changes, bug fixes to app behavior, performance.
         NOT user-facing (never mention these): dependency or tooling updates, CI/workflow
         changes, release process changes, documentation (including contributor docs and code
         comments), refactors, tests, translations infrastructure.
-        Each bullet = one concise sentence describing what the tester SEES or EXPERIENCES,
-        never how it was implemented. No PR numbers, author names, class/widget names, or
-        technical terms (streaming, provider, component, refactor) — say "頁面/page",
-        "畫面/screen", "更即時/updates faster" instead. Never copy widget or class names
-        from PR titles (e.g. "ListTile") — describe the visible result in plain words, or
-        if the only effect is an internal style/widget swap, treat the PR as not user-facing.
-        Do not embellish or infer benefits beyond what the PR states. Do not add a top-level heading.
-        If no PR is user-facing, output EXACTLY one bullet per language: "本次更新僅包含內部改進。"
+        Each bullet describes what the tester SEES or EXPERIENCES, never how it was implemented.
+        No PR numbers, author names, class/widget names, or technical terms (streaming, provider,
+        component, refactor) — say "頁面/page", "畫面/screen", "更即時/updates faster" instead.
+        Never copy widget or class names from PR titles (e.g. "ListTile") — describe the visible
+        result in plain words, or if the only effect is an internal style/widget swap, treat the
+        PR as not user-facing.
+        Do not embellish or infer benefits beyond what the PR states.
+        If no PR is user-facing, return EXACTLY one bullet per language: "本次更新僅包含內部改進。"
         and "This update contains only internal improvements." — do not list the chores.'
 
+        SCHEMA='{
+          "type": "json_schema",
+          "json_schema": {
+            "name": "changelog",
+            "strict": true,
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["zh", "en"],
+              "properties": {
+                "zh": {"type": "array", "maxItems": 6, "items": {"type": "string"}},
+                "en": {"type": "array", "maxItems": 6, "items": {"type": "string"}}
+              }
+            }
+          }
+        }'
+
         REQ=$(jq -n --arg model "openai/gpt-4.1" --arg sys "$SYSTEM" --arg usr "$CLEANED" \
-          '{model:$model, temperature:0.2,
+          --argjson fmt "$SCHEMA" \
+          '{model:$model, temperature:0.2, response_format:$fmt,
             messages:[{role:"system",content:$sys},{role:"user",content:$usr}]}')
 
         OUT=$(mktemp)
@@ -133,15 +168,22 @@ runs:
 
         if [ "$CODE" != "200" ]; then
           echo "Models API HTTP $CODE; falling back." >&2
-          emit_changelog "$FALLBACK"
-          exit 0
+          fallback
         fi
 
-        SUMMARY=$(jq -r '.choices[0].message.content // empty' "$OUT")
-        if [ -z "$SUMMARY" ]; then
-          echo "Empty model response; falling back." >&2
-          emit_changelog "$FALLBACK"
-          exit 0
+        # response_format guarantees message.content is a JSON string matching SCHEMA.
+        DATA=$(jq -r '.choices[0].message.content // empty' "$OUT")
+        if ! printf '%s' "$DATA" | jq -e '.zh and .en' >/dev/null 2>&1; then
+          echo "Missing or malformed model response; falling back." >&2
+          fallback
         fi
 
-        emit_changelog "$SUMMARY"
+        # GitHub release body: bilingual Markdown.
+        GITHUB_MD=$(printf '%s' "$DATA" | jq -r '
+          "繁體中文：\n" + (.zh | map("- " + .) | join("\n")) +
+          "\n\nEnglish:\n" + (.en | map("- " + .) | join("\n"))')
+
+        # Store notes: plain zh-TW, one bullet per line.
+        STORE_ZH=$(printf '%s' "$DATA" | jq -r '.zh | map("- " + .) | join("\n")')
+
+        emit_all "$GITHUB_MD" "$STORE_ZH"

--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -1,0 +1,147 @@
+name: Generate Changelog
+description: Summarize merged PR bodies between two refs into a bilingual changelog via GitHub Models, with commit-subject fallback
+
+inputs:
+  github_token:
+    description: 'Token with contents:read and models:read'
+    required: true
+  last_sha:
+    description: 'Previous release commit (empty = no baseline)'
+    required: false
+  head_ref:
+    description: 'Head ref being released (SHA or branch name)'
+    required: true
+  fallback_message:
+    description: 'Commit subject used when summarization is unavailable'
+    required: true
+  repository:
+    description: 'owner/repo'
+    required: false
+    default: ${{ github.repository }}
+
+outputs:
+  changelog:
+    description: 'Markdown changelog (always non-empty; falls back to fallback_message)'
+    value: ${{ steps.generate.outputs.changelog }}
+
+runs:
+  using: composite
+  steps:
+    - name: Generate changelog
+      id: generate
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        REPO: ${{ inputs.repository }}
+        BASE: ${{ inputs.last_sha }}
+        HEAD_REF: ${{ inputs.head_ref }}
+        FALLBACK: ${{ inputs.fallback_message }}
+      run: |
+        set -uo pipefail
+
+        emit_changelog() {            # multiline-safe $GITHUB_OUTPUT
+          local delim="EOF_changelog"
+          {
+            echo "changelog<<$delim"
+            printf '%s\n' "$1"
+            echo "$delim"
+          } >> "$GITHUB_OUTPUT"
+        }
+
+        # Any unexpected non-zero exit still produces the fallback and succeeds.
+        trap 'rc=$?; if [ "$rc" -ne 0 ]; then emit_changelog "$FALLBACK"; exit 0; fi' EXIT
+
+        # No baseline (first release, or force_build short-circuit) -> fallback.
+        if [ -z "$BASE" ]; then
+          echo "No baseline commit; falling back."
+          emit_changelog "$FALLBACK"
+          exit 0
+        fi
+
+        # Enumerate PRs via ONE compare call; pull #<n> from merge-commit subjects.
+        PR_NUMBERS=$(gh api "repos/$REPO/compare/$BASE...$HEAD_REF" \
+          --jq '.commits[].commit.message | split("\n")[0]
+                | capture("Merge pull request #(?<n>[0-9]+)").n' 2>/dev/null | sort -un)
+        if [ -z "$PR_NUMBERS" ]; then
+          echo "No merged PRs in range; falling back."
+          emit_changelog "$FALLBACK"
+          exit 0
+        fi
+
+        # Fetch title+body only (no diff/stats/comments).
+        PR_BODIES=""
+        for n in $PR_NUMBERS; do
+          BLOCK=$(gh pr view "$n" --repo "$REPO" --json title,body \
+            --jq '"### " + .title + "\n\n" + (.body // "")' 2>/dev/null) || continue
+          PR_BODIES+="$BLOCK"$'\n\n'
+        done
+
+        # Clean: HTML comments, md images, md links (keep text), HTML tags, bare URLs; collapse blanks.
+        CLEANED=$(printf '%s' "$PR_BODIES" | perl -0777 -pe '
+          s/<!--.*?-->//gs;
+          s/!\[[^\]]*\]\([^)]*\)//g;
+          s/\[([^\]]*)\]\([^)]*\)/$1/g;
+          s/<[^>]+>//g;
+          s{https?://\S+}{}g;
+          s/\n{3,}/\n\n/g;')
+
+        # Nothing meaningful left -> fallback.
+        if ! printf '%s' "$CLEANED" | grep -q '[^[:space:]]'; then
+          echo "No PR content to summarize; falling back."
+          emit_changelog "$FALLBACK"
+          exit 0
+        fi
+
+        # Guard size (rarely hit for a daily delta).
+        MAX_CHARS=24000
+        if [ "${#CLEANED}" -gt "$MAX_CHARS" ]; then
+          CLEANED="${CLEANED:0:$MAX_CHARS}"$'\n\n[...truncated...]'
+        fi
+
+        SYSTEM='You write release notes for a Flutter app used by NTUT student testers.
+        Summarize the merged pull request descriptions into a short, user-facing changelog.
+        Output GitHub-flavored Markdown with EXACTLY two labeled groups, in this order:
+        a plain line "繁體中文：" then a bullet list, a blank line, then a plain line
+        "English:" then a bullet list.
+        Both lists describe the SAME changes (translations of each other), max 6 bullets each.
+        A change is user-facing ONLY if a tester would notice it while using the app:
+        new screens or features, visible UI changes, bug fixes to app behavior, performance.
+        NOT user-facing (never mention these): dependency or tooling updates, CI/workflow
+        changes, release process changes, documentation (including contributor docs and code
+        comments), refactors, tests, translations infrastructure.
+        Each bullet = one concise sentence describing what the tester SEES or EXPERIENCES,
+        never how it was implemented. No PR numbers, author names, class/widget names, or
+        technical terms (streaming, provider, component, refactor) — say "頁面/page",
+        "畫面/screen", "更即時/updates faster" instead. Never copy widget or class names
+        from PR titles (e.g. "ListTile") — describe the visible result in plain words, or
+        if the only effect is an internal style/widget swap, treat the PR as not user-facing.
+        Do not embellish or infer benefits beyond what the PR states. Do not add a top-level heading.
+        If no PR is user-facing, output EXACTLY one bullet per language: "本次更新僅包含內部改進。"
+        and "This update contains only internal improvements." — do not list the chores.'
+
+        REQ=$(jq -n --arg model "openai/gpt-4.1" --arg sys "$SYSTEM" --arg usr "$CLEANED" \
+          '{model:$model, temperature:0.2,
+            messages:[{role:"system",content:$sys},{role:"user",content:$usr}]}')
+
+        OUT=$(mktemp)
+        CODE=$(curl -sS -o "$OUT" -w '%{http_code}' --max-time 60 \
+          -X POST "https://models.github.ai/inference/chat/completions" \
+          -H "Authorization: Bearer $GH_TOKEN" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/vnd.github+json" \
+          -d "$REQ" || echo "000")
+
+        if [ "$CODE" != "200" ]; then
+          echo "Models API HTTP $CODE; falling back." >&2
+          emit_changelog "$FALLBACK"
+          exit 0
+        fi
+
+        SUMMARY=$(jq -r '.choices[0].message.content // empty' "$OUT")
+        if [ -z "$SUMMARY" ]; then
+          echo "Empty model response; falling back." >&2
+          emit_changelog "$FALLBACK"
+          exit 0
+        fi
+
+        emit_changelog "$SUMMARY"

--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -40,7 +40,7 @@ runs:
         set -uo pipefail
 
         emit_changelog() {            # multiline-safe $GITHUB_OUTPUT
-          local delim="EOF_changelog"
+          local delim="EOF_changelog_$RANDOM"  # unique to guard against delimiter injection
           {
             echo "changelog<<$delim"
             printf '%s\n' "$1"

--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -72,10 +72,12 @@ runs:
           fallback
         fi
 
-        # Enumerate PRs via ONE compare call; pull #<n> from merge-commit subjects.
-        PR_NUMBERS=$(gh api "repos/$REPO/compare/$BASE...$HEAD_REF" \
-          --jq '.commits[].commit.message | split("\n")[0]
-                | capture("Merge pull request #(?<n>[0-9]+)").n' 2>/dev/null | sort -un)
+        # Enumerate PRs by resolving each commit in the range to its associated PR(s).
+        PR_NUMBERS=$(gh api "repos/$REPO/compare/$BASE...$HEAD_REF" --jq '.commits[].sha' 2>/dev/null \
+          | while read -r sha; do
+              gh api "repos/$REPO/commits/$sha/pulls" \
+                --jq '.[] | select(.merged_at != null) | .number' 2>/dev/null
+            done | sort -un)
         if [ -z "$PR_NUMBERS" ]; then
           echo "No merged PRs in range; falling back."
           fallback
@@ -146,8 +148,8 @@ runs:
               "additionalProperties": false,
               "required": ["zh", "en"],
               "properties": {
-                "zh": {"type": "array", "maxItems": 6, "items": {"type": "string"}},
-                "en": {"type": "array", "maxItems": 6, "items": {"type": "string"}}
+                "zh": {"type": "array", "minItems": 1, "maxItems": 6, "items": {"type": "string"}},
+                "en": {"type": "array", "minItems": 1, "maxItems": 6, "items": {"type": "string"}}
               }
             }
           }
@@ -173,8 +175,8 @@ runs:
 
         # response_format guarantees message.content is a JSON string matching SCHEMA.
         DATA=$(jq -r '.choices[0].message.content // empty' "$OUT")
-        if ! printf '%s' "$DATA" | jq -e '.zh and .en' >/dev/null 2>&1; then
-          echo "Missing or malformed model response; falling back." >&2
+        if ! printf '%s' "$DATA" | jq -e '(.zh | type=="array" and length>0) and (.en | type=="array" and length>0)' >/dev/null 2>&1; then
+          echo "Missing, malformed, or empty model response; falling back." >&2
           fallback
         fi
 

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -30,11 +30,13 @@ concurrency:
 
 permissions:
   contents: write
-  models: read
 
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      models: read
     outputs:
       build_number: ${{ steps.build-number.outputs.build_number }}
       version_suffix: ${{ steps.version-suffix.outputs.suffix }}

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -45,6 +45,7 @@ jobs:
       commit_message: ${{ steps.summary.outputs.message }}
       target_ref: ${{ steps.set-ref.outputs.ref }}
       skip_build: ${{ steps.check-changes.outputs.skip }}
+      store_changelog: ${{ steps.changelog.outputs.store_changelog }}
     steps:
       - name: Checkout Actions
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -174,6 +175,7 @@ jobs:
       PR_TITLE: "Daily Build ${{ needs.prepare.outputs.date }}"
       COMMIT_SHA: ${{ needs.prepare.outputs.commit_sha }}
       COMMIT_MESSAGE: ${{ needs.prepare.outputs.commit_message }}
+      CHANGELOG: ${{ needs.prepare.outputs.store_changelog }}
       FIREBASEAPPDISTRO_APP: ${{ secrets.FIREBASEAPPDISTRO_APP }}
     timeout-minutes: 30
     steps:
@@ -246,6 +248,7 @@ jobs:
       PR_TITLE: "Daily Build ${{ needs.prepare.outputs.date }}"
       COMMIT_SHA: ${{ needs.prepare.outputs.commit_sha }}
       COMMIT_MESSAGE: ${{ needs.prepare.outputs.commit_message }}
+      CHANGELOG: ${{ needs.prepare.outputs.store_changelog }}
       PUBLIC_TESTERS: ${{ github.event_name == 'schedule' || inputs.include_public_testers }}
     timeout-minutes: 30
     steps:

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -30,6 +30,7 @@ concurrency:
 
 permissions:
   contents: write
+  models: read
 
 jobs:
   prepare:
@@ -81,6 +82,7 @@ jobs:
           if gh release view daily &>/dev/null; then
             LAST_SHA=$(gh release view daily --json targetCommitish -q .targetCommitish)
             CURRENT_SHA=$(git rev-parse HEAD)
+            echo "last_sha=$LAST_SHA" >> $GITHUB_OUTPUT
             if [ "$LAST_SHA" = "$CURRENT_SHA" ]; then
               echo "skip=true" >> $GITHUB_OUTPUT
               echo "No changes since last daily build ($LAST_SHA). Skipping."
@@ -107,16 +109,31 @@ jobs:
           title: "Release Builds"
           build_number: ${{ steps.build-number.outputs.build_number }}
 
+      - name: Generate changelog
+        if: steps.check-changes.outputs.skip != 'true'
+        id: changelog
+        uses: ./.github/actions/generate-changelog
+        with:
+          github_token: ${{ github.token }}
+          last_sha: ${{ steps.check-changes.outputs.last_sha }}
+          head_ref: ${{ steps.set-ref.outputs.ref }}
+          fallback_message: ${{ steps.summary.outputs.message }}
+
       - name: Find or create pre-release
         if: steps.check-changes.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          CHANGELOG: ${{ steps.changelog.outputs.changelog }}
         run: |
-          BODY=$(cat <<'BODY_EOF'
+          STATIC_TOP=$(cat <<'BODY_EOF'
           **Build Number:** ${{ steps.build-number.outputs.build_number }}
           **Commit:** ${{ steps.summary.outputs.sha }}
-          **Message:** ${{ steps.summary.outputs.message }}
 
+          ## What's changed
+          BODY_EOF
+          )
+
+          STATIC_BOTTOM=$(cat <<'BODY_EOF'
           <!--android-build-->
 
           <!--ios-build-->
@@ -127,6 +144,8 @@ jobs:
           > Please use **Google Play** (Android) or **TestFlight** (iOS) for the best experience and automatic updates.
           BODY_EOF
           )
+
+          BODY=$(printf '%s\n\n%s\n\n%s\n' "$STATIC_TOP" "$CHANGELOG" "$STATIC_BOTTOM")
 
           if gh release view daily &>/dev/null; then
             gh release delete daily --yes --cleanup-tag

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,6 +18,13 @@ def changelog(pr_number, pr_title, commit_sha, commit_message)
   "#{prefix}\n#{commit_sha} #{commit_message}"
 end
 
+# Prefer the AI-generated store changelog injected by CI; fall back to PR/commit
+# info for manual builds where CHANGELOG is unset.
+def release_notes(pr_number, pr_title, commit_sha, commit_message)
+  generated = ENV["CHANGELOG"].to_s.strip
+  generated.empty? ? changelog(pr_number, pr_title, commit_sha, commit_message) : generated
+end
+
 def get_build_settings(options)
   { 
     build_number: options[:build_number] || ENV["BUILD_NUMBER"],
@@ -87,7 +94,7 @@ platform :ios do
       is_key_content_base64: true,
     )
 
-    changelog = changelog(pr_number, pr_title, commit_sha, commit_message)
+    changelog = release_notes(pr_number, pr_title, commit_sha, commit_message)
 
     target_groups = include_public_testers ? ["Private External Testers", "Public External Testers"] : ["Private External Testers"]
 
@@ -135,7 +142,7 @@ platform :android do
     pr_title = options[:pr_title] || ENV["PR_TITLE"] || "manual build"
     commit_sha = options[:commit_sha] || ENV["COMMIT_SHA"] || "manual build"
     commit_message = options[:commit_message] || ENV["COMMIT_MESSAGE"] || "This is a manual build without PR information"
-    changelog_text = changelog(pr_number, pr_title, commit_sha, commit_message)
+    changelog_text = release_notes(pr_number, pr_title, commit_sha, commit_message)
     aab_path = options[:aab] || File.expand_path("../build/app/outputs/bundle/release/app-release.aab", __dir__)
 
     target_groups = "dev-tester"
@@ -162,7 +169,7 @@ platform :android do
     commit_sha = options[:commit_sha] || ENV["COMMIT_SHA"] || "manual build"
     commit_message = options[:commit_message] || ENV["COMMIT_MESSAGE"] || "This is a manual build without PR information"
 
-    changelog_text = changelog(pr_number, pr_title, commit_sha, commit_message)
+    changelog_text = release_notes(pr_number, pr_title, commit_sha, commit_message)
     ["zh-TW"].each do |locale|
       path = "metadata/android/#{locale}/changelogs"
       FileUtils.mkdir_p(path)


### PR DESCRIPTION
Fixes #324

Adds a `generate-changelog` composite action that enumerates PRs merged since the previous daily build, strips markup noise from their bodies, and summarizes them via GitHub Models (`openai/gpt-4.1`) into bilingual (繁體中文 + English) bullet lists. The daily release body gains a `## What's changed` section in place of the single commit subject.

All failure paths (no baseline, no PRs, Models API error, unexpected crash) fall back to the commit subject and exit 0.

## Testing

Simulated the script locally against real repo history:

- A range of pure chores (#318, #323, #328–#331) collapses to a single「本次更新僅包含內部改進。」bullet.
- A range with features (#303, #315, #316) yields accurate tester-facing bullets and omits the chores.
- Verified the EXIT-trap fallback rescues an unexpected crash with exit 0.