### PR TITLE
Add CJK–Latin inter-script spacing at render time

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Dart 3 idioms not yet covered by linter rules (see [#288](https://github.com/NTU
 
 ## Typography & i18n
 
-- **No CJK–Latin spaces (in-app only):** Do not insert literal spaces between CJK and alphanumeric characters in i18n strings or UI text. Spacing is a rendering concern. GitHub discussions should still use spaces for readability.
+- **No CJK–Latin spaces in source; space at render time:** Never put literal spaces between CJK and alphanumeric characters in i18n strings or UI text — spacing is a rendering concern. Instead apply the `String.spaced` extension (`lib/utils/auto_spacing.dart`) where CJK-mixed text is displayed (i18n and dynamic NTUT content); for parameterized strings call it on the interpolated result. GitHub discussions should still use spaces for readability.
 
 ## Git and GitHub Workflows
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:tattoo/repositories/auth_repository.dart';
 import 'package:tattoo/router/app_router.dart';
 import 'package:tattoo/services/demo_mode.dart';
 import 'package:tattoo/services/firebase_service.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 
 enum ErrorType {
   flutter,
@@ -60,7 +61,7 @@ Future<void> main() async {
       if (stackTrace != null) stackTrace.toString(),
     ].join('\n');
     final errorTitle = switch (type) {
-      .flutter => t.errors.flutterError,
+      .flutter => t.errors.flutterError.spaced,
       .async => t.errors.asyncError,
       .unknown => t.errors.occurred,
     };

--- a/lib/screens/main/calendar/calendar_screen.dart
+++ b/lib/screens/main/calendar/calendar_screen.dart
@@ -5,6 +5,7 @@ import 'package:table_calendar/table_calendar.dart';
 import 'package:tattoo/database/database.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/screens/main/calendar/calendar_providers.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 
 final _dateFormatter = DateFormat('yyyy-MM-dd');
 
@@ -132,13 +133,13 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
               final subtitle = start == end ? start : '$start – $end';
 
               return ListTile(
-                title: Text(event.title ?? t.general.unknown),
+                title: Text((event.title ?? t.general.unknown).spaced),
                 subtitle: Text(subtitle),
                 trailing: switch (event.place) {
                   final place? => ConstrainedBox(
                     constraints: const BoxConstraints(maxWidth: 120),
                     child: Text(
-                      place,
+                      place.spaced,
                       overflow: .ellipsis,
                       textAlign: .end,
                     ),

--- a/lib/screens/main/course_table/course_table_cell.dart
+++ b/lib/screens/main/course_table/course_table_cell.dart
@@ -5,6 +5,7 @@ import 'package:tattoo/components/app_skeleton.dart';
 import 'package:tattoo/components/widget_preview_frame.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/course_repository.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 
 /// A single course block shown in the course table grid.
 ///
@@ -86,7 +87,7 @@ class CourseTableCell extends StatelessWidget {
                     mainAxisAlignment: .center,
                     children: [
                       AutoSizeText(
-                        courseTitle,
+                        courseTitle.spaced,
                         style: theme.textTheme.bodyMedium?.copyWith(
                           fontSize: 12,
                           fontWeight: .w700,
@@ -99,7 +100,7 @@ class CourseTableCell extends StatelessWidget {
                       if (classroomName case final classroomName?
                           when classroomName.isNotEmpty)
                         AutoSizeText(
-                          classroomName,
+                          classroomName.spaced,
                           style: theme.textTheme.bodySmall?.copyWith(
                             fontSize: 8,
                             fontWeight: .w400,
@@ -197,7 +198,7 @@ class CourseTableUnscheduledCell extends StatelessWidget {
                   dense: true,
                   visualDensity: .compact,
                   title: Text(
-                    titleText,
+                    titleText.spaced,
                     style: theme.textTheme.bodyLarge?.copyWith(
                       fontWeight: .w600,
                     ),
@@ -206,7 +207,7 @@ class CourseTableUnscheduledCell extends StatelessWidget {
                   ),
                   subtitle: switch (subtitleText) {
                     final subtitleText? => Text(
-                      subtitleText,
+                      subtitleText.spaced,
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: theme.colorScheme.onSurfaceVariant,
                       ),

--- a/lib/screens/main/course_table/course_table_detail_sheet.dart
+++ b/lib/screens/main/course_table/course_table_detail_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/course_repository.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 
 Future<void> showCourseTableDetailSheet(
   BuildContext context, {
@@ -46,9 +47,10 @@ class CourseTableDetailSheet extends StatelessWidget {
                 crossAxisAlignment: .center,
                 children: [
                   Text(
-                    cell.courseName.isNotEmpty
-                        ? cell.courseName
-                        : cell.number ?? t.general.unknown,
+                    (cell.courseName.isNotEmpty
+                            ? cell.courseName
+                            : cell.number ?? t.general.unknown)
+                        .spaced,
                     style: theme.textTheme.titleLarge,
                   ),
                 ],
@@ -72,7 +74,7 @@ class CourseTableDetailSheet extends StatelessWidget {
                     children: [
                       // TODO: replace with course name when available
                       if (cell.number case final number?) Text('課號: $number'),
-                      Text('教室: ${cell.classroomName ?? '-'}'),
+                      Text('教室: ${cell.classroomName ?? '-'}'.spaced),
                       Text('學分: ${cell.credits}'),
                       Text('時數: ${cell.hours}'),
                       Text('連續節數: ${cell.span}'),

--- a/lib/screens/main/course_table/course_table_grid.dart
+++ b/lib/screens/main/course_table/course_table_grid.dart
@@ -10,6 +10,7 @@ import 'package:tattoo/models/course.dart';
 import 'package:tattoo/repositories/course_repository.dart';
 import 'package:tattoo/screens/main/course_table/course_table_cell.dart';
 import 'package:tattoo/screens/main/course_table/course_table_detail_sheet.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 
 /// Internal value type that describes the currently visible grid scope.
 ///
@@ -594,8 +595,8 @@ class CourseTableGrid extends StatelessWidget {
       child: Center(
         child: Text(
           ' - '
-          '${t.courseTable.summary.credits(count: courseTableData.totalCredits)} · '
-          '${t.courseTable.summary.hours(count: courseTableData.totalHours)}'
+          '${t.courseTable.summary.credits(count: courseTableData.totalCredits).spaced} · '
+          '${t.courseTable.summary.hours(count: courseTableData.totalHours).spaced}'
           ' - ',
           style: Theme.of(context).textTheme.bodyMedium,
         ),

--- a/lib/screens/main/home/home_screen.dart
+++ b/lib/screens/main/home/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:tattoo/components/option_entry_tile.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/router/app_router.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 import 'package:tattoo/utils/launch_url.dart';
 
 class MainHomeScreen extends StatelessWidget {
@@ -14,14 +15,14 @@ class MainHomeScreen extends StatelessWidget {
       OptionEntryTile.svg(
         svgIconAsset: "assets/tat_icon.svg",
         actionIcon: .exitToApp,
-        title: t.home.projectTattoo.title,
+        title: t.home.projectTattoo.title.spaced,
         description: t.home.projectTattoo.description,
         onTap: () => launchUrl(.parse(t.home.projectTattoo.url)),
       ),
       OptionEntryTile.icon(
         icon: Icons.explore_outlined,
         actionIcon: .exitToApp,
-        title: t.home.ideation.title,
+        title: t.home.ideation.title.spaced,
         description: t.home.ideation.description,
         onTap: () => launchUrl(
           .parse(t.home.ideation.url),
@@ -39,14 +40,14 @@ class MainHomeScreen extends StatelessWidget {
               OptionEntryTile.icon(
                 icon: Icons.how_to_vote_outlined,
                 title: t.nav.vote,
-                description: t.home.vote.description,
+                description: t.home.vote.description.spaced,
                 onTap: () => context.push(AppRoutes.kioskLoginQr),
               ),
             ]
           : <Widget>[]),
       OptionEntryTile.icon(
         icon: Icons.qr_code_scanner,
-        title: t.scanner.loginIStudy,
+        title: t.scanner.loginIStudy.spaced,
         onTap: () => context.push(AppRoutes.scanner),
       ),
       OptionEntryTile.icon(

--- a/lib/screens/main/home_screen.dart
+++ b/lib/screens/main/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/router/app_router.dart';
 import 'package:tattoo/screens/main/profile/profile_providers.dart';
 import 'package:tattoo/screens/main/user_providers.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({
@@ -40,7 +41,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       ..hideCurrentSnackBar()
       ..showSnackBar(
         SnackBar(
-          content: Text(t.profile.passwordExpiry.warning(days: days)),
+          content: Text(
+            t.profile.passwordExpiry.warning(days: days).spaced,
+          ),
           // SnackBar defaults persist=true when an action is set; we want the
           // warning to auto-dismiss so the user isn't left staring at it.
           persist: false,

--- a/lib/screens/main/kiosk_login/kiosk_login_qr_screen.dart
+++ b/lib/screens/main/kiosk_login/kiosk_login_qr_screen.dart
@@ -8,6 +8,7 @@ import 'package:qr_flutter/qr_flutter.dart';
 import 'package:tattoo/components/notices.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/auth_repository.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 
 const _kioskLoginServiceCode = 'per_001_oauth';
 const _kioskLoginHost = 'ntut.app';
@@ -196,7 +197,7 @@ class _KioskLoginQrContentState extends State<_KioskLoginQrContent>
       onRefresh: widget.onExpired,
       child: _KioskLoginQrContainer(
         child: Semantics(
-          label: t.kioskLogin.qrCode,
+          label: t.kioskLogin.qrCode.spaced,
           child: QrImageView(
             data: widget.uri.toString(),
             version: QrVersions.auto,
@@ -341,7 +342,7 @@ class _KioskLoginQrNotice extends StatelessWidget {
   Widget build(BuildContext context) {
     return ClearNoticeVertical(
       text: TextSpan(
-        text: t.kioskLogin.notice,
+        text: t.kioskLogin.notice.spaced,
       ),
     );
   }
@@ -381,8 +382,8 @@ class _KioskLoginQrError extends StatelessWidget {
     final colorScheme = theme.colorScheme;
     final message = switch (error) {
       DioException() => t.errors.connectionFailed,
-      FormatException() => t.kioskLogin.invalidSsoUrl,
-      _ => t.kioskLogin.loadFailed,
+      FormatException() => t.kioskLogin.invalidSsoUrl.spaced,
+      _ => t.kioskLogin.loadFailed.spaced,
     };
 
     return _KioskLoginQrLayout(

--- a/lib/screens/main/kiosk_login/kiosk_login_qr_screen.dart
+++ b/lib/screens/main/kiosk_login/kiosk_login_qr_screen.dart
@@ -197,7 +197,7 @@ class _KioskLoginQrContentState extends State<_KioskLoginQrContent>
       onRefresh: widget.onExpired,
       child: _KioskLoginQrContainer(
         child: Semantics(
-          label: t.kioskLogin.qrCode.spaced,
+          label: t.kioskLogin.qrCode,
           child: QrImageView(
             data: widget.uri.toString(),
             version: QrVersions.auto,

--- a/lib/screens/main/profile/about_screen.dart
+++ b/lib/screens/main/profile/about_screen.dart
@@ -9,6 +9,7 @@ import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/preferences_repository.dart';
 import 'package:tattoo/screens/main/profile/profile_providers.dart';
 import 'package:tattoo/services/github_service.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 import 'package:tattoo/utils/launch_url.dart';
 
 final packageInfoProvider = FutureProvider.autoDispose<String>((ref) async {
@@ -65,7 +66,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(t.profile.options.about),
+        title: Text(t.profile.options.about.spaced),
       ),
       body: SafeArea(
         child: CustomScrollView(
@@ -130,10 +131,10 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                         OptionEntryTile.icon(
                           icon: Icons.article_outlined,
                           title: t.about.openSourceLicenses,
-                          description: t.about.viewOpenSourceLicenses,
+                          description: t.about.viewOpenSourceLicenses.spaced,
                           onTap: () => showLicensePage(
                             context: context,
-                            applicationLegalese: t.about.copyright,
+                            applicationLegalese: t.about.copyright.spaced,
                             applicationName: t.general.appTitle,
                             applicationVersion: packageInfoAsync.value ?? '...',
                           ),
@@ -141,7 +142,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                         OptionEntryTile.icon(
                           icon: Icons.translate,
                           title: 'Crowdin',
-                          description: t.about.helpTranslate,
+                          description: t.about.helpTranslate.spaced,
                           onTap: () => launchUrl(
                             .parse('https://translate.ntut.club'),
                           ),
@@ -237,7 +238,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
 
                     // Copyright
                     Text.rich(
-                      TextSpan(text: t.about.copyright),
+                      TextSpan(text: t.about.copyright.spaced),
                       style: theme.textTheme.bodySmall?.copyWith(
                         height: 1.6,
                         color: Colors.grey[600],

--- a/lib/screens/main/profile/profile_card.dart
+++ b/lib/screens/main/profile/profile_card.dart
@@ -8,6 +8,7 @@ import 'package:tattoo/database/database.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/screens/main/profile/profile_providers.dart';
 import 'package:tattoo/screens/main/user_providers.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 
 const _placeholderProfile = User(
   id: 0,
@@ -167,9 +168,10 @@ class ProfileContent extends StatelessWidget {
                         // fix horizontal alignment with other text
                         offset: Offset(-height * 0.01, 0),
                         child: Text(
-                          profile.nameZh.isNotEmpty
-                              ? profile.nameZh
-                              : t.general.unknown,
+                          (profile.nameZh.isNotEmpty
+                                  ? profile.nameZh
+                                  : t.general.unknown)
+                              .spaced,
                           maxLines: 1,
                           overflow: .ellipsis,
                           style: textTheme.titleMedium?.copyWith(
@@ -182,7 +184,7 @@ class ProfileContent extends StatelessWidget {
                         ),
                       ),
                       Text(
-                        profile.departmentZh ?? '',
+                        (profile.departmentZh ?? '').spaced,
                         maxLines: 1,
                         overflow: .ellipsis,
                       ),
@@ -194,6 +196,7 @@ class ProfileContent extends StatelessWidget {
                       Text(
                         registration != null
                             ? '${registration!.year}-${registration!.term} ${registration!.className ?? ''}'
+                                  .spaced
                             : '',
                         maxLines: 1,
                         overflow: .ellipsis,

--- a/lib/screens/main/profile/profile_danger_zone.dart
+++ b/lib/screens/main/profile/profile_danger_zone.dart
@@ -11,6 +11,7 @@ import 'package:tattoo/repositories/auth_repository.dart';
 import 'package:tattoo/repositories/preferences_repository.dart';
 import 'package:tattoo/screens/main/profile/profile_providers.dart';
 import 'package:tattoo/screens/main/user_providers.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 import 'package:tattoo/utils/http.dart';
 import 'package:tattoo/utils/shared_preferences.dart';
 
@@ -29,14 +30,20 @@ class ProfileDangerZone extends ConsumerWidget {
     } catch (e) {
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(t.profile.dangerZone.clearFailed(item: item))),
+          SnackBar(
+            content: Text(
+              t.profile.dangerZone.clearFailed(item: item).spaced,
+            ),
+          ),
         );
       }
       rethrow;
     }
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(t.profile.dangerZone.cleared(item: item))),
+        SnackBar(
+          content: Text(t.profile.dangerZone.cleared(item: item).spaced),
+        ),
       );
     }
   }
@@ -124,14 +131,14 @@ class ProfileDangerZone extends ConsumerWidget {
             ),
             OptionEntryTile.icon(
               icon: Icons.sports_bar_outlined,
-              title: t.profile.dangerZone.goAction(action: action),
+              title: t.profile.dangerZone.goAction(action: action).spaced,
               color: dangerColor,
               borderColor: dangerColor,
               onTap: () => _goAction(action),
             ),
             OptionEntryTile.icon(
               icon: Icons.bug_report_outlined,
-              title: t.profile.dangerZone.nonFlutterCrash,
+              title: t.profile.dangerZone.nonFlutterCrash.spaced,
               color: dangerColor,
               borderColor: dangerColor,
               onTap: _triggerNonFlutterCrash,
@@ -145,7 +152,7 @@ class ProfileDangerZone extends ConsumerWidget {
             ),
             OptionEntryTile.icon(
               icon: Icons.cookie_outlined,
-              title: t.profile.dangerZone.clearCookies,
+              title: t.profile.dangerZone.clearCookies.spaced,
               color: dangerColor,
               borderColor: dangerColor,
               onTap: () => _clearCookies(context),

--- a/lib/screens/main/profile/profile_screen.dart
+++ b/lib/screens/main/profile/profile_screen.dart
@@ -12,6 +12,7 @@ import 'package:tattoo/repositories/auth_repository.dart';
 import 'package:tattoo/router/app_router.dart';
 import 'package:tattoo/screens/main/profile/profile_card.dart';
 import 'package:tattoo/screens/main/profile/profile_danger_zone.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 import 'package:tattoo/utils/launch_url.dart';
 
 class ProfileScreen extends ConsumerWidget {
@@ -56,7 +57,7 @@ class ProfileScreen extends ConsumerWidget {
 
   String _mapChangeAvatarError(Object error) {
     return switch (error) {
-      AvatarTooLargeException() => t.profile.avatar.tooLarge,
+      AvatarTooLargeException() => t.profile.avatar.tooLarge.spaced,
       FormatException() => t.profile.avatar.invalidFormat,
       DioException() => t.errors.connectionFailed,
       _ => t.profile.avatar.uploadFailed,
@@ -110,7 +111,7 @@ class ProfileScreen extends ConsumerWidget {
       ),
       OptionEntryTile.icon(
         icon: Icons.info_outline,
-        title: t.profile.options.about,
+        title: t.profile.options.about.spaced,
         onTap: () => context.push(AppRoutes.about),
       ),
       OptionEntryTile.svg(

--- a/lib/screens/main/scanner/scanner_guide_bottom_sheet.dart
+++ b/lib/screens/main/scanner/scanner_guide_bottom_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:tattoo/i18n/strings.g.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 
 class ScannerGuideSheet extends StatelessWidget {
   final DraggableScrollableController controller;
@@ -131,7 +132,7 @@ class ScannerGuideSheet extends StatelessWidget {
         ),
         const SizedBox(height: 16),
         Text(
-          message,
+          message.spaced,
           textAlign: .center,
           style: theme.textTheme.bodyLarge,
         ),

--- a/lib/screens/main/scanner/scanner_screen.dart
+++ b/lib/screens/main/scanner/scanner_screen.dart
@@ -7,6 +7,7 @@ import 'package:tattoo/models/login_exception.dart';
 import 'package:tattoo/repositories/auth_repository.dart';
 import 'package:tattoo/screens/main/scanner/scanner_guide_bottom_sheet.dart';
 import 'package:tattoo/services/portal/portal_service.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 import 'package:tattoo/utils/http.dart';
 
 class ScannerScreen extends ConsumerStatefulWidget {
@@ -251,7 +252,7 @@ class _ScannerScreenState extends ConsumerState<ScannerScreen> {
 
     switch (error.errorCode) {
       case .permissionDenied:
-        message = t.scanner.permissionDenied;
+        message = t.scanner.permissionDenied.spaced;
         description = t.scanner.permissionDeniedDescription;
         icon = Icons.no_photography_outlined;
       case .unsupported:

--- a/lib/screens/main/score/score_screen.dart
+++ b/lib/screens/main/score/score_screen.dart
@@ -367,7 +367,7 @@ class _ScoreTile extends StatelessWidget {
       visualDensity: .compact,
       contentPadding: const .symmetric(horizontal: 8, vertical: 0),
       title: Text(
-        localized(score.nameZh, score.nameEn),
+        localized(score.nameZh, score.nameEn).spaced,
         style: Theme.of(context).textTheme.titleMedium,
       ),
       subtitle: Text(

--- a/lib/screens/main/score/score_screen.dart
+++ b/lib/screens/main/score/score_screen.dart
@@ -10,6 +10,7 @@ import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/student_repository.dart';
 import 'package:tattoo/screens/main/score/score_providers.dart';
 import 'package:tattoo/screens/main/score/score_view_helpers.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 import 'package:tattoo/utils/localized.dart';
 
 const _loadingSemesterTabLabels = ['114-2', '114-1', '113-2'];
@@ -295,7 +296,7 @@ class _SemesterSummaryCard extends StatelessWidget {
               children: [
                 _buildStat(
                   context,
-                  t.score.summary.cumulativeGpa,
+                  t.score.summary.cumulativeGpa.spaced,
                   _formatDouble(summary.gpa),
                 ),
                 const SizedBox(width: 24),

--- a/lib/utils/auto_spacing.dart
+++ b/lib/utils/auto_spacing.dart
@@ -1,0 +1,37 @@
+/// Inserts a four-per-em space (U+2005) between adjacent CJK ideographs and
+/// Latin letters or digits, approximating the inter-script gap specified by the
+/// W3C's Requirements for Chinese Text Layout (CLREQ) and CSS
+/// `text-autospace: ideograph-alpha ideograph-numeric`.
+///
+/// CLREQ targets *flexible* spacing applied by the layout engine — a default of
+/// 1/4 em, compressible to 1/8 em and expandable to 1/2 em during
+/// justification. Flutter has no native inter-script spacing
+/// (https://github.com/flutter/flutter/issues/94531), so this inserts a fixed
+/// U+2005 (exactly 1/4 em, the CLREQ resting width) as the closest static
+/// approximation. Hardcoding a regular space in source strings instead would
+/// produce an incorrect ~1/2 em gap and double up if native support ever lands,
+/// so apply this at render time — see issue #178.
+///
+/// Only Han ideographs are treated as CJK and only ASCII letters/digits as
+/// Latin; punctuation on either side is left untouched, matching the CSS spec.
+/// For non-mixed text (e.g. English-only strings) this is a cheap no-op.
+extension AutoSpacing on String {
+  static const _space = '\u2005';
+
+  // CJK Extension A, Unified Ideographs, and Compatibility Ideographs.
+  static const _cjk = '\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF';
+  static const _latin = 'A-Za-z0-9';
+
+  static final _cjkThenLatin = RegExp('([$_cjk])([$_latin])');
+  static final _latinThenCjk = RegExp('([$_latin])([$_cjk])');
+
+  /// This string with 1/4-em spaces inserted at CJK–Latin boundaries.
+  String get spaced =>
+      replaceAllMapped(
+        _cjkThenLatin,
+        (m) => '${m[1]}$_space${m[2]}',
+      ).replaceAllMapped(
+        _latinThenCjk,
+        (m) => '${m[1]}$_space${m[2]}',
+      );
+}

--- a/test/utils/auto_spacing_test.dart
+++ b/test/utils/auto_spacing_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
+
+void main() {
+  final sp = String.fromCharCode(0x2005); // FOUR-PER-EM SPACE (1/4 em)
+
+  group('spaced', () {
+    test('inserts a space between CJK and following Latin', () {
+      expect('關於TAT'.spaced, '關於${sp}TAT');
+    });
+
+    test('inserts a space between Latin and following CJK', () {
+      expect('TAT的實作'.spaced, 'TAT$sp的實作');
+    });
+
+    test('spaces both sides of an embedded Latin run', () {
+      expect('發生Flutter錯誤'.spaced, '發生${sp}Flutter$sp錯誤');
+    });
+
+    test('spaces digits against CJK', () {
+      expect('歷年GPA'.spaced, '歷年${sp}GPA');
+      expect('密碼將在1天後過期'.spaced, '密碼將在${sp}1$sp天後過期');
+    });
+
+    test('leaves ASCII punctuation between scripts untouched', () {
+      // Closing paren is punctuation, not a letter/digit — no space added.
+      expect('Project Tattoo (TAT)是'.spaced, 'Project Tattoo (TAT)是');
+    });
+
+    test('is a no-op for English-only text', () {
+      expect('Project Tattoo'.spaced, 'Project Tattoo');
+    });
+
+    test('is a no-op for CJK-only text', () {
+      expect('北科生活'.spaced, '北科生活');
+    });
+
+    test('is idempotent', () {
+      final once = '關於TAT'.spaced;
+      expect(once.spaced, once);
+    });
+
+    test('handles empty string', () {
+      expect(''.spaced, '');
+    });
+  });
+}


### PR DESCRIPTION
Closes #178.

## Problem

Mixed CJK–Latin text renders with zero spacing between scripts (e.g. `關於Project Tattoo`, `歷年GPA`, `清除Cookies`). The correct inter-script gap is ~1/4 em per W3C CLREQ. Flutter has no native support (tracked upstream as flutter issue 94531, open since 2021 with no progress), and hardcoding spaces in i18n strings produces an incorrect ~1/2 em gap that would double up if native support ever lands.

## Approach

This implements **option B** from the issue (string extension + call-site adoption).

- **`String.spaced`** (`lib/utils/auto_spacing.dart`) — inserts a **four-per-em space (U+2005, exactly 1/4 em)** at Han↔Latin boundaries. U+2005 matches CLREQ's resting width; the spec's ideal is *flexible* 1/8–1/2 em spacing the layout engine stretches during justification, which no fixed character can replicate, so this is the closest static approximation. Only Han ideographs (Unified, Ext-A, Compatibility) vs. ASCII letters/digits are spaced — punctuation is left untouched, matching CSS `text-autospace: ideograph-alpha ideograph-numeric`. No-op for non-mixed text.
- **Call sites** — applied `.spaced` only where strings actually mix scripts. Each candidate i18n string was run through the extension to confirm it changes; pure no-ops were skipped (e.g. `about.description`, where the Latin runs sit inside parentheses/spaces, and the two `(rich)` strings, whose link text is CJK-only). For parameterized strings it's called on the interpolated result so runtime values are spaced too.

`en-US` has zero CJK–Latin mixers, so this only affects the `zh-TW` locale.

## Tests

`test/utils/auto_spacing_test.dart` — 9 unit tests covering both boundary directions, embedded Latin runs, digits, punctuation pass-through, no-ops, idempotency, and empty input.

## Docs

Updated the **Typography & i18n** section of `CONTRIBUTING.md` to fold the render-time spacing guidance into the existing no-source-spaces rule.