### PR TITLE
chore: clean up Flutter 3.44 upgrade aftermath

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# Committed so the Flutter migrator stops re-adding them on every build. AGP 9
+# opt-outs (built-in Kotlin, new DSL); inert no-ops under the current AGP 8.
+android.newDsl=false
+android.builtInKotlin=false

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -535,12 +535,12 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "380a129f7d5d25cdb560050ae23dd0cf74bf301f41c0241e4c59c9b55cb87ac0"
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.0-beta.1"
+    version: "10.3.1"
   flutter_secure_storage_darwin:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: flutter_secure_storage_darwin
       sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   riverpod: ^3.2.1
   flutter_riverpod: ^3.3.1
   go_router: ^17.2.3
-  flutter_secure_storage: ^11.0.0-beta.1
+  flutter_secure_storage: ^10.3.1
   package_info_plus: ^10.1.0
   image_picker: ^1.2.2
   skeletonizer: ^2.1.3
@@ -49,6 +49,11 @@ dependencies:
   table_calendar: ^3.2.0
   mobile_scanner: ^7.2.0
   qr_flutter: ^4.1.0
+
+# darwin <=0.3.2 declares iOS 12.0 but uses iOS-13+ CryptoKit, breaking the SPM
+# iOS build. 0.4.0 only raises that floor. Drop once fss 11 ships stable.
+dependency_overrides:
+  flutter_secure_storage_darwin: ^0.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Two pieces of leftover drift from the Flutter 3.44 upgrade (#328), independent of the parked AGP 9 work (#27).

- **`7ed7d0b chore: track stable flutter_secure_storage with darwin 0.4.0 override`** — replace the `11.0.0-beta.1` prerelease pin with stable `10.3.1`, and force `flutter_secure_storage_darwin 0.4.0` via `dependency_overrides`. 0.4.0 carries the SPM iOS-13 CryptoKit fix (raises its `Package.swift` floor to 13.0) without dragging in a prerelease Dart layer. Verified: Android debug + iOS **release** build.
- **`a949d0b chore(android): commit Flutter migrator gradle.properties flags`** — the Flutter 3.44 migrator re-adds `android.newDsl=false` / `android.builtInKotlin=false` on every build when missing, dirtying the working tree. Committing them stops the drift; inert no-ops under the current AGP 8.

No functional/runtime change; both are build/dependency housekeeping.