### PR TITLE
feat: support multiple syllabuses per course offering

### DIFF
--- a/lib/database/actions.dart
+++ b/lib/database/actions.dart
@@ -217,7 +217,6 @@ extension DatabaseActions on AppDatabase {
     String? status,
     String? language,
     String? remarks,
-    String? syllabusId,
   }) async {
     return (await into(courseOfferings).insertReturning(
       CourseOfferingsCompanion.insert(
@@ -232,7 +231,6 @@ extension DatabaseActions on AppDatabase {
         status: Value(status),
         language: Value(language),
         remarks: Value(remarks),
-        syllabusId: Value(syllabusId),
       ),
       onConflict: DoUpdate(
         (old) => CourseOfferingsCompanion(
@@ -245,7 +243,6 @@ extension DatabaseActions on AppDatabase {
           status: Value(status),
           language: Value(language),
           remarks: Value(remarks),
-          syllabusId: Value(syllabusId),
         ),
         target: [courseOfferings.semester, courseOfferings.number],
       ),

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -40,6 +40,7 @@ final databaseProvider = Provider<AppDatabase>((ref) {
     CourseOfferingClasses,
     CourseOfferingStudents,
     Schedules,
+    Syllabuses,
     Materials,
     TeacherSemesters,
     TeacherOfficeHours,

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -6418,17 +6418,6 @@ class $SyllabusesTable extends Syllabuses
       'PRIMARY KEY AUTOINCREMENT',
     ),
   );
-  static const VerificationMeta _fetchedAtMeta = const VerificationMeta(
-    'fetchedAt',
-  );
-  @override
-  late final GeneratedColumn<DateTime> fetchedAt = GeneratedColumn<DateTime>(
-    'fetched_at',
-    aliasedName,
-    true,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-  );
   static const VerificationMeta _courseOfferingMeta = const VerificationMeta(
     'courseOffering',
   );
@@ -6526,7 +6515,6 @@ class $SyllabusesTable extends Syllabuses
   @override
   List<GeneratedColumn> get $columns => [
     id,
-    fetchedAt,
     courseOffering,
     teacher,
     updatedAt,
@@ -6550,12 +6538,6 @@ class $SyllabusesTable extends Syllabuses
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
-    }
-    if (data.containsKey('fetched_at')) {
-      context.handle(
-        _fetchedAtMeta,
-        fetchedAt.isAcceptableOrUnknown(data['fetched_at']!, _fetchedAtMeta),
-      );
     }
     if (data.containsKey('course_offering')) {
       context.handle(
@@ -6629,10 +6611,6 @@ class $SyllabusesTable extends Syllabuses
         DriftSqlType.int,
         data['${effectivePrefix}id'],
       )!,
-      fetchedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}fetched_at'],
-      ),
       courseOffering: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}course_offering'],
@@ -6678,16 +6656,6 @@ class Syllabus extends DataClass implements Insertable<Syllabus> {
   /// Auto-incrementing primary key.
   final int id;
 
-  /// Timestamp of when complete data was last fetched from the server.
-  ///
-  /// - `null`: Only partial/basic information is available (e.g., name + ID from a list page)
-  /// - `non-null`: Complete details have been fetched (e.g., full profile from detail page)
-  ///
-  /// Use this field to:
-  /// - Determine if a detail fetch is needed (null = need to fetch)
-  /// - Implement cache expiration (old timestamp = stale, re-fetch)
-  final DateTime? fetchedAt;
-
   /// Reference to the course offering this syllabus belongs to.
   final int courseOffering;
 
@@ -6716,7 +6684,6 @@ class Syllabus extends DataClass implements Insertable<Syllabus> {
   final String? remarks;
   const Syllabus({
     required this.id,
-    this.fetchedAt,
     required this.courseOffering,
     required this.teacher,
     this.updatedAt,
@@ -6730,9 +6697,6 @@ class Syllabus extends DataClass implements Insertable<Syllabus> {
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['id'] = Variable<int>(id);
-    if (!nullToAbsent || fetchedAt != null) {
-      map['fetched_at'] = Variable<DateTime>(fetchedAt);
-    }
     map['course_offering'] = Variable<int>(courseOffering);
     map['teacher'] = Variable<int>(teacher);
     if (!nullToAbsent || updatedAt != null) {
@@ -6759,9 +6723,6 @@ class Syllabus extends DataClass implements Insertable<Syllabus> {
   SyllabusesCompanion toCompanion(bool nullToAbsent) {
     return SyllabusesCompanion(
       id: Value(id),
-      fetchedAt: fetchedAt == null && nullToAbsent
-          ? const Value.absent()
-          : Value(fetchedAt),
       courseOffering: Value(courseOffering),
       teacher: Value(teacher),
       updatedAt: updatedAt == null && nullToAbsent
@@ -6792,7 +6753,6 @@ class Syllabus extends DataClass implements Insertable<Syllabus> {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return Syllabus(
       id: serializer.fromJson<int>(json['id']),
-      fetchedAt: serializer.fromJson<DateTime?>(json['fetchedAt']),
       courseOffering: serializer.fromJson<int>(json['courseOffering']),
       teacher: serializer.fromJson<int>(json['teacher']),
       updatedAt: serializer.fromJson<DateTime?>(json['updatedAt']),
@@ -6808,7 +6768,6 @@ class Syllabus extends DataClass implements Insertable<Syllabus> {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return <String, dynamic>{
       'id': serializer.toJson<int>(id),
-      'fetchedAt': serializer.toJson<DateTime?>(fetchedAt),
       'courseOffering': serializer.toJson<int>(courseOffering),
       'teacher': serializer.toJson<int>(teacher),
       'updatedAt': serializer.toJson<DateTime?>(updatedAt),
@@ -6822,7 +6781,6 @@ class Syllabus extends DataClass implements Insertable<Syllabus> {
 
   Syllabus copyWith({
     int? id,
-    Value<DateTime?> fetchedAt = const Value.absent(),
     int? courseOffering,
     int? teacher,
     Value<DateTime?> updatedAt = const Value.absent(),
@@ -6833,7 +6791,6 @@ class Syllabus extends DataClass implements Insertable<Syllabus> {
     Value<String?> remarks = const Value.absent(),
   }) => Syllabus(
     id: id ?? this.id,
-    fetchedAt: fetchedAt.present ? fetchedAt.value : this.fetchedAt,
     courseOffering: courseOffering ?? this.courseOffering,
     teacher: teacher ?? this.teacher,
     updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
@@ -6846,7 +6803,6 @@ class Syllabus extends DataClass implements Insertable<Syllabus> {
   Syllabus copyWithCompanion(SyllabusesCompanion data) {
     return Syllabus(
       id: data.id.present ? data.id.value : this.id,
-      fetchedAt: data.fetchedAt.present ? data.fetchedAt.value : this.fetchedAt,
       courseOffering: data.courseOffering.present
           ? data.courseOffering.value
           : this.courseOffering,
@@ -6868,7 +6824,6 @@ class Syllabus extends DataClass implements Insertable<Syllabus> {
   String toString() {
     return (StringBuffer('Syllabus(')
           ..write('id: $id, ')
-          ..write('fetchedAt: $fetchedAt, ')
           ..write('courseOffering: $courseOffering, ')
           ..write('teacher: $teacher, ')
           ..write('updatedAt: $updatedAt, ')
@@ -6884,7 +6839,6 @@ class Syllabus extends DataClass implements Insertable<Syllabus> {
   @override
   int get hashCode => Object.hash(
     id,
-    fetchedAt,
     courseOffering,
     teacher,
     updatedAt,
@@ -6899,7 +6853,6 @@ class Syllabus extends DataClass implements Insertable<Syllabus> {
       identical(this, other) ||
       (other is Syllabus &&
           other.id == this.id &&
-          other.fetchedAt == this.fetchedAt &&
           other.courseOffering == this.courseOffering &&
           other.teacher == this.teacher &&
           other.updatedAt == this.updatedAt &&
@@ -6912,7 +6865,6 @@ class Syllabus extends DataClass implements Insertable<Syllabus> {
 
 class SyllabusesCompanion extends UpdateCompanion<Syllabus> {
   final Value<int> id;
-  final Value<DateTime?> fetchedAt;
   final Value<int> courseOffering;
   final Value<int> teacher;
   final Value<DateTime?> updatedAt;
@@ -6923,7 +6875,6 @@ class SyllabusesCompanion extends UpdateCompanion<Syllabus> {
   final Value<String?> remarks;
   const SyllabusesCompanion({
     this.id = const Value.absent(),
-    this.fetchedAt = const Value.absent(),
     this.courseOffering = const Value.absent(),
     this.teacher = const Value.absent(),
     this.updatedAt = const Value.absent(),
@@ -6935,7 +6886,6 @@ class SyllabusesCompanion extends UpdateCompanion<Syllabus> {
   });
   SyllabusesCompanion.insert({
     this.id = const Value.absent(),
-    this.fetchedAt = const Value.absent(),
     required int courseOffering,
     required int teacher,
     this.updatedAt = const Value.absent(),
@@ -6948,7 +6898,6 @@ class SyllabusesCompanion extends UpdateCompanion<Syllabus> {
        teacher = Value(teacher);
   static Insertable<Syllabus> custom({
     Expression<int>? id,
-    Expression<DateTime>? fetchedAt,
     Expression<int>? courseOffering,
     Expression<int>? teacher,
     Expression<DateTime>? updatedAt,
@@ -6960,7 +6909,6 @@ class SyllabusesCompanion extends UpdateCompanion<Syllabus> {
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
-      if (fetchedAt != null) 'fetched_at': fetchedAt,
       if (courseOffering != null) 'course_offering': courseOffering,
       if (teacher != null) 'teacher': teacher,
       if (updatedAt != null) 'updated_at': updatedAt,
@@ -6974,7 +6922,6 @@ class SyllabusesCompanion extends UpdateCompanion<Syllabus> {
 
   SyllabusesCompanion copyWith({
     Value<int>? id,
-    Value<DateTime?>? fetchedAt,
     Value<int>? courseOffering,
     Value<int>? teacher,
     Value<DateTime?>? updatedAt,
@@ -6986,7 +6933,6 @@ class SyllabusesCompanion extends UpdateCompanion<Syllabus> {
   }) {
     return SyllabusesCompanion(
       id: id ?? this.id,
-      fetchedAt: fetchedAt ?? this.fetchedAt,
       courseOffering: courseOffering ?? this.courseOffering,
       teacher: teacher ?? this.teacher,
       updatedAt: updatedAt ?? this.updatedAt,
@@ -7003,9 +6949,6 @@ class SyllabusesCompanion extends UpdateCompanion<Syllabus> {
     final map = <String, Expression>{};
     if (id.present) {
       map['id'] = Variable<int>(id.value);
-    }
-    if (fetchedAt.present) {
-      map['fetched_at'] = Variable<DateTime>(fetchedAt.value);
     }
     if (courseOffering.present) {
       map['course_offering'] = Variable<int>(courseOffering.value);
@@ -7038,7 +6981,6 @@ class SyllabusesCompanion extends UpdateCompanion<Syllabus> {
   String toString() {
     return (StringBuffer('SyllabusesCompanion(')
           ..write('id: $id, ')
-          ..write('fetchedAt: $fetchedAt, ')
           ..write('courseOffering: $courseOffering, ')
           ..write('teacher: $teacher, ')
           ..write('updatedAt: $updatedAt, ')
@@ -19566,7 +19508,6 @@ typedef $$SchedulesTableProcessedTableManager =
 typedef $$SyllabusesTableCreateCompanionBuilder =
     SyllabusesCompanion Function({
       Value<int> id,
-      Value<DateTime?> fetchedAt,
       required int courseOffering,
       required int teacher,
       Value<DateTime?> updatedAt,
@@ -19579,7 +19520,6 @@ typedef $$SyllabusesTableCreateCompanionBuilder =
 typedef $$SyllabusesTableUpdateCompanionBuilder =
     SyllabusesCompanion Function({
       Value<int> id,
-      Value<DateTime?> fetchedAt,
       Value<int> courseOffering,
       Value<int> teacher,
       Value<DateTime?> updatedAt,
@@ -19641,11 +19581,6 @@ class $$SyllabusesTableFilterComposer
   });
   ColumnFilters<int> get id => $composableBuilder(
     column: $table.id,
-    builder: (column) => ColumnFilters(column),
-  );
-
-  ColumnFilters<DateTime> get fetchedAt => $composableBuilder(
-    column: $table.fetchedAt,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -19740,11 +19675,6 @@ class $$SyllabusesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
-  ColumnOrderings<DateTime> get fetchedAt => $composableBuilder(
-    column: $table.fetchedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
-
   ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
     column: $table.updatedAt,
     builder: (column) => ColumnOrderings(column),
@@ -19833,9 +19763,6 @@ class $$SyllabusesTableAnnotationComposer
   });
   GeneratedColumn<int> get id =>
       $composableBuilder(column: $table.id, builder: (column) => column);
-
-  GeneratedColumn<DateTime> get fetchedAt =>
-      $composableBuilder(column: $table.fetchedAt, builder: (column) => column);
 
   GeneratedColumn<DateTime> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
@@ -19935,7 +19862,6 @@ class $$SyllabusesTableTableManager
           updateCompanionCallback:
               ({
                 Value<int> id = const Value.absent(),
-                Value<DateTime?> fetchedAt = const Value.absent(),
                 Value<int> courseOffering = const Value.absent(),
                 Value<int> teacher = const Value.absent(),
                 Value<DateTime?> updatedAt = const Value.absent(),
@@ -19946,7 +19872,6 @@ class $$SyllabusesTableTableManager
                 Value<String?> remarks = const Value.absent(),
               }) => SyllabusesCompanion(
                 id: id,
-                fetchedAt: fetchedAt,
                 courseOffering: courseOffering,
                 teacher: teacher,
                 updatedAt: updatedAt,
@@ -19959,7 +19884,6 @@ class $$SyllabusesTableTableManager
           createCompanionCallback:
               ({
                 Value<int> id = const Value.absent(),
-                Value<DateTime?> fetchedAt = const Value.absent(),
                 required int courseOffering,
                 required int teacher,
                 Value<DateTime?> updatedAt = const Value.absent(),
@@ -19970,7 +19894,6 @@ class $$SyllabusesTableTableManager
                 Value<String?> remarks = const Value.absent(),
               }) => SyllabusesCompanion.insert(
                 id: id,
-                fetchedAt: fetchedAt,
                 courseOffering: courseOffering,
                 teacher: teacher,
                 updatedAt: updatedAt,

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -3850,29 +3850,6 @@ class $CourseOfferingsTable extends CourseOfferings
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
-  static const VerificationMeta _syllabusIdMeta = const VerificationMeta(
-    'syllabusId',
-  );
-  @override
-  late final GeneratedColumn<String> syllabusId = GeneratedColumn<String>(
-    'syllabus_id',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _syllabusUpdatedAtMeta = const VerificationMeta(
-    'syllabusUpdatedAt',
-  );
-  @override
-  late final GeneratedColumn<DateTime> syllabusUpdatedAt =
-      GeneratedColumn<DateTime>(
-        'syllabus_updated_at',
-        aliasedName,
-        true,
-        type: DriftSqlType.dateTime,
-        requiredDuringInsert: false,
-      );
   static const VerificationMeta _enrolledMeta = const VerificationMeta(
     'enrolled',
   );
@@ -3895,61 +3872,6 @@ class $CourseOfferingsTable extends CourseOfferings
     type: DriftSqlType.int,
     requiredDuringInsert: false,
   );
-  static const VerificationMeta _objectiveMeta = const VerificationMeta(
-    'objective',
-  );
-  @override
-  late final GeneratedColumn<String> objective = GeneratedColumn<String>(
-    'objective',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _weeklyPlanMeta = const VerificationMeta(
-    'weeklyPlan',
-  );
-  @override
-  late final GeneratedColumn<String> weeklyPlan = GeneratedColumn<String>(
-    'weekly_plan',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _evaluationMeta = const VerificationMeta(
-    'evaluation',
-  );
-  @override
-  late final GeneratedColumn<String> evaluation = GeneratedColumn<String>(
-    'evaluation',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _textbooksMeta = const VerificationMeta(
-    'textbooks',
-  );
-  @override
-  late final GeneratedColumn<String> textbooks = GeneratedColumn<String>(
-    'textbooks',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _syllabusRemarksMeta = const VerificationMeta(
-    'syllabusRemarks',
-  );
-  @override
-  late final GeneratedColumn<String> syllabusRemarks = GeneratedColumn<String>(
-    'syllabus_remarks',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -3966,15 +3888,8 @@ class $CourseOfferingsTable extends CourseOfferings
     status,
     language,
     remarks,
-    syllabusId,
-    syllabusUpdatedAt,
     enrolled,
     withdrawn,
-    objective,
-    weeklyPlan,
-    evaluation,
-    textbooks,
-    syllabusRemarks,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -4067,21 +3982,6 @@ class $CourseOfferingsTable extends CourseOfferings
         remarks.isAcceptableOrUnknown(data['remarks']!, _remarksMeta),
       );
     }
-    if (data.containsKey('syllabus_id')) {
-      context.handle(
-        _syllabusIdMeta,
-        syllabusId.isAcceptableOrUnknown(data['syllabus_id']!, _syllabusIdMeta),
-      );
-    }
-    if (data.containsKey('syllabus_updated_at')) {
-      context.handle(
-        _syllabusUpdatedAtMeta,
-        syllabusUpdatedAt.isAcceptableOrUnknown(
-          data['syllabus_updated_at']!,
-          _syllabusUpdatedAtMeta,
-        ),
-      );
-    }
     if (data.containsKey('enrolled')) {
       context.handle(
         _enrolledMeta,
@@ -4092,39 +3992,6 @@ class $CourseOfferingsTable extends CourseOfferings
       context.handle(
         _withdrawnMeta,
         withdrawn.isAcceptableOrUnknown(data['withdrawn']!, _withdrawnMeta),
-      );
-    }
-    if (data.containsKey('objective')) {
-      context.handle(
-        _objectiveMeta,
-        objective.isAcceptableOrUnknown(data['objective']!, _objectiveMeta),
-      );
-    }
-    if (data.containsKey('weekly_plan')) {
-      context.handle(
-        _weeklyPlanMeta,
-        weeklyPlan.isAcceptableOrUnknown(data['weekly_plan']!, _weeklyPlanMeta),
-      );
-    }
-    if (data.containsKey('evaluation')) {
-      context.handle(
-        _evaluationMeta,
-        evaluation.isAcceptableOrUnknown(data['evaluation']!, _evaluationMeta),
-      );
-    }
-    if (data.containsKey('textbooks')) {
-      context.handle(
-        _textbooksMeta,
-        textbooks.isAcceptableOrUnknown(data['textbooks']!, _textbooksMeta),
-      );
-    }
-    if (data.containsKey('syllabus_remarks')) {
-      context.handle(
-        _syllabusRemarksMeta,
-        syllabusRemarks.isAcceptableOrUnknown(
-          data['syllabus_remarks']!,
-          _syllabusRemarksMeta,
-        ),
       );
     }
     return context;
@@ -4198,14 +4065,6 @@ class $CourseOfferingsTable extends CourseOfferings
         DriftSqlType.string,
         data['${effectivePrefix}remarks'],
       ),
-      syllabusId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}syllabus_id'],
-      ),
-      syllabusUpdatedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}syllabus_updated_at'],
-      ),
       enrolled: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}enrolled'],
@@ -4213,26 +4072,6 @@ class $CourseOfferingsTable extends CourseOfferings
       withdrawn: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}withdrawn'],
-      ),
-      objective: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}objective'],
-      ),
-      weeklyPlan: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}weekly_plan'],
-      ),
-      evaluation: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}evaluation'],
-      ),
-      textbooks: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}textbooks'],
-      ),
-      syllabusRemarks: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}syllabus_remarks'],
       ),
     );
   }
@@ -4328,37 +4167,11 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
   /// Not a [Fetchable] field.
   final String? remarks;
 
-  /// Syllabus ID for fetching detailed syllabus information.
-  ///
-  /// Not a [Fetchable] field.
-  final String? syllabusId;
-
-  /// When the syllabus was last updated (最後更新時間).
-  final DateTime? syllabusUpdatedAt;
-
   /// Number of enrolled students (人).
   final int? enrolled;
 
   /// Number of withdrawn students (撤).
   final int? withdrawn;
-
-  /// Course objective/outline (課程大綱).
-  final String? objective;
-
-  /// Weekly plan describing topics covered each week (課程進度).
-  ///
-  /// Note: Called "Course Schedule" on English page, but refers to weekly
-  /// topics, not class meeting times.
-  final String? weeklyPlan;
-
-  /// Evaluation and grading policy (評量方式與標準).
-  final String? evaluation;
-
-  /// Textbooks and reference materials (使用教材、參考書目或其他).
-  final String? textbooks;
-
-  /// Teacher-authored remarks from the syllabus page (備註).
-  final String? syllabusRemarks;
   const CourseOffering({
     required this.id,
     this.fetchedAt,
@@ -4374,15 +4187,8 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
     this.status,
     this.language,
     this.remarks,
-    this.syllabusId,
-    this.syllabusUpdatedAt,
     this.enrolled,
     this.withdrawn,
-    this.objective,
-    this.weeklyPlan,
-    this.evaluation,
-    this.textbooks,
-    this.syllabusRemarks,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -4425,32 +4231,11 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
     if (!nullToAbsent || remarks != null) {
       map['remarks'] = Variable<String>(remarks);
     }
-    if (!nullToAbsent || syllabusId != null) {
-      map['syllabus_id'] = Variable<String>(syllabusId);
-    }
-    if (!nullToAbsent || syllabusUpdatedAt != null) {
-      map['syllabus_updated_at'] = Variable<DateTime>(syllabusUpdatedAt);
-    }
     if (!nullToAbsent || enrolled != null) {
       map['enrolled'] = Variable<int>(enrolled);
     }
     if (!nullToAbsent || withdrawn != null) {
       map['withdrawn'] = Variable<int>(withdrawn);
-    }
-    if (!nullToAbsent || objective != null) {
-      map['objective'] = Variable<String>(objective);
-    }
-    if (!nullToAbsent || weeklyPlan != null) {
-      map['weekly_plan'] = Variable<String>(weeklyPlan);
-    }
-    if (!nullToAbsent || evaluation != null) {
-      map['evaluation'] = Variable<String>(evaluation);
-    }
-    if (!nullToAbsent || textbooks != null) {
-      map['textbooks'] = Variable<String>(textbooks);
-    }
-    if (!nullToAbsent || syllabusRemarks != null) {
-      map['syllabus_remarks'] = Variable<String>(syllabusRemarks);
     }
     return map;
   }
@@ -4493,33 +4278,12 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
       remarks: remarks == null && nullToAbsent
           ? const Value.absent()
           : Value(remarks),
-      syllabusId: syllabusId == null && nullToAbsent
-          ? const Value.absent()
-          : Value(syllabusId),
-      syllabusUpdatedAt: syllabusUpdatedAt == null && nullToAbsent
-          ? const Value.absent()
-          : Value(syllabusUpdatedAt),
       enrolled: enrolled == null && nullToAbsent
           ? const Value.absent()
           : Value(enrolled),
       withdrawn: withdrawn == null && nullToAbsent
           ? const Value.absent()
           : Value(withdrawn),
-      objective: objective == null && nullToAbsent
-          ? const Value.absent()
-          : Value(objective),
-      weeklyPlan: weeklyPlan == null && nullToAbsent
-          ? const Value.absent()
-          : Value(weeklyPlan),
-      evaluation: evaluation == null && nullToAbsent
-          ? const Value.absent()
-          : Value(evaluation),
-      textbooks: textbooks == null && nullToAbsent
-          ? const Value.absent()
-          : Value(textbooks),
-      syllabusRemarks: syllabusRemarks == null && nullToAbsent
-          ? const Value.absent()
-          : Value(syllabusRemarks),
     );
   }
 
@@ -4545,17 +4309,8 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
       status: serializer.fromJson<String?>(json['status']),
       language: serializer.fromJson<String?>(json['language']),
       remarks: serializer.fromJson<String?>(json['remarks']),
-      syllabusId: serializer.fromJson<String?>(json['syllabusId']),
-      syllabusUpdatedAt: serializer.fromJson<DateTime?>(
-        json['syllabusUpdatedAt'],
-      ),
       enrolled: serializer.fromJson<int?>(json['enrolled']),
       withdrawn: serializer.fromJson<int?>(json['withdrawn']),
-      objective: serializer.fromJson<String?>(json['objective']),
-      weeklyPlan: serializer.fromJson<String?>(json['weeklyPlan']),
-      evaluation: serializer.fromJson<String?>(json['evaluation']),
-      textbooks: serializer.fromJson<String?>(json['textbooks']),
-      syllabusRemarks: serializer.fromJson<String?>(json['syllabusRemarks']),
     );
   }
   @override
@@ -4578,15 +4333,8 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
       'status': serializer.toJson<String?>(status),
       'language': serializer.toJson<String?>(language),
       'remarks': serializer.toJson<String?>(remarks),
-      'syllabusId': serializer.toJson<String?>(syllabusId),
-      'syllabusUpdatedAt': serializer.toJson<DateTime?>(syllabusUpdatedAt),
       'enrolled': serializer.toJson<int?>(enrolled),
       'withdrawn': serializer.toJson<int?>(withdrawn),
-      'objective': serializer.toJson<String?>(objective),
-      'weeklyPlan': serializer.toJson<String?>(weeklyPlan),
-      'evaluation': serializer.toJson<String?>(evaluation),
-      'textbooks': serializer.toJson<String?>(textbooks),
-      'syllabusRemarks': serializer.toJson<String?>(syllabusRemarks),
     };
   }
 
@@ -4605,15 +4353,8 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
     Value<String?> status = const Value.absent(),
     Value<String?> language = const Value.absent(),
     Value<String?> remarks = const Value.absent(),
-    Value<String?> syllabusId = const Value.absent(),
-    Value<DateTime?> syllabusUpdatedAt = const Value.absent(),
     Value<int?> enrolled = const Value.absent(),
     Value<int?> withdrawn = const Value.absent(),
-    Value<String?> objective = const Value.absent(),
-    Value<String?> weeklyPlan = const Value.absent(),
-    Value<String?> evaluation = const Value.absent(),
-    Value<String?> textbooks = const Value.absent(),
-    Value<String?> syllabusRemarks = const Value.absent(),
   }) => CourseOffering(
     id: id ?? this.id,
     fetchedAt: fetchedAt.present ? fetchedAt.value : this.fetchedAt,
@@ -4629,19 +4370,8 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
     status: status.present ? status.value : this.status,
     language: language.present ? language.value : this.language,
     remarks: remarks.present ? remarks.value : this.remarks,
-    syllabusId: syllabusId.present ? syllabusId.value : this.syllabusId,
-    syllabusUpdatedAt: syllabusUpdatedAt.present
-        ? syllabusUpdatedAt.value
-        : this.syllabusUpdatedAt,
     enrolled: enrolled.present ? enrolled.value : this.enrolled,
     withdrawn: withdrawn.present ? withdrawn.value : this.withdrawn,
-    objective: objective.present ? objective.value : this.objective,
-    weeklyPlan: weeklyPlan.present ? weeklyPlan.value : this.weeklyPlan,
-    evaluation: evaluation.present ? evaluation.value : this.evaluation,
-    textbooks: textbooks.present ? textbooks.value : this.textbooks,
-    syllabusRemarks: syllabusRemarks.present
-        ? syllabusRemarks.value
-        : this.syllabusRemarks,
   );
   CourseOffering copyWithCompanion(CourseOfferingsCompanion data) {
     return CourseOffering(
@@ -4663,25 +4393,8 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
       status: data.status.present ? data.status.value : this.status,
       language: data.language.present ? data.language.value : this.language,
       remarks: data.remarks.present ? data.remarks.value : this.remarks,
-      syllabusId: data.syllabusId.present
-          ? data.syllabusId.value
-          : this.syllabusId,
-      syllabusUpdatedAt: data.syllabusUpdatedAt.present
-          ? data.syllabusUpdatedAt.value
-          : this.syllabusUpdatedAt,
       enrolled: data.enrolled.present ? data.enrolled.value : this.enrolled,
       withdrawn: data.withdrawn.present ? data.withdrawn.value : this.withdrawn,
-      objective: data.objective.present ? data.objective.value : this.objective,
-      weeklyPlan: data.weeklyPlan.present
-          ? data.weeklyPlan.value
-          : this.weeklyPlan,
-      evaluation: data.evaluation.present
-          ? data.evaluation.value
-          : this.evaluation,
-      textbooks: data.textbooks.present ? data.textbooks.value : this.textbooks,
-      syllabusRemarks: data.syllabusRemarks.present
-          ? data.syllabusRemarks.value
-          : this.syllabusRemarks,
     );
   }
 
@@ -4702,21 +4415,14 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
           ..write('status: $status, ')
           ..write('language: $language, ')
           ..write('remarks: $remarks, ')
-          ..write('syllabusId: $syllabusId, ')
-          ..write('syllabusUpdatedAt: $syllabusUpdatedAt, ')
           ..write('enrolled: $enrolled, ')
-          ..write('withdrawn: $withdrawn, ')
-          ..write('objective: $objective, ')
-          ..write('weeklyPlan: $weeklyPlan, ')
-          ..write('evaluation: $evaluation, ')
-          ..write('textbooks: $textbooks, ')
-          ..write('syllabusRemarks: $syllabusRemarks')
+          ..write('withdrawn: $withdrawn')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hashAll([
+  int get hashCode => Object.hash(
     id,
     fetchedAt,
     courseCode,
@@ -4731,16 +4437,9 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
     status,
     language,
     remarks,
-    syllabusId,
-    syllabusUpdatedAt,
     enrolled,
     withdrawn,
-    objective,
-    weeklyPlan,
-    evaluation,
-    textbooks,
-    syllabusRemarks,
-  ]);
+  );
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -4759,15 +4458,8 @@ class CourseOffering extends DataClass implements Insertable<CourseOffering> {
           other.status == this.status &&
           other.language == this.language &&
           other.remarks == this.remarks &&
-          other.syllabusId == this.syllabusId &&
-          other.syllabusUpdatedAt == this.syllabusUpdatedAt &&
           other.enrolled == this.enrolled &&
-          other.withdrawn == this.withdrawn &&
-          other.objective == this.objective &&
-          other.weeklyPlan == this.weeklyPlan &&
-          other.evaluation == this.evaluation &&
-          other.textbooks == this.textbooks &&
-          other.syllabusRemarks == this.syllabusRemarks);
+          other.withdrawn == this.withdrawn);
 }
 
 class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
@@ -4785,15 +4477,8 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
   final Value<String?> status;
   final Value<String?> language;
   final Value<String?> remarks;
-  final Value<String?> syllabusId;
-  final Value<DateTime?> syllabusUpdatedAt;
   final Value<int?> enrolled;
   final Value<int?> withdrawn;
-  final Value<String?> objective;
-  final Value<String?> weeklyPlan;
-  final Value<String?> evaluation;
-  final Value<String?> textbooks;
-  final Value<String?> syllabusRemarks;
   const CourseOfferingsCompanion({
     this.id = const Value.absent(),
     this.fetchedAt = const Value.absent(),
@@ -4809,15 +4494,8 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
     this.status = const Value.absent(),
     this.language = const Value.absent(),
     this.remarks = const Value.absent(),
-    this.syllabusId = const Value.absent(),
-    this.syllabusUpdatedAt = const Value.absent(),
     this.enrolled = const Value.absent(),
     this.withdrawn = const Value.absent(),
-    this.objective = const Value.absent(),
-    this.weeklyPlan = const Value.absent(),
-    this.evaluation = const Value.absent(),
-    this.textbooks = const Value.absent(),
-    this.syllabusRemarks = const Value.absent(),
   });
   CourseOfferingsCompanion.insert({
     this.id = const Value.absent(),
@@ -4834,15 +4512,8 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
     this.status = const Value.absent(),
     this.language = const Value.absent(),
     this.remarks = const Value.absent(),
-    this.syllabusId = const Value.absent(),
-    this.syllabusUpdatedAt = const Value.absent(),
     this.enrolled = const Value.absent(),
     this.withdrawn = const Value.absent(),
-    this.objective = const Value.absent(),
-    this.weeklyPlan = const Value.absent(),
-    this.evaluation = const Value.absent(),
-    this.textbooks = const Value.absent(),
-    this.syllabusRemarks = const Value.absent(),
   }) : semester = Value(semester),
        nameZh = Value(nameZh);
   static Insertable<CourseOffering> custom({
@@ -4860,15 +4531,8 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
     Expression<String>? status,
     Expression<String>? language,
     Expression<String>? remarks,
-    Expression<String>? syllabusId,
-    Expression<DateTime>? syllabusUpdatedAt,
     Expression<int>? enrolled,
     Expression<int>? withdrawn,
-    Expression<String>? objective,
-    Expression<String>? weeklyPlan,
-    Expression<String>? evaluation,
-    Expression<String>? textbooks,
-    Expression<String>? syllabusRemarks,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -4885,15 +4549,8 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
       if (status != null) 'status': status,
       if (language != null) 'language': language,
       if (remarks != null) 'remarks': remarks,
-      if (syllabusId != null) 'syllabus_id': syllabusId,
-      if (syllabusUpdatedAt != null) 'syllabus_updated_at': syllabusUpdatedAt,
       if (enrolled != null) 'enrolled': enrolled,
       if (withdrawn != null) 'withdrawn': withdrawn,
-      if (objective != null) 'objective': objective,
-      if (weeklyPlan != null) 'weekly_plan': weeklyPlan,
-      if (evaluation != null) 'evaluation': evaluation,
-      if (textbooks != null) 'textbooks': textbooks,
-      if (syllabusRemarks != null) 'syllabus_remarks': syllabusRemarks,
     });
   }
 
@@ -4912,15 +4569,8 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
     Value<String?>? status,
     Value<String?>? language,
     Value<String?>? remarks,
-    Value<String?>? syllabusId,
-    Value<DateTime?>? syllabusUpdatedAt,
     Value<int?>? enrolled,
     Value<int?>? withdrawn,
-    Value<String?>? objective,
-    Value<String?>? weeklyPlan,
-    Value<String?>? evaluation,
-    Value<String?>? textbooks,
-    Value<String?>? syllabusRemarks,
   }) {
     return CourseOfferingsCompanion(
       id: id ?? this.id,
@@ -4937,15 +4587,8 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
       status: status ?? this.status,
       language: language ?? this.language,
       remarks: remarks ?? this.remarks,
-      syllabusId: syllabusId ?? this.syllabusId,
-      syllabusUpdatedAt: syllabusUpdatedAt ?? this.syllabusUpdatedAt,
       enrolled: enrolled ?? this.enrolled,
       withdrawn: withdrawn ?? this.withdrawn,
-      objective: objective ?? this.objective,
-      weeklyPlan: weeklyPlan ?? this.weeklyPlan,
-      evaluation: evaluation ?? this.evaluation,
-      textbooks: textbooks ?? this.textbooks,
-      syllabusRemarks: syllabusRemarks ?? this.syllabusRemarks,
     );
   }
 
@@ -4996,32 +4639,11 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
     if (remarks.present) {
       map['remarks'] = Variable<String>(remarks.value);
     }
-    if (syllabusId.present) {
-      map['syllabus_id'] = Variable<String>(syllabusId.value);
-    }
-    if (syllabusUpdatedAt.present) {
-      map['syllabus_updated_at'] = Variable<DateTime>(syllabusUpdatedAt.value);
-    }
     if (enrolled.present) {
       map['enrolled'] = Variable<int>(enrolled.value);
     }
     if (withdrawn.present) {
       map['withdrawn'] = Variable<int>(withdrawn.value);
-    }
-    if (objective.present) {
-      map['objective'] = Variable<String>(objective.value);
-    }
-    if (weeklyPlan.present) {
-      map['weekly_plan'] = Variable<String>(weeklyPlan.value);
-    }
-    if (evaluation.present) {
-      map['evaluation'] = Variable<String>(evaluation.value);
-    }
-    if (textbooks.present) {
-      map['textbooks'] = Variable<String>(textbooks.value);
-    }
-    if (syllabusRemarks.present) {
-      map['syllabus_remarks'] = Variable<String>(syllabusRemarks.value);
     }
     return map;
   }
@@ -5043,15 +4665,8 @@ class CourseOfferingsCompanion extends UpdateCompanion<CourseOffering> {
           ..write('status: $status, ')
           ..write('language: $language, ')
           ..write('remarks: $remarks, ')
-          ..write('syllabusId: $syllabusId, ')
-          ..write('syllabusUpdatedAt: $syllabusUpdatedAt, ')
           ..write('enrolled: $enrolled, ')
-          ..write('withdrawn: $withdrawn, ')
-          ..write('objective: $objective, ')
-          ..write('weeklyPlan: $weeklyPlan, ')
-          ..write('evaluation: $evaluation, ')
-          ..write('textbooks: $textbooks, ')
-          ..write('syllabusRemarks: $syllabusRemarks')
+          ..write('withdrawn: $withdrawn')
           ..write(')'))
         .toString();
   }
@@ -6779,6 +6394,659 @@ class SchedulesCompanion extends UpdateCompanion<Schedule> {
           ..write('dayOfWeek: $dayOfWeek, ')
           ..write('period: $period, ')
           ..write('classroom: $classroom')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $SyllabusesTable extends Syllabuses
+    with TableInfo<$SyllabusesTable, Syllabus> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $SyllabusesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _fetchedAtMeta = const VerificationMeta(
+    'fetchedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> fetchedAt = GeneratedColumn<DateTime>(
+    'fetched_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _courseOfferingMeta = const VerificationMeta(
+    'courseOffering',
+  );
+  @override
+  late final GeneratedColumn<int> courseOffering = GeneratedColumn<int>(
+    'course_offering',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES course_offerings (id) ON DELETE CASCADE',
+    ),
+  );
+  static const VerificationMeta _teacherMeta = const VerificationMeta(
+    'teacher',
+  );
+  @override
+  late final GeneratedColumn<int> teacher = GeneratedColumn<int>(
+    'teacher',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES teachers (id)',
+    ),
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _objectiveMeta = const VerificationMeta(
+    'objective',
+  );
+  @override
+  late final GeneratedColumn<String> objective = GeneratedColumn<String>(
+    'objective',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _weeklyPlanMeta = const VerificationMeta(
+    'weeklyPlan',
+  );
+  @override
+  late final GeneratedColumn<String> weeklyPlan = GeneratedColumn<String>(
+    'weekly_plan',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _evaluationMeta = const VerificationMeta(
+    'evaluation',
+  );
+  @override
+  late final GeneratedColumn<String> evaluation = GeneratedColumn<String>(
+    'evaluation',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _textbooksMeta = const VerificationMeta(
+    'textbooks',
+  );
+  @override
+  late final GeneratedColumn<String> textbooks = GeneratedColumn<String>(
+    'textbooks',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _remarksMeta = const VerificationMeta(
+    'remarks',
+  );
+  @override
+  late final GeneratedColumn<String> remarks = GeneratedColumn<String>(
+    'remarks',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    fetchedAt,
+    courseOffering,
+    teacher,
+    updatedAt,
+    objective,
+    weeklyPlan,
+    evaluation,
+    textbooks,
+    remarks,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'syllabuses';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<Syllabus> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('fetched_at')) {
+      context.handle(
+        _fetchedAtMeta,
+        fetchedAt.isAcceptableOrUnknown(data['fetched_at']!, _fetchedAtMeta),
+      );
+    }
+    if (data.containsKey('course_offering')) {
+      context.handle(
+        _courseOfferingMeta,
+        courseOffering.isAcceptableOrUnknown(
+          data['course_offering']!,
+          _courseOfferingMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_courseOfferingMeta);
+    }
+    if (data.containsKey('teacher')) {
+      context.handle(
+        _teacherMeta,
+        teacher.isAcceptableOrUnknown(data['teacher']!, _teacherMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_teacherMeta);
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    }
+    if (data.containsKey('objective')) {
+      context.handle(
+        _objectiveMeta,
+        objective.isAcceptableOrUnknown(data['objective']!, _objectiveMeta),
+      );
+    }
+    if (data.containsKey('weekly_plan')) {
+      context.handle(
+        _weeklyPlanMeta,
+        weeklyPlan.isAcceptableOrUnknown(data['weekly_plan']!, _weeklyPlanMeta),
+      );
+    }
+    if (data.containsKey('evaluation')) {
+      context.handle(
+        _evaluationMeta,
+        evaluation.isAcceptableOrUnknown(data['evaluation']!, _evaluationMeta),
+      );
+    }
+    if (data.containsKey('textbooks')) {
+      context.handle(
+        _textbooksMeta,
+        textbooks.isAcceptableOrUnknown(data['textbooks']!, _textbooksMeta),
+      );
+    }
+    if (data.containsKey('remarks')) {
+      context.handle(
+        _remarksMeta,
+        remarks.isAcceptableOrUnknown(data['remarks']!, _remarksMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  List<Set<GeneratedColumn>> get uniqueKeys => [
+    {courseOffering, teacher},
+  ];
+  @override
+  Syllabus map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Syllabus(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      fetchedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}fetched_at'],
+      ),
+      courseOffering: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}course_offering'],
+      )!,
+      teacher: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}teacher'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      ),
+      objective: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}objective'],
+      ),
+      weeklyPlan: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}weekly_plan'],
+      ),
+      evaluation: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}evaluation'],
+      ),
+      textbooks: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}textbooks'],
+      ),
+      remarks: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}remarks'],
+      ),
+    );
+  }
+
+  @override
+  $SyllabusesTable createAlias(String alias) {
+    return $SyllabusesTable(attachedDatabase, alias);
+  }
+}
+
+class Syllabus extends DataClass implements Insertable<Syllabus> {
+  /// Auto-incrementing primary key.
+  final int id;
+
+  /// Timestamp of when complete data was last fetched from the server.
+  ///
+  /// - `null`: Only partial/basic information is available (e.g., name + ID from a list page)
+  /// - `non-null`: Complete details have been fetched (e.g., full profile from detail page)
+  ///
+  /// Use this field to:
+  /// - Determine if a detail fetch is needed (null = need to fetch)
+  /// - Implement cache expiration (old timestamp = stale, re-fetch)
+  final DateTime? fetchedAt;
+
+  /// Reference to the course offering this syllabus belongs to.
+  final int courseOffering;
+
+  /// Reference to the authoring teacher (the syllabus's code is their code).
+  final int teacher;
+
+  /// When this syllabus was last updated by the teacher (最後更新時間).
+  final DateTime? updatedAt;
+
+  /// Course objective/outline (課程大綱).
+  final String? objective;
+
+  /// Weekly plan describing topics covered each week (課程進度).
+  ///
+  /// Note: Called "Course Schedule" on the English page, but refers to weekly
+  /// topics, not class meeting times.
+  final String? weeklyPlan;
+
+  /// Evaluation and grading policy (評量方式與標準).
+  final String? evaluation;
+
+  /// Textbooks and reference materials (使用教材、參考書目或其他).
+  final String? textbooks;
+
+  /// Teacher-authored remarks from the syllabus page (備註).
+  final String? remarks;
+  const Syllabus({
+    required this.id,
+    this.fetchedAt,
+    required this.courseOffering,
+    required this.teacher,
+    this.updatedAt,
+    this.objective,
+    this.weeklyPlan,
+    this.evaluation,
+    this.textbooks,
+    this.remarks,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    if (!nullToAbsent || fetchedAt != null) {
+      map['fetched_at'] = Variable<DateTime>(fetchedAt);
+    }
+    map['course_offering'] = Variable<int>(courseOffering);
+    map['teacher'] = Variable<int>(teacher);
+    if (!nullToAbsent || updatedAt != null) {
+      map['updated_at'] = Variable<DateTime>(updatedAt);
+    }
+    if (!nullToAbsent || objective != null) {
+      map['objective'] = Variable<String>(objective);
+    }
+    if (!nullToAbsent || weeklyPlan != null) {
+      map['weekly_plan'] = Variable<String>(weeklyPlan);
+    }
+    if (!nullToAbsent || evaluation != null) {
+      map['evaluation'] = Variable<String>(evaluation);
+    }
+    if (!nullToAbsent || textbooks != null) {
+      map['textbooks'] = Variable<String>(textbooks);
+    }
+    if (!nullToAbsent || remarks != null) {
+      map['remarks'] = Variable<String>(remarks);
+    }
+    return map;
+  }
+
+  SyllabusesCompanion toCompanion(bool nullToAbsent) {
+    return SyllabusesCompanion(
+      id: Value(id),
+      fetchedAt: fetchedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(fetchedAt),
+      courseOffering: Value(courseOffering),
+      teacher: Value(teacher),
+      updatedAt: updatedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(updatedAt),
+      objective: objective == null && nullToAbsent
+          ? const Value.absent()
+          : Value(objective),
+      weeklyPlan: weeklyPlan == null && nullToAbsent
+          ? const Value.absent()
+          : Value(weeklyPlan),
+      evaluation: evaluation == null && nullToAbsent
+          ? const Value.absent()
+          : Value(evaluation),
+      textbooks: textbooks == null && nullToAbsent
+          ? const Value.absent()
+          : Value(textbooks),
+      remarks: remarks == null && nullToAbsent
+          ? const Value.absent()
+          : Value(remarks),
+    );
+  }
+
+  factory Syllabus.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return Syllabus(
+      id: serializer.fromJson<int>(json['id']),
+      fetchedAt: serializer.fromJson<DateTime?>(json['fetchedAt']),
+      courseOffering: serializer.fromJson<int>(json['courseOffering']),
+      teacher: serializer.fromJson<int>(json['teacher']),
+      updatedAt: serializer.fromJson<DateTime?>(json['updatedAt']),
+      objective: serializer.fromJson<String?>(json['objective']),
+      weeklyPlan: serializer.fromJson<String?>(json['weeklyPlan']),
+      evaluation: serializer.fromJson<String?>(json['evaluation']),
+      textbooks: serializer.fromJson<String?>(json['textbooks']),
+      remarks: serializer.fromJson<String?>(json['remarks']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'fetchedAt': serializer.toJson<DateTime?>(fetchedAt),
+      'courseOffering': serializer.toJson<int>(courseOffering),
+      'teacher': serializer.toJson<int>(teacher),
+      'updatedAt': serializer.toJson<DateTime?>(updatedAt),
+      'objective': serializer.toJson<String?>(objective),
+      'weeklyPlan': serializer.toJson<String?>(weeklyPlan),
+      'evaluation': serializer.toJson<String?>(evaluation),
+      'textbooks': serializer.toJson<String?>(textbooks),
+      'remarks': serializer.toJson<String?>(remarks),
+    };
+  }
+
+  Syllabus copyWith({
+    int? id,
+    Value<DateTime?> fetchedAt = const Value.absent(),
+    int? courseOffering,
+    int? teacher,
+    Value<DateTime?> updatedAt = const Value.absent(),
+    Value<String?> objective = const Value.absent(),
+    Value<String?> weeklyPlan = const Value.absent(),
+    Value<String?> evaluation = const Value.absent(),
+    Value<String?> textbooks = const Value.absent(),
+    Value<String?> remarks = const Value.absent(),
+  }) => Syllabus(
+    id: id ?? this.id,
+    fetchedAt: fetchedAt.present ? fetchedAt.value : this.fetchedAt,
+    courseOffering: courseOffering ?? this.courseOffering,
+    teacher: teacher ?? this.teacher,
+    updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
+    objective: objective.present ? objective.value : this.objective,
+    weeklyPlan: weeklyPlan.present ? weeklyPlan.value : this.weeklyPlan,
+    evaluation: evaluation.present ? evaluation.value : this.evaluation,
+    textbooks: textbooks.present ? textbooks.value : this.textbooks,
+    remarks: remarks.present ? remarks.value : this.remarks,
+  );
+  Syllabus copyWithCompanion(SyllabusesCompanion data) {
+    return Syllabus(
+      id: data.id.present ? data.id.value : this.id,
+      fetchedAt: data.fetchedAt.present ? data.fetchedAt.value : this.fetchedAt,
+      courseOffering: data.courseOffering.present
+          ? data.courseOffering.value
+          : this.courseOffering,
+      teacher: data.teacher.present ? data.teacher.value : this.teacher,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      objective: data.objective.present ? data.objective.value : this.objective,
+      weeklyPlan: data.weeklyPlan.present
+          ? data.weeklyPlan.value
+          : this.weeklyPlan,
+      evaluation: data.evaluation.present
+          ? data.evaluation.value
+          : this.evaluation,
+      textbooks: data.textbooks.present ? data.textbooks.value : this.textbooks,
+      remarks: data.remarks.present ? data.remarks.value : this.remarks,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('Syllabus(')
+          ..write('id: $id, ')
+          ..write('fetchedAt: $fetchedAt, ')
+          ..write('courseOffering: $courseOffering, ')
+          ..write('teacher: $teacher, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('objective: $objective, ')
+          ..write('weeklyPlan: $weeklyPlan, ')
+          ..write('evaluation: $evaluation, ')
+          ..write('textbooks: $textbooks, ')
+          ..write('remarks: $remarks')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    fetchedAt,
+    courseOffering,
+    teacher,
+    updatedAt,
+    objective,
+    weeklyPlan,
+    evaluation,
+    textbooks,
+    remarks,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Syllabus &&
+          other.id == this.id &&
+          other.fetchedAt == this.fetchedAt &&
+          other.courseOffering == this.courseOffering &&
+          other.teacher == this.teacher &&
+          other.updatedAt == this.updatedAt &&
+          other.objective == this.objective &&
+          other.weeklyPlan == this.weeklyPlan &&
+          other.evaluation == this.evaluation &&
+          other.textbooks == this.textbooks &&
+          other.remarks == this.remarks);
+}
+
+class SyllabusesCompanion extends UpdateCompanion<Syllabus> {
+  final Value<int> id;
+  final Value<DateTime?> fetchedAt;
+  final Value<int> courseOffering;
+  final Value<int> teacher;
+  final Value<DateTime?> updatedAt;
+  final Value<String?> objective;
+  final Value<String?> weeklyPlan;
+  final Value<String?> evaluation;
+  final Value<String?> textbooks;
+  final Value<String?> remarks;
+  const SyllabusesCompanion({
+    this.id = const Value.absent(),
+    this.fetchedAt = const Value.absent(),
+    this.courseOffering = const Value.absent(),
+    this.teacher = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.objective = const Value.absent(),
+    this.weeklyPlan = const Value.absent(),
+    this.evaluation = const Value.absent(),
+    this.textbooks = const Value.absent(),
+    this.remarks = const Value.absent(),
+  });
+  SyllabusesCompanion.insert({
+    this.id = const Value.absent(),
+    this.fetchedAt = const Value.absent(),
+    required int courseOffering,
+    required int teacher,
+    this.updatedAt = const Value.absent(),
+    this.objective = const Value.absent(),
+    this.weeklyPlan = const Value.absent(),
+    this.evaluation = const Value.absent(),
+    this.textbooks = const Value.absent(),
+    this.remarks = const Value.absent(),
+  }) : courseOffering = Value(courseOffering),
+       teacher = Value(teacher);
+  static Insertable<Syllabus> custom({
+    Expression<int>? id,
+    Expression<DateTime>? fetchedAt,
+    Expression<int>? courseOffering,
+    Expression<int>? teacher,
+    Expression<DateTime>? updatedAt,
+    Expression<String>? objective,
+    Expression<String>? weeklyPlan,
+    Expression<String>? evaluation,
+    Expression<String>? textbooks,
+    Expression<String>? remarks,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (fetchedAt != null) 'fetched_at': fetchedAt,
+      if (courseOffering != null) 'course_offering': courseOffering,
+      if (teacher != null) 'teacher': teacher,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (objective != null) 'objective': objective,
+      if (weeklyPlan != null) 'weekly_plan': weeklyPlan,
+      if (evaluation != null) 'evaluation': evaluation,
+      if (textbooks != null) 'textbooks': textbooks,
+      if (remarks != null) 'remarks': remarks,
+    });
+  }
+
+  SyllabusesCompanion copyWith({
+    Value<int>? id,
+    Value<DateTime?>? fetchedAt,
+    Value<int>? courseOffering,
+    Value<int>? teacher,
+    Value<DateTime?>? updatedAt,
+    Value<String?>? objective,
+    Value<String?>? weeklyPlan,
+    Value<String?>? evaluation,
+    Value<String?>? textbooks,
+    Value<String?>? remarks,
+  }) {
+    return SyllabusesCompanion(
+      id: id ?? this.id,
+      fetchedAt: fetchedAt ?? this.fetchedAt,
+      courseOffering: courseOffering ?? this.courseOffering,
+      teacher: teacher ?? this.teacher,
+      updatedAt: updatedAt ?? this.updatedAt,
+      objective: objective ?? this.objective,
+      weeklyPlan: weeklyPlan ?? this.weeklyPlan,
+      evaluation: evaluation ?? this.evaluation,
+      textbooks: textbooks ?? this.textbooks,
+      remarks: remarks ?? this.remarks,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (fetchedAt.present) {
+      map['fetched_at'] = Variable<DateTime>(fetchedAt.value);
+    }
+    if (courseOffering.present) {
+      map['course_offering'] = Variable<int>(courseOffering.value);
+    }
+    if (teacher.present) {
+      map['teacher'] = Variable<int>(teacher.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (objective.present) {
+      map['objective'] = Variable<String>(objective.value);
+    }
+    if (weeklyPlan.present) {
+      map['weekly_plan'] = Variable<String>(weeklyPlan.value);
+    }
+    if (evaluation.present) {
+      map['evaluation'] = Variable<String>(evaluation.value);
+    }
+    if (textbooks.present) {
+      map['textbooks'] = Variable<String>(textbooks.value);
+    }
+    if (remarks.present) {
+      map['remarks'] = Variable<String>(remarks.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SyllabusesCompanion(')
+          ..write('id: $id, ')
+          ..write('fetchedAt: $fetchedAt, ')
+          ..write('courseOffering: $courseOffering, ')
+          ..write('teacher: $teacher, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('objective: $objective, ')
+          ..write('weeklyPlan: $weeklyPlan, ')
+          ..write('evaluation: $evaluation, ')
+          ..write('textbooks: $textbooks, ')
+          ..write('remarks: $remarks')
           ..write(')'))
         .toString();
   }
@@ -10521,12 +10789,6 @@ class CourseOfferingOverview extends DataClass {
   final int? enrolled;
   final int? withdrawn;
   final DateTime? fetchedAt;
-  final DateTime? syllabusUpdatedAt;
-  final String? objective;
-  final String? weeklyPlan;
-  final String? evaluation;
-  final String? textbooks;
-  final String? syllabusRemarks;
   const CourseOfferingOverview({
     required this.id,
     this.courseCode,
@@ -10544,12 +10806,6 @@ class CourseOfferingOverview extends DataClass {
     this.enrolled,
     this.withdrawn,
     this.fetchedAt,
-    this.syllabusUpdatedAt,
-    this.objective,
-    this.weeklyPlan,
-    this.evaluation,
-    this.textbooks,
-    this.syllabusRemarks,
   });
   factory CourseOfferingOverview.fromJson(
     Map<String, dynamic> json, {
@@ -10575,14 +10831,6 @@ class CourseOfferingOverview extends DataClass {
       enrolled: serializer.fromJson<int?>(json['enrolled']),
       withdrawn: serializer.fromJson<int?>(json['withdrawn']),
       fetchedAt: serializer.fromJson<DateTime?>(json['fetchedAt']),
-      syllabusUpdatedAt: serializer.fromJson<DateTime?>(
-        json['syllabusUpdatedAt'],
-      ),
-      objective: serializer.fromJson<String?>(json['objective']),
-      weeklyPlan: serializer.fromJson<String?>(json['weeklyPlan']),
-      evaluation: serializer.fromJson<String?>(json['evaluation']),
-      textbooks: serializer.fromJson<String?>(json['textbooks']),
-      syllabusRemarks: serializer.fromJson<String?>(json['syllabusRemarks']),
     );
   }
   @override
@@ -10607,12 +10855,6 @@ class CourseOfferingOverview extends DataClass {
       'enrolled': serializer.toJson<int?>(enrolled),
       'withdrawn': serializer.toJson<int?>(withdrawn),
       'fetchedAt': serializer.toJson<DateTime?>(fetchedAt),
-      'syllabusUpdatedAt': serializer.toJson<DateTime?>(syllabusUpdatedAt),
-      'objective': serializer.toJson<String?>(objective),
-      'weeklyPlan': serializer.toJson<String?>(weeklyPlan),
-      'evaluation': serializer.toJson<String?>(evaluation),
-      'textbooks': serializer.toJson<String?>(textbooks),
-      'syllabusRemarks': serializer.toJson<String?>(syllabusRemarks),
     };
   }
 
@@ -10633,12 +10875,6 @@ class CourseOfferingOverview extends DataClass {
     Value<int?> enrolled = const Value.absent(),
     Value<int?> withdrawn = const Value.absent(),
     Value<DateTime?> fetchedAt = const Value.absent(),
-    Value<DateTime?> syllabusUpdatedAt = const Value.absent(),
-    Value<String?> objective = const Value.absent(),
-    Value<String?> weeklyPlan = const Value.absent(),
-    Value<String?> evaluation = const Value.absent(),
-    Value<String?> textbooks = const Value.absent(),
-    Value<String?> syllabusRemarks = const Value.absent(),
   }) => CourseOfferingOverview(
     id: id ?? this.id,
     courseCode: courseCode.present ? courseCode.value : this.courseCode,
@@ -10656,16 +10892,6 @@ class CourseOfferingOverview extends DataClass {
     enrolled: enrolled.present ? enrolled.value : this.enrolled,
     withdrawn: withdrawn.present ? withdrawn.value : this.withdrawn,
     fetchedAt: fetchedAt.present ? fetchedAt.value : this.fetchedAt,
-    syllabusUpdatedAt: syllabusUpdatedAt.present
-        ? syllabusUpdatedAt.value
-        : this.syllabusUpdatedAt,
-    objective: objective.present ? objective.value : this.objective,
-    weeklyPlan: weeklyPlan.present ? weeklyPlan.value : this.weeklyPlan,
-    evaluation: evaluation.present ? evaluation.value : this.evaluation,
-    textbooks: textbooks.present ? textbooks.value : this.textbooks,
-    syllabusRemarks: syllabusRemarks.present
-        ? syllabusRemarks.value
-        : this.syllabusRemarks,
   );
   @override
   String toString() {
@@ -10685,19 +10911,13 @@ class CourseOfferingOverview extends DataClass {
           ..write('remarks: $remarks, ')
           ..write('enrolled: $enrolled, ')
           ..write('withdrawn: $withdrawn, ')
-          ..write('fetchedAt: $fetchedAt, ')
-          ..write('syllabusUpdatedAt: $syllabusUpdatedAt, ')
-          ..write('objective: $objective, ')
-          ..write('weeklyPlan: $weeklyPlan, ')
-          ..write('evaluation: $evaluation, ')
-          ..write('textbooks: $textbooks, ')
-          ..write('syllabusRemarks: $syllabusRemarks')
+          ..write('fetchedAt: $fetchedAt')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hashAll([
+  int get hashCode => Object.hash(
     id,
     courseCode,
     semester,
@@ -10714,13 +10934,7 @@ class CourseOfferingOverview extends DataClass {
     enrolled,
     withdrawn,
     fetchedAt,
-    syllabusUpdatedAt,
-    objective,
-    weeklyPlan,
-    evaluation,
-    textbooks,
-    syllabusRemarks,
-  ]);
+  );
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -10740,13 +10954,7 @@ class CourseOfferingOverview extends DataClass {
           other.remarks == this.remarks &&
           other.enrolled == this.enrolled &&
           other.withdrawn == this.withdrawn &&
-          other.fetchedAt == this.fetchedAt &&
-          other.syllabusUpdatedAt == this.syllabusUpdatedAt &&
-          other.objective == this.objective &&
-          other.weeklyPlan == this.weeklyPlan &&
-          other.evaluation == this.evaluation &&
-          other.textbooks == this.textbooks &&
-          other.syllabusRemarks == this.syllabusRemarks);
+          other.fetchedAt == this.fetchedAt);
 }
 
 class $CourseOfferingOverviewsView
@@ -10777,12 +10985,6 @@ class $CourseOfferingOverviewsView
     enrolled,
     withdrawn,
     fetchedAt,
-    syllabusUpdatedAt,
-    objective,
-    weeklyPlan,
-    evaluation,
-    textbooks,
-    syllabusRemarks,
   ];
   @override
   String get aliasedName => _alias ?? entityName;
@@ -10861,30 +11063,6 @@ class $CourseOfferingOverviewsView
       fetchedAt: attachedDatabase.typeMapping.read(
         DriftSqlType.dateTime,
         data['${effectivePrefix}fetched_at'],
-      ),
-      syllabusUpdatedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}syllabus_updated_at'],
-      ),
-      objective: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}objective'],
-      ),
-      weeklyPlan: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}weekly_plan'],
-      ),
-      evaluation: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}evaluation'],
-      ),
-      textbooks: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}textbooks'],
-      ),
-      syllabusRemarks: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}syllabus_remarks'],
       ),
     );
   }
@@ -11013,49 +11191,6 @@ class $CourseOfferingOverviewsView
     true,
     generatedAs: GeneratedAs(courseOfferings.fetchedAt, false),
     type: DriftSqlType.dateTime,
-  );
-  late final GeneratedColumn<DateTime> syllabusUpdatedAt =
-      GeneratedColumn<DateTime>(
-        'syllabus_updated_at',
-        aliasedName,
-        true,
-        generatedAs: GeneratedAs(courseOfferings.syllabusUpdatedAt, false),
-        type: DriftSqlType.dateTime,
-      );
-  late final GeneratedColumn<String> objective = GeneratedColumn<String>(
-    'objective',
-    aliasedName,
-    true,
-    generatedAs: GeneratedAs(courseOfferings.objective, false),
-    type: DriftSqlType.string,
-  );
-  late final GeneratedColumn<String> weeklyPlan = GeneratedColumn<String>(
-    'weekly_plan',
-    aliasedName,
-    true,
-    generatedAs: GeneratedAs(courseOfferings.weeklyPlan, false),
-    type: DriftSqlType.string,
-  );
-  late final GeneratedColumn<String> evaluation = GeneratedColumn<String>(
-    'evaluation',
-    aliasedName,
-    true,
-    generatedAs: GeneratedAs(courseOfferings.evaluation, false),
-    type: DriftSqlType.string,
-  );
-  late final GeneratedColumn<String> textbooks = GeneratedColumn<String>(
-    'textbooks',
-    aliasedName,
-    true,
-    generatedAs: GeneratedAs(courseOfferings.textbooks, false),
-    type: DriftSqlType.string,
-  );
-  late final GeneratedColumn<String> syllabusRemarks = GeneratedColumn<String>(
-    'syllabus_remarks',
-    aliasedName,
-    true,
-    generatedAs: GeneratedAs(courseOfferings.syllabusRemarks, false),
-    type: DriftSqlType.string,
   );
   @override
   $CourseOfferingOverviewsView createAlias(String alias) {
@@ -12235,6 +12370,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $CourseOfferingStudentsTable courseOfferingStudents =
       $CourseOfferingStudentsTable(this);
   late final $SchedulesTable schedules = $SchedulesTable(this);
+  late final $SyllabusesTable syllabuses = $SyllabusesTable(this);
   late final $MaterialsTable materials = $MaterialsTable(this);
   late final $TeacherOfficeHoursTable teacherOfficeHours =
       $TeacherOfficeHoursTable(this);
@@ -12314,6 +12450,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     courseOfferingClasses,
     courseOfferingStudents,
     schedules,
+    syllabuses,
     materials,
     teacherOfficeHours,
     scores,
@@ -12370,6 +12507,13 @@ abstract class _$AppDatabase extends GeneratedDatabase {
         limitUpdateKind: UpdateKind.delete,
       ),
       result: [TableUpdate('schedules', kind: UpdateKind.delete)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'course_offerings',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('syllabuses', kind: UpdateKind.delete)],
     ),
     WritePropagation(
       on: TableUpdateQuery.onTableName(
@@ -14706,6 +14850,24 @@ final class $$TeachersTableReferences
       manager.$state.copyWith(prefetchedData: cache),
     );
   }
+
+  static MultiTypedResultKey<$SyllabusesTable, List<Syllabus>>
+  _syllabusesRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+    db.syllabuses,
+    aliasName: 'teachers__id__syllabuses__teacher',
+  );
+
+  $$SyllabusesTableProcessedTableManager get syllabusesRefs {
+    final manager = $$SyllabusesTableTableManager(
+      $_db,
+      $_db.syllabuses,
+    ).filter((f) => f.teacher.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_syllabusesRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
 }
 
 class $$TeachersTableFilterComposer
@@ -14753,6 +14915,31 @@ class $$TeachersTableFilterComposer
           }) => $$TeacherSemestersTableFilterComposer(
             $db: $db,
             $table: $db.teacherSemesters,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+
+  Expression<bool> syllabusesRefs(
+    Expression<bool> Function($$SyllabusesTableFilterComposer f) f,
+  ) {
+    final $$SyllabusesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.syllabuses,
+      getReferencedColumn: (t) => t.teacher,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$SyllabusesTableFilterComposer(
+            $db: $db,
+            $table: $db.syllabuses,
             $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
             joinBuilder: joinBuilder,
             $removeJoinBuilderFromRootComposer:
@@ -14838,6 +15025,31 @@ class $$TeachersTableAnnotationComposer
     );
     return f(composer);
   }
+
+  Expression<T> syllabusesRefs<T extends Object>(
+    Expression<T> Function($$SyllabusesTableAnnotationComposer a) f,
+  ) {
+    final $$SyllabusesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.syllabuses,
+      getReferencedColumn: (t) => t.teacher,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$SyllabusesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.syllabuses,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
 }
 
 class $$TeachersTableTableManager
@@ -14853,7 +15065,10 @@ class $$TeachersTableTableManager
           $$TeachersTableUpdateCompanionBuilder,
           (Teacher, $$TeachersTableReferences),
           Teacher,
-          PrefetchHooks Function({bool teacherSemestersRefs})
+          PrefetchHooks Function({
+            bool teacherSemestersRefs,
+            bool syllabusesRefs,
+          })
         > {
   $$TeachersTableTableManager(_$AppDatabase db, $TeachersTable table)
     : super(
@@ -14898,37 +15113,63 @@ class $$TeachersTableTableManager
                 ),
               )
               .toList(),
-          prefetchHooksCallback: ({teacherSemestersRefs = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [
-                if (teacherSemestersRefs) db.teacherSemesters,
-              ],
-              addJoins: null,
-              getPrefetchedDataCallback: (items) async {
-                return [
-                  if (teacherSemestersRefs)
-                    await $_getPrefetchedData<
-                      Teacher,
-                      $TeachersTable,
-                      TeacherSemester
-                    >(
-                      currentTable: table,
-                      referencedTable: $$TeachersTableReferences
-                          ._teacherSemestersRefsTable(db),
-                      managerFromTypedResult: (p0) => $$TeachersTableReferences(
-                        db,
-                        table,
-                        p0,
-                      ).teacherSemestersRefs,
-                      referencedItemsForCurrentItem: (item, referencedItems) =>
-                          referencedItems.where((e) => e.teacher == item.id),
-                      typedResults: items,
-                    ),
-                ];
+          prefetchHooksCallback:
+              ({teacherSemestersRefs = false, syllabusesRefs = false}) {
+                return PrefetchHooks(
+                  db: db,
+                  explicitlyWatchedTables: [
+                    if (teacherSemestersRefs) db.teacherSemesters,
+                    if (syllabusesRefs) db.syllabuses,
+                  ],
+                  addJoins: null,
+                  getPrefetchedDataCallback: (items) async {
+                    return [
+                      if (teacherSemestersRefs)
+                        await $_getPrefetchedData<
+                          Teacher,
+                          $TeachersTable,
+                          TeacherSemester
+                        >(
+                          currentTable: table,
+                          referencedTable: $$TeachersTableReferences
+                              ._teacherSemestersRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$TeachersTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).teacherSemestersRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.teacher == item.id,
+                              ),
+                          typedResults: items,
+                        ),
+                      if (syllabusesRefs)
+                        await $_getPrefetchedData<
+                          Teacher,
+                          $TeachersTable,
+                          Syllabus
+                        >(
+                          currentTable: table,
+                          referencedTable: $$TeachersTableReferences
+                              ._syllabusesRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$TeachersTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).syllabusesRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.teacher == item.id,
+                              ),
+                          typedResults: items,
+                        ),
+                    ];
+                  },
+                );
               },
-            );
-          },
         ),
       );
 }
@@ -14945,7 +15186,7 @@ typedef $$TeachersTableProcessedTableManager =
       $$TeachersTableUpdateCompanionBuilder,
       (Teacher, $$TeachersTableReferences),
       Teacher,
-      PrefetchHooks Function({bool teacherSemestersRefs})
+      PrefetchHooks Function({bool teacherSemestersRefs, bool syllabusesRefs})
     >;
 typedef $$ClassesTableCreateCompanionBuilder =
     ClassesCompanion Function({
@@ -15693,15 +15934,8 @@ typedef $$CourseOfferingsTableCreateCompanionBuilder =
       Value<String?> status,
       Value<String?> language,
       Value<String?> remarks,
-      Value<String?> syllabusId,
-      Value<DateTime?> syllabusUpdatedAt,
       Value<int?> enrolled,
       Value<int?> withdrawn,
-      Value<String?> objective,
-      Value<String?> weeklyPlan,
-      Value<String?> evaluation,
-      Value<String?> textbooks,
-      Value<String?> syllabusRemarks,
     });
 typedef $$CourseOfferingsTableUpdateCompanionBuilder =
     CourseOfferingsCompanion Function({
@@ -15719,15 +15953,8 @@ typedef $$CourseOfferingsTableUpdateCompanionBuilder =
       Value<String?> status,
       Value<String?> language,
       Value<String?> remarks,
-      Value<String?> syllabusId,
-      Value<DateTime?> syllabusUpdatedAt,
       Value<int?> enrolled,
       Value<int?> withdrawn,
-      Value<String?> objective,
-      Value<String?> weeklyPlan,
-      Value<String?> evaluation,
-      Value<String?> textbooks,
-      Value<String?> syllabusRemarks,
     });
 
 final class $$CourseOfferingsTableReferences
@@ -15852,6 +16079,24 @@ final class $$CourseOfferingsTableReferences
     );
   }
 
+  static MultiTypedResultKey<$SyllabusesTable, List<Syllabus>>
+  _syllabusesRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+    db.syllabuses,
+    aliasName: 'course_offerings__id__syllabuses__course_offering',
+  );
+
+  $$SyllabusesTableProcessedTableManager get syllabusesRefs {
+    final manager = $$SyllabusesTableTableManager(
+      $_db,
+      $_db.syllabuses,
+    ).filter((f) => f.courseOffering.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_syllabusesRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+
   static MultiTypedResultKey<$MaterialsTable, List<CourseMaterial>>
   _materialsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
     db.materials,
@@ -15965,16 +16210,6 @@ class $$CourseOfferingsTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
-  ColumnFilters<String> get syllabusId => $composableBuilder(
-    column: $table.syllabusId,
-    builder: (column) => ColumnFilters(column),
-  );
-
-  ColumnFilters<DateTime> get syllabusUpdatedAt => $composableBuilder(
-    column: $table.syllabusUpdatedAt,
-    builder: (column) => ColumnFilters(column),
-  );
-
   ColumnFilters<int> get enrolled => $composableBuilder(
     column: $table.enrolled,
     builder: (column) => ColumnFilters(column),
@@ -15982,31 +16217,6 @@ class $$CourseOfferingsTableFilterComposer
 
   ColumnFilters<int> get withdrawn => $composableBuilder(
     column: $table.withdrawn,
-    builder: (column) => ColumnFilters(column),
-  );
-
-  ColumnFilters<String> get objective => $composableBuilder(
-    column: $table.objective,
-    builder: (column) => ColumnFilters(column),
-  );
-
-  ColumnFilters<String> get weeklyPlan => $composableBuilder(
-    column: $table.weeklyPlan,
-    builder: (column) => ColumnFilters(column),
-  );
-
-  ColumnFilters<String> get evaluation => $composableBuilder(
-    column: $table.evaluation,
-    builder: (column) => ColumnFilters(column),
-  );
-
-  ColumnFilters<String> get textbooks => $composableBuilder(
-    column: $table.textbooks,
-    builder: (column) => ColumnFilters(column),
-  );
-
-  ColumnFilters<String> get syllabusRemarks => $composableBuilder(
-    column: $table.syllabusRemarks,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -16127,6 +16337,31 @@ class $$CourseOfferingsTableFilterComposer
           }) => $$SchedulesTableFilterComposer(
             $db: $db,
             $table: $db.schedules,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+
+  Expression<bool> syllabusesRefs(
+    Expression<bool> Function($$SyllabusesTableFilterComposer f) f,
+  ) {
+    final $$SyllabusesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.syllabuses,
+      getReferencedColumn: (t) => t.courseOffering,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$SyllabusesTableFilterComposer(
+            $db: $db,
+            $table: $db.syllabuses,
             $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
             joinBuilder: joinBuilder,
             $removeJoinBuilderFromRootComposer:
@@ -16261,16 +16496,6 @@ class $$CourseOfferingsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
-  ColumnOrderings<String> get syllabusId => $composableBuilder(
-    column: $table.syllabusId,
-    builder: (column) => ColumnOrderings(column),
-  );
-
-  ColumnOrderings<DateTime> get syllabusUpdatedAt => $composableBuilder(
-    column: $table.syllabusUpdatedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
-
   ColumnOrderings<int> get enrolled => $composableBuilder(
     column: $table.enrolled,
     builder: (column) => ColumnOrderings(column),
@@ -16278,31 +16503,6 @@ class $$CourseOfferingsTableOrderingComposer
 
   ColumnOrderings<int> get withdrawn => $composableBuilder(
     column: $table.withdrawn,
-    builder: (column) => ColumnOrderings(column),
-  );
-
-  ColumnOrderings<String> get objective => $composableBuilder(
-    column: $table.objective,
-    builder: (column) => ColumnOrderings(column),
-  );
-
-  ColumnOrderings<String> get weeklyPlan => $composableBuilder(
-    column: $table.weeklyPlan,
-    builder: (column) => ColumnOrderings(column),
-  );
-
-  ColumnOrderings<String> get evaluation => $composableBuilder(
-    column: $table.evaluation,
-    builder: (column) => ColumnOrderings(column),
-  );
-
-  ColumnOrderings<String> get textbooks => $composableBuilder(
-    column: $table.textbooks,
-    builder: (column) => ColumnOrderings(column),
-  );
-
-  ColumnOrderings<String> get syllabusRemarks => $composableBuilder(
-    column: $table.syllabusRemarks,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -16383,42 +16583,11 @@ class $$CourseOfferingsTableAnnotationComposer
   GeneratedColumn<String> get remarks =>
       $composableBuilder(column: $table.remarks, builder: (column) => column);
 
-  GeneratedColumn<String> get syllabusId => $composableBuilder(
-    column: $table.syllabusId,
-    builder: (column) => column,
-  );
-
-  GeneratedColumn<DateTime> get syllabusUpdatedAt => $composableBuilder(
-    column: $table.syllabusUpdatedAt,
-    builder: (column) => column,
-  );
-
   GeneratedColumn<int> get enrolled =>
       $composableBuilder(column: $table.enrolled, builder: (column) => column);
 
   GeneratedColumn<int> get withdrawn =>
       $composableBuilder(column: $table.withdrawn, builder: (column) => column);
-
-  GeneratedColumn<String> get objective =>
-      $composableBuilder(column: $table.objective, builder: (column) => column);
-
-  GeneratedColumn<String> get weeklyPlan => $composableBuilder(
-    column: $table.weeklyPlan,
-    builder: (column) => column,
-  );
-
-  GeneratedColumn<String> get evaluation => $composableBuilder(
-    column: $table.evaluation,
-    builder: (column) => column,
-  );
-
-  GeneratedColumn<String> get textbooks =>
-      $composableBuilder(column: $table.textbooks, builder: (column) => column);
-
-  GeneratedColumn<String> get syllabusRemarks => $composableBuilder(
-    column: $table.syllabusRemarks,
-    builder: (column) => column,
-  );
 
   $$SemestersTableAnnotationComposer get semester {
     final $$SemestersTableAnnotationComposer composer = $composerBuilder(
@@ -16546,6 +16715,31 @@ class $$CourseOfferingsTableAnnotationComposer
     return f(composer);
   }
 
+  Expression<T> syllabusesRefs<T extends Object>(
+    Expression<T> Function($$SyllabusesTableAnnotationComposer a) f,
+  ) {
+    final $$SyllabusesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.syllabuses,
+      getReferencedColumn: (t) => t.courseOffering,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$SyllabusesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.syllabuses,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+
   Expression<T> materialsRefs<T extends Object>(
     Expression<T> Function($$MaterialsTableAnnotationComposer a) f,
   ) {
@@ -16616,6 +16810,7 @@ class $$CourseOfferingsTableTableManager
             bool courseOfferingClassesRefs,
             bool courseOfferingStudentsRefs,
             bool schedulesRefs,
+            bool syllabusesRefs,
             bool materialsRefs,
             bool scoresRefs,
           })
@@ -16649,15 +16844,8 @@ class $$CourseOfferingsTableTableManager
                 Value<String?> status = const Value.absent(),
                 Value<String?> language = const Value.absent(),
                 Value<String?> remarks = const Value.absent(),
-                Value<String?> syllabusId = const Value.absent(),
-                Value<DateTime?> syllabusUpdatedAt = const Value.absent(),
                 Value<int?> enrolled = const Value.absent(),
                 Value<int?> withdrawn = const Value.absent(),
-                Value<String?> objective = const Value.absent(),
-                Value<String?> weeklyPlan = const Value.absent(),
-                Value<String?> evaluation = const Value.absent(),
-                Value<String?> textbooks = const Value.absent(),
-                Value<String?> syllabusRemarks = const Value.absent(),
               }) => CourseOfferingsCompanion(
                 id: id,
                 fetchedAt: fetchedAt,
@@ -16673,15 +16861,8 @@ class $$CourseOfferingsTableTableManager
                 status: status,
                 language: language,
                 remarks: remarks,
-                syllabusId: syllabusId,
-                syllabusUpdatedAt: syllabusUpdatedAt,
                 enrolled: enrolled,
                 withdrawn: withdrawn,
-                objective: objective,
-                weeklyPlan: weeklyPlan,
-                evaluation: evaluation,
-                textbooks: textbooks,
-                syllabusRemarks: syllabusRemarks,
               ),
           createCompanionCallback:
               ({
@@ -16699,15 +16880,8 @@ class $$CourseOfferingsTableTableManager
                 Value<String?> status = const Value.absent(),
                 Value<String?> language = const Value.absent(),
                 Value<String?> remarks = const Value.absent(),
-                Value<String?> syllabusId = const Value.absent(),
-                Value<DateTime?> syllabusUpdatedAt = const Value.absent(),
                 Value<int?> enrolled = const Value.absent(),
                 Value<int?> withdrawn = const Value.absent(),
-                Value<String?> objective = const Value.absent(),
-                Value<String?> weeklyPlan = const Value.absent(),
-                Value<String?> evaluation = const Value.absent(),
-                Value<String?> textbooks = const Value.absent(),
-                Value<String?> syllabusRemarks = const Value.absent(),
               }) => CourseOfferingsCompanion.insert(
                 id: id,
                 fetchedAt: fetchedAt,
@@ -16723,15 +16897,8 @@ class $$CourseOfferingsTableTableManager
                 status: status,
                 language: language,
                 remarks: remarks,
-                syllabusId: syllabusId,
-                syllabusUpdatedAt: syllabusUpdatedAt,
                 enrolled: enrolled,
                 withdrawn: withdrawn,
-                objective: objective,
-                weeklyPlan: weeklyPlan,
-                evaluation: evaluation,
-                textbooks: textbooks,
-                syllabusRemarks: syllabusRemarks,
               ),
           withReferenceMapper: (p0) => p0
               .map(
@@ -16748,6 +16915,7 @@ class $$CourseOfferingsTableTableManager
                 courseOfferingClassesRefs = false,
                 courseOfferingStudentsRefs = false,
                 schedulesRefs = false,
+                syllabusesRefs = false,
                 materialsRefs = false,
                 scoresRefs = false,
               }) {
@@ -16758,6 +16926,7 @@ class $$CourseOfferingsTableTableManager
                     if (courseOfferingClassesRefs) db.courseOfferingClasses,
                     if (courseOfferingStudentsRefs) db.courseOfferingStudents,
                     if (schedulesRefs) db.schedules,
+                    if (syllabusesRefs) db.syllabuses,
                     if (materialsRefs) db.materials,
                     if (scoresRefs) db.scores,
                   ],
@@ -16881,6 +17050,27 @@ class $$CourseOfferingsTableTableManager
                               ),
                           typedResults: items,
                         ),
+                      if (syllabusesRefs)
+                        await $_getPrefetchedData<
+                          CourseOffering,
+                          $CourseOfferingsTable,
+                          Syllabus
+                        >(
+                          currentTable: table,
+                          referencedTable: $$CourseOfferingsTableReferences
+                              ._syllabusesRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$CourseOfferingsTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).syllabusesRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.courseOffering == item.id,
+                              ),
+                          typedResults: items,
+                        ),
                       if (materialsRefs)
                         await $_getPrefetchedData<
                           CourseOffering,
@@ -16949,6 +17139,7 @@ typedef $$CourseOfferingsTableProcessedTableManager =
         bool courseOfferingClassesRefs,
         bool courseOfferingStudentsRefs,
         bool schedulesRefs,
+        bool syllabusesRefs,
         bool materialsRefs,
         bool scoresRefs,
       })
@@ -19371,6 +19562,503 @@ typedef $$SchedulesTableProcessedTableManager =
       (Schedule, $$SchedulesTableReferences),
       Schedule,
       PrefetchHooks Function({bool courseOffering, bool classroom})
+    >;
+typedef $$SyllabusesTableCreateCompanionBuilder =
+    SyllabusesCompanion Function({
+      Value<int> id,
+      Value<DateTime?> fetchedAt,
+      required int courseOffering,
+      required int teacher,
+      Value<DateTime?> updatedAt,
+      Value<String?> objective,
+      Value<String?> weeklyPlan,
+      Value<String?> evaluation,
+      Value<String?> textbooks,
+      Value<String?> remarks,
+    });
+typedef $$SyllabusesTableUpdateCompanionBuilder =
+    SyllabusesCompanion Function({
+      Value<int> id,
+      Value<DateTime?> fetchedAt,
+      Value<int> courseOffering,
+      Value<int> teacher,
+      Value<DateTime?> updatedAt,
+      Value<String?> objective,
+      Value<String?> weeklyPlan,
+      Value<String?> evaluation,
+      Value<String?> textbooks,
+      Value<String?> remarks,
+    });
+
+final class $$SyllabusesTableReferences
+    extends BaseReferences<_$AppDatabase, $SyllabusesTable, Syllabus> {
+  $$SyllabusesTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $CourseOfferingsTable _courseOfferingTable(_$AppDatabase db) => db
+      .courseOfferings
+      .createAlias('syllabuses__course_offering__course_offerings__id');
+
+  $$CourseOfferingsTableProcessedTableManager get courseOffering {
+    final $_column = $_itemColumn<int>('course_offering')!;
+
+    final manager = $$CourseOfferingsTableTableManager(
+      $_db,
+      $_db.courseOfferings,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_courseOfferingTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static $TeachersTable _teacherTable(_$AppDatabase db) =>
+      db.teachers.createAlias('syllabuses__teacher__teachers__id');
+
+  $$TeachersTableProcessedTableManager get teacher {
+    final $_column = $_itemColumn<int>('teacher')!;
+
+    final manager = $$TeachersTableTableManager(
+      $_db,
+      $_db.teachers,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_teacherTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$SyllabusesTableFilterComposer
+    extends Composer<_$AppDatabase, $SyllabusesTable> {
+  $$SyllabusesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get fetchedAt => $composableBuilder(
+    column: $table.fetchedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get objective => $composableBuilder(
+    column: $table.objective,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get weeklyPlan => $composableBuilder(
+    column: $table.weeklyPlan,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get evaluation => $composableBuilder(
+    column: $table.evaluation,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get textbooks => $composableBuilder(
+    column: $table.textbooks,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get remarks => $composableBuilder(
+    column: $table.remarks,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$CourseOfferingsTableFilterComposer get courseOffering {
+    final $$CourseOfferingsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.courseOffering,
+      referencedTable: $db.courseOfferings,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$CourseOfferingsTableFilterComposer(
+            $db: $db,
+            $table: $db.courseOfferings,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$TeachersTableFilterComposer get teacher {
+    final $$TeachersTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.teacher,
+      referencedTable: $db.teachers,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TeachersTableFilterComposer(
+            $db: $db,
+            $table: $db.teachers,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$SyllabusesTableOrderingComposer
+    extends Composer<_$AppDatabase, $SyllabusesTable> {
+  $$SyllabusesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get fetchedAt => $composableBuilder(
+    column: $table.fetchedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get objective => $composableBuilder(
+    column: $table.objective,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get weeklyPlan => $composableBuilder(
+    column: $table.weeklyPlan,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get evaluation => $composableBuilder(
+    column: $table.evaluation,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get textbooks => $composableBuilder(
+    column: $table.textbooks,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get remarks => $composableBuilder(
+    column: $table.remarks,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$CourseOfferingsTableOrderingComposer get courseOffering {
+    final $$CourseOfferingsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.courseOffering,
+      referencedTable: $db.courseOfferings,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$CourseOfferingsTableOrderingComposer(
+            $db: $db,
+            $table: $db.courseOfferings,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$TeachersTableOrderingComposer get teacher {
+    final $$TeachersTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.teacher,
+      referencedTable: $db.teachers,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TeachersTableOrderingComposer(
+            $db: $db,
+            $table: $db.teachers,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$SyllabusesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $SyllabusesTable> {
+  $$SyllabusesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get fetchedAt =>
+      $composableBuilder(column: $table.fetchedAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<String> get objective =>
+      $composableBuilder(column: $table.objective, builder: (column) => column);
+
+  GeneratedColumn<String> get weeklyPlan => $composableBuilder(
+    column: $table.weeklyPlan,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get evaluation => $composableBuilder(
+    column: $table.evaluation,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get textbooks =>
+      $composableBuilder(column: $table.textbooks, builder: (column) => column);
+
+  GeneratedColumn<String> get remarks =>
+      $composableBuilder(column: $table.remarks, builder: (column) => column);
+
+  $$CourseOfferingsTableAnnotationComposer get courseOffering {
+    final $$CourseOfferingsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.courseOffering,
+      referencedTable: $db.courseOfferings,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$CourseOfferingsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.courseOfferings,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$TeachersTableAnnotationComposer get teacher {
+    final $$TeachersTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.teacher,
+      referencedTable: $db.teachers,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TeachersTableAnnotationComposer(
+            $db: $db,
+            $table: $db.teachers,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$SyllabusesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $SyllabusesTable,
+          Syllabus,
+          $$SyllabusesTableFilterComposer,
+          $$SyllabusesTableOrderingComposer,
+          $$SyllabusesTableAnnotationComposer,
+          $$SyllabusesTableCreateCompanionBuilder,
+          $$SyllabusesTableUpdateCompanionBuilder,
+          (Syllabus, $$SyllabusesTableReferences),
+          Syllabus,
+          PrefetchHooks Function({bool courseOffering, bool teacher})
+        > {
+  $$SyllabusesTableTableManager(_$AppDatabase db, $SyllabusesTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$SyllabusesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$SyllabusesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$SyllabusesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<DateTime?> fetchedAt = const Value.absent(),
+                Value<int> courseOffering = const Value.absent(),
+                Value<int> teacher = const Value.absent(),
+                Value<DateTime?> updatedAt = const Value.absent(),
+                Value<String?> objective = const Value.absent(),
+                Value<String?> weeklyPlan = const Value.absent(),
+                Value<String?> evaluation = const Value.absent(),
+                Value<String?> textbooks = const Value.absent(),
+                Value<String?> remarks = const Value.absent(),
+              }) => SyllabusesCompanion(
+                id: id,
+                fetchedAt: fetchedAt,
+                courseOffering: courseOffering,
+                teacher: teacher,
+                updatedAt: updatedAt,
+                objective: objective,
+                weeklyPlan: weeklyPlan,
+                evaluation: evaluation,
+                textbooks: textbooks,
+                remarks: remarks,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<DateTime?> fetchedAt = const Value.absent(),
+                required int courseOffering,
+                required int teacher,
+                Value<DateTime?> updatedAt = const Value.absent(),
+                Value<String?> objective = const Value.absent(),
+                Value<String?> weeklyPlan = const Value.absent(),
+                Value<String?> evaluation = const Value.absent(),
+                Value<String?> textbooks = const Value.absent(),
+                Value<String?> remarks = const Value.absent(),
+              }) => SyllabusesCompanion.insert(
+                id: id,
+                fetchedAt: fetchedAt,
+                courseOffering: courseOffering,
+                teacher: teacher,
+                updatedAt: updatedAt,
+                objective: objective,
+                weeklyPlan: weeklyPlan,
+                evaluation: evaluation,
+                textbooks: textbooks,
+                remarks: remarks,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$SyllabusesTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({courseOffering = false, teacher = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (courseOffering) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.courseOffering,
+                                referencedTable: $$SyllabusesTableReferences
+                                    ._courseOfferingTable(db),
+                                referencedColumn: $$SyllabusesTableReferences
+                                    ._courseOfferingTable(db)
+                                    .id,
+                              )
+                              as T;
+                    }
+                    if (teacher) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.teacher,
+                                referencedTable: $$SyllabusesTableReferences
+                                    ._teacherTable(db),
+                                referencedColumn: $$SyllabusesTableReferences
+                                    ._teacherTable(db)
+                                    .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$SyllabusesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $SyllabusesTable,
+      Syllabus,
+      $$SyllabusesTableFilterComposer,
+      $$SyllabusesTableOrderingComposer,
+      $$SyllabusesTableAnnotationComposer,
+      $$SyllabusesTableCreateCompanionBuilder,
+      $$SyllabusesTableUpdateCompanionBuilder,
+      (Syllabus, $$SyllabusesTableReferences),
+      Syllabus,
+      PrefetchHooks Function({bool courseOffering, bool teacher})
     >;
 typedef $$MaterialsTableCreateCompanionBuilder =
     MaterialsCompanion Function({
@@ -22968,6 +23656,8 @@ class $AppDatabaseManager {
       );
   $$SchedulesTableTableManager get schedules =>
       $$SchedulesTableTableManager(_db, _db.schedules);
+  $$SyllabusesTableTableManager get syllabuses =>
+      $$SyllabusesTableTableManager(_db, _db.syllabuses);
   $$MaterialsTableTableManager get materials =>
       $$MaterialsTableTableManager(_db, _db.materials);
   $$TeacherOfficeHoursTableTableManager get teacherOfficeHours =>

--- a/lib/database/schema.dart
+++ b/lib/database/schema.dart
@@ -393,8 +393,7 @@ class CourseOfferings extends Table with AutoIncrementId, Fetchable {
 
   // Syllabus header fields (課程基本資料): identical on every syllabus page, so
   // they live on the offering. Populated lazily by the syllabus refresh, which
-  // also sets `fetchedAt` (a last-populated marker here, not a fetch gate —
-  // per-syllabus content is gated by Syllabuses.fetchedAt).
+  // also sets `fetchedAt` (a last-populated marker here, not a fetch gate).
 
   /// Number of enrolled students (人).
   late final enrolled = integer().nullable()();
@@ -502,11 +501,11 @@ class Schedules extends Table with AutoIncrementId {
 /// keyed by the authoring teacher's code (hence the [Teachers] reference;
 /// per-semester teacher details live on [TeacherSemesters]). Fields shared
 /// across an offering's syllabi (course type, enrolled, withdrawn) stay on
-/// [CourseOfferings]. Rows start as stubs (`fetchedAt == null`) and are
-/// populated lazily.
+/// [CourseOfferings]. A row exists only for a teacher who has submitted a
+/// syllabus; it is created lazily on first fetch and always refetched fresh.
 // Without @DataClassName, Drift names the row class 'Syllabuse'.
 @DataClassName('Syllabus')
-class Syllabuses extends Table with AutoIncrementId, Fetchable {
+class Syllabuses extends Table with AutoIncrementId {
   /// Reference to the course offering this syllabus belongs to.
   late final courseOffering = integer().references(
     CourseOfferings,

--- a/lib/database/schema.dart
+++ b/lib/database/schema.dart
@@ -391,39 +391,16 @@ class CourseOfferings extends Table with AutoIncrementId, Fetchable {
   /// Not a [Fetchable] field.
   late final remarks = text().nullable()();
 
-  /// Syllabus ID for fetching detailed syllabus information.
-  ///
-  /// Not a [Fetchable] field.
-  late final syllabusId = text().nullable()();
-
-  // Syllabus fields (教學大綱與進度)
-
-  /// When the syllabus was last updated (最後更新時間).
-  late final syllabusUpdatedAt = dateTime().nullable()();
+  // Syllabus header fields (課程基本資料): identical on every syllabus page, so
+  // they live on the offering. Populated lazily by the syllabus refresh, which
+  // also sets `fetchedAt` (a last-populated marker here, not a fetch gate —
+  // per-syllabus content is gated by Syllabuses.fetchedAt).
 
   /// Number of enrolled students (人).
   late final enrolled = integer().nullable()();
 
   /// Number of withdrawn students (撤).
   late final withdrawn = integer().nullable()();
-
-  /// Course objective/outline (課程大綱).
-  late final objective = text().nullable()();
-
-  /// Weekly plan describing topics covered each week (課程進度).
-  ///
-  /// Note: Called "Course Schedule" on English page, but refers to weekly
-  /// topics, not class meeting times.
-  late final weeklyPlan = text().nullable()();
-
-  /// Evaluation and grading policy (評量方式與標準).
-  late final evaluation = text().nullable()();
-
-  /// Textbooks and reference materials (使用教材、參考書目或其他).
-  late final textbooks = text().nullable()();
-
-  /// Teacher-authored remarks from the syllabus page (備註).
-  late final syllabusRemarks = text().nullable()();
 
   @override
   List<Set<Column>> get uniqueKeys => [
@@ -516,6 +493,54 @@ class Schedules extends Table with AutoIncrementId {
   @override
   List<Set<Column>> get uniqueKeys => [
     {courseOffering, dayOfWeek, period},
+  ];
+}
+
+/// A teacher-authored syllabus for a course offering (教學大綱與進度).
+///
+/// An offering can have multiple syllabi — one per teacher who submits one,
+/// keyed by the authoring teacher's code (hence the [Teachers] reference;
+/// per-semester teacher details live on [TeacherSemesters]). Fields shared
+/// across an offering's syllabi (course type, enrolled, withdrawn) stay on
+/// [CourseOfferings]. Rows start as stubs (`fetchedAt == null`) and are
+/// populated lazily.
+// Without @DataClassName, Drift names the row class 'Syllabuse'.
+@DataClassName('Syllabus')
+class Syllabuses extends Table with AutoIncrementId, Fetchable {
+  /// Reference to the course offering this syllabus belongs to.
+  late final courseOffering = integer().references(
+    CourseOfferings,
+    #id,
+    onDelete: .cascade,
+  )();
+
+  /// Reference to the authoring teacher (the syllabus's code is their code).
+  late final teacher = integer().references(Teachers, #id)();
+
+  /// When this syllabus was last updated by the teacher (最後更新時間).
+  late final updatedAt = dateTime().nullable()();
+
+  /// Course objective/outline (課程大綱).
+  late final objective = text().nullable()();
+
+  /// Weekly plan describing topics covered each week (課程進度).
+  ///
+  /// Note: Called "Course Schedule" on the English page, but refers to weekly
+  /// topics, not class meeting times.
+  late final weeklyPlan = text().nullable()();
+
+  /// Evaluation and grading policy (評量方式與標準).
+  late final evaluation = text().nullable()();
+
+  /// Textbooks and reference materials (使用教材、參考書目或其他).
+  late final textbooks = text().nullable()();
+
+  /// Teacher-authored remarks from the syllabus page (備註).
+  late final remarks = text().nullable()();
+
+  @override
+  List<Set<Column>> get uniqueKeys => [
+    {courseOffering, teacher},
   ];
 }
 

--- a/lib/database/views.dart
+++ b/lib/database/views.dart
@@ -126,12 +126,6 @@ abstract class CourseOfferingOverviews extends View {
         courseOfferings.enrolled,
         courseOfferings.withdrawn,
         courseOfferings.fetchedAt,
-        courseOfferings.syllabusUpdatedAt,
-        courseOfferings.objective,
-        courseOfferings.weeklyPlan,
-        courseOfferings.evaluation,
-        courseOfferings.textbooks,
-        courseOfferings.syllabusRemarks,
       ]).from(courseOfferings).join([
         leftOuterJoin(
           courses,

--- a/lib/repositories/course_repository.dart
+++ b/lib/repositories/course_repository.dart
@@ -15,18 +15,6 @@ import 'package:tattoo/services/i_school_plus/i_school_plus_service.dart';
 import 'package:tattoo/services/portal/portal_service.dart';
 import 'package:tattoo/utils/localized.dart';
 
-/// One of a course offering's available syllabi, with its authoring teacher.
-///
-/// Content is fetched lazily via [CourseRepository.watchSyllabus]; `fetchedAt`
-/// is null until then.
-typedef OfferingSyllabus = ({
-  int id,
-  String teacherCode,
-  String teacherNameZh,
-  String? teacherNameEn,
-  DateTime? fetchedAt,
-});
-
 /// Detailed data for a single course offering, sufficient to populate the
 /// course-table detail bottom sheet. Composes the [CourseOfferingOverview]
 /// view row (single-value offering+catalog fields) with the offering's
@@ -47,9 +35,6 @@ typedef CourseOfferingDetail = ({
   schedule,
   List<({String code, String nameZh, String? nameEn})> teachers,
   List<({String code, String nameZh, String? nameEn})> classes,
-
-  /// Available syllabi, ordered as in the course list (the UI shows the first).
-  List<OfferingSyllabus> syllabi,
 });
 
 /// Data for a single cell in the course table grid.
@@ -403,8 +388,7 @@ class CourseRepository {
           remarks: dto.remarks,
         );
 
-        // Clear old junctions and schedules for this offering. Syllabi are
-        // reconciled separately below so cached content survives a refresh.
+        // Clear old junctions and schedules for this offering
         await (_database.delete(
           _database.courseOfferingTeachers,
         )..where((t) => t.courseOffering.equals(offeringId))).go();
@@ -492,56 +476,6 @@ class CourseRepository {
                   mode: .insertOrReplace,
                 );
           }
-        }
-
-        // Syllabus stubs — record which teachers have a syllabus (one 查詢 link
-        // each, keyed by the teacher's code). Content is fetched lazily later,
-        // so insertOrIgnore preserves cached rows; only stale authors removed.
-        final syllabusCodes = dto.syllabusIds ?? const <String>[];
-        final syllabusTeacherIds = <int>[];
-        if (syllabusCodes.isNotEmpty) {
-          final teacherRows = await (_database.select(
-            _database.teachers,
-          )..where((t) => t.code.isIn(syllabusCodes))).get();
-          final teacherIdByCode = {for (final t in teacherRows) t.code: t.id};
-          // Keep course-list order (first syllabus = first listed teacher).
-          for (final code in syllabusCodes) {
-            if (teacherIdByCode[code] case final teacherId?) {
-              syllabusTeacherIds.add(teacherId);
-            }
-          }
-        }
-        if (syllabusCodes.isEmpty) {
-          // No syllabi — drop any cached rows.
-          await (_database.delete(
-            _database.syllabuses,
-          )..where((s) => s.courseOffering.equals(offeringId))).go();
-        } else if (syllabusTeacherIds.isNotEmpty) {
-          // Drop syllabi whose author no longer offers one; keep the rest.
-          await (_database.delete(_database.syllabuses)..where(
-                (s) =>
-                    s.courseOffering.equals(offeringId) &
-                    s.teacher.isNotIn(syllabusTeacherIds),
-              ))
-              .go();
-        } else {
-          // Codes present but none resolved to a teacher (invariant violation);
-          // keep cached content rather than wiping it.
-          _firebaseService.recordNonFatal(
-            'Syllabus codes unresolved for offering ${dto.number}: '
-            '$syllabusCodes',
-          );
-        }
-        for (final teacherId in syllabusTeacherIds) {
-          await _database
-              .into(_database.syllabuses)
-              .insert(
-                SyllabusesCompanion.insert(
-                  courseOffering: offeringId,
-                  teacher: teacherId,
-                ),
-                mode: .insertOrIgnore,
-              );
         }
       }
 
@@ -701,10 +635,10 @@ class CourseRepository {
   }
 
   /// Watches a course offering's joined detail (overview + schedule + teachers
-  /// + classes + available syllabi), composed from the database — no network.
-  /// Syllabus content is fetched separately via [watchSyllabus]. Emits `null`
-  /// when the offering is missing; re-emits when a syllabus refresh writes the
-  /// offering's header fields.
+  /// + classes), composed from the database — no network. A teacher's syllabus
+  /// is fetched separately via [watchSyllabus]. Emits `null` when the offering
+  /// is missing; re-emits when a syllabus refresh writes the offering's header
+  /// fields.
   Stream<CourseOfferingDetail?> watchCourseOffering(int id) async* {
     final query = _database.select(_database.courseOfferingOverviews)
       ..where((o) => o.id.equals(id));
@@ -715,120 +649,146 @@ class CourseRepository {
         continue;
       }
 
-      final (schedule, teachers, classes, syllabi) = await (
+      final (schedule, teachers, classes) = await (
         _readOfferingSchedule(id),
         _readOfferingTeachers(id),
         _readOfferingClasses(id),
-        _readOfferingSyllabi(id),
       ).wait;
       yield (
         overview: overview,
         schedule: schedule,
         teachers: teachers,
         classes: classes,
-        syllabi: syllabi,
       );
     }
   }
 
-  /// Watches a single syllabus, always fetching fresh content once per
-  /// subscription rather than caching.
+  /// Watches the syllabus authored by [teacherId] for offering [offeringId],
+  /// always fetching fresh content once per subscription rather than caching.
   ///
-  /// Waits on the fetch while the row is still a stub (`fetchedAt == null`) so
-  /// the screen doesn't flash empty content; an already-populated row emits
-  /// first and refreshes in the background. The stream re-emits automatically
-  /// when the DB is updated. Emits `null` when the syllabus is missing.
-  Stream<Syllabus?> watchSyllabus(int id) async* {
+  /// Emits cached content immediately, then refreshes in the background; with
+  /// no cached row it blocks on the first fetch instead, so the UI shows
+  /// content (or a definitive "no syllabus") rather than flashing empty. The
+  /// stream re-emits when the DB is updated. Emits `null` when the teacher
+  /// hasn't submitted a syllabus (尚未登錄) or is unknown.
+  Stream<Syllabus?> watchSyllabus({
+    required int offeringId,
+    required String teacherId,
+  }) async* {
+    final teacher = await (_database.select(
+      _database.teachers,
+    )..where((t) => t.code.equals(teacherId))).getSingleOrNull();
+    if (teacher == null) {
+      yield null;
+      return;
+    }
+
     final query = _database.select(_database.syllabuses)
-      ..where((s) => s.id.equals(id));
+      ..where(
+        (s) =>
+            s.courseOffering.equals(offeringId) & s.teacher.equals(teacher.id),
+      );
 
     // Fetch once per subscription. The guard stops the refresh's own write
-    // (which stamps `fetchedAt`) from re-triggering the fetch on the re-emit.
+    // from re-triggering the fetch on the re-emit.
     var refreshed = false;
     await for (final syllabus in query.watchSingleOrNull()) {
-      if (syllabus == null) {
-        yield null;
-        continue;
-      }
-
-      final refresh = !refreshed;
-      refreshed = true;
-
-      // Stub: fetch before emitting so we don't flash empty content.
-      if (refresh && syllabus.fetchedAt == null) {
+      if (syllabus == null && !refreshed) {
+        refreshed = true;
         try {
-          await refreshSyllabus(id);
-          final refreshedRow = await (_database.select(
-            _database.syllabuses,
-          )..where((s) => s.id.equals(id))).getSingleOrNull();
-          yield refreshedRow ?? syllabus;
+          await refreshSyllabus(offeringId: offeringId, teacherId: teacherId);
         } catch (_) {
-          // Absorb: yield the stub so the UI exits its loading state
-          yield syllabus;
+          // Absorb: yield null below so the UI exits its loading state
         }
-        continue;
       }
 
       yield syllabus;
 
-      // Populated: refresh in the background; the stream re-emits when written.
-      if (refresh && syllabus.fetchedAt != null) {
+      if (syllabus != null && !refreshed) {
+        refreshed = true;
         try {
-          await refreshSyllabus(id);
+          await refreshSyllabus(offeringId: offeringId, teacherId: teacherId);
         } catch (_) {
-          // Absorb: stale data is shown via stream
+          // Absorb: stale content is shown via stream
         }
       }
     }
   }
 
-  /// Fetches a syllabus's content and writes it back: content to the
-  /// [Syllabuses] row, instructor email to [TeacherSemesters], and the shared
-  /// header fields (course type, enrolled, withdrawn) to [CourseOfferings].
+  /// Fetches teacher [teacherId]'s syllabus for offering [offeringId] and
+  /// writes it back: content to a [Syllabuses] row (created on first fetch),
+  /// instructor email to [TeacherSemesters], and the shared header fields
+  /// (course type, enrolled, withdrawn) to [CourseOfferings]. Deletes the row
+  /// when the teacher hasn't submitted a syllabus (`getSyllabus` returns null).
   ///
-  /// No-ops when the syllabus/offering is missing or has no `number`;
-  /// network errors propagate to the caller.
-  Future<void> refreshSyllabus(int id) async {
-    final syllabusRow = await (_database.select(
-      _database.syllabuses,
-    )..where((s) => s.id.equals(id))).getSingleOrNull();
-    if (syllabusRow == null) return;
-
+  /// No-ops when the offering/teacher is missing or the offering has no
+  /// `number`; network errors propagate to the caller.
+  Future<void> refreshSyllabus({
+    required int offeringId,
+    required String teacherId,
+  }) async {
     final offering = await (_database.select(
       _database.courseOfferings,
-    )..where((o) => o.id.equals(syllabusRow.courseOffering))).getSingleOrNull();
+    )..where((o) => o.id.equals(offeringId))).getSingleOrNull();
     if (offering == null || offering.number == null) return;
 
     final teacher = await (_database.select(
       _database.teachers,
-    )..where((t) => t.id.equals(syllabusRow.teacher))).getSingle();
+    )..where((t) => t.code.equals(teacherId))).getSingleOrNull();
+    if (teacher == null) return;
 
     final syllabus = await _authRepository.withAuth(
       () => _courseService.getSyllabus(
         courseNumber: offering.number!,
-        syllabusId: teacher.code,
+        syllabusId: teacherId,
       ),
       sso: [.courseService],
     );
 
     await _database.transaction(() async {
-      await (_database.update(
-        _database.syllabuses,
-      )..where((s) => s.id.equals(id))).write(
-        SyllabusesCompanion(
-          updatedAt: Value(syllabus.lastUpdated),
-          objective: Value(syllabus.objective),
-          weeklyPlan: Value(syllabus.weeklyPlan),
-          evaluation: Value(syllabus.evaluation),
-          textbooks: Value(syllabus.materials),
-          remarks: Value(syllabus.remarks),
-          fetchedAt: Value(DateTime.now()),
-        ),
-      );
+      if (syllabus == null) {
+        // Teacher hasn't submitted a syllabus; drop any cached row.
+        await (_database.delete(_database.syllabuses)..where(
+              (s) =>
+                  s.courseOffering.equals(offeringId) &
+                  s.teacher.equals(teacher.id),
+            ))
+            .go();
+        return;
+      }
+
+      await _database
+          .into(_database.syllabuses)
+          .insert(
+            SyllabusesCompanion.insert(
+              courseOffering: offeringId,
+              teacher: teacher.id,
+              updatedAt: Value(syllabus.lastUpdated),
+              objective: Value(syllabus.objective),
+              weeklyPlan: Value(syllabus.weeklyPlan),
+              evaluation: Value(syllabus.evaluation),
+              textbooks: Value(syllabus.materials),
+              remarks: Value(syllabus.remarks),
+            ),
+            onConflict: DoUpdate(
+              (_) => SyllabusesCompanion(
+                updatedAt: Value(syllabus.lastUpdated),
+                objective: Value(syllabus.objective),
+                weeklyPlan: Value(syllabus.weeklyPlan),
+                evaluation: Value(syllabus.evaluation),
+                textbooks: Value(syllabus.materials),
+                remarks: Value(syllabus.remarks),
+              ),
+              target: [
+                _database.syllabuses.courseOffering,
+                _database.syllabuses.teacher,
+              ],
+            ),
+          );
 
       await (_database.update(
         _database.courseOfferings,
-      )..where((o) => o.id.equals(offering.id))).write(
+      )..where((o) => o.id.equals(offeringId))).write(
         CourseOfferingsCompanion(
           courseType: Value(syllabus.type),
           enrolled: Value(syllabus.enrolled),
@@ -933,31 +893,6 @@ class CourseRepository {
           code: row.readTable(_database.classes).code,
           nameZh: row.readTable(_database.classes).nameZh,
           nameEn: row.readTable(_database.classes).nameEn,
-        ),
-    ];
-  }
-
-  Future<List<OfferingSyllabus>> _readOfferingSyllabi(int id) async {
-    final rows =
-        await (_database.select(_database.syllabuses).join([
-                innerJoin(
-                  _database.teachers,
-                  _database.teachers.id.equalsExp(
-                    _database.syllabuses.teacher,
-                  ),
-                ),
-              ])
-              ..where(_database.syllabuses.courseOffering.equals(id))
-              ..orderBy([OrderingTerm.asc(_database.syllabuses.id)]))
-            .get();
-    return [
-      for (final row in rows)
-        (
-          id: row.readTable(_database.syllabuses).id,
-          teacherCode: row.readTable(_database.teachers).code,
-          teacherNameZh: row.readTable(_database.teachers).nameZh,
-          teacherNameEn: row.readTable(_database.teachers).nameEn,
-          fetchedAt: row.readTable(_database.syllabuses).fetchedAt,
         ),
     ];
   }

--- a/lib/repositories/course_repository.dart
+++ b/lib/repositories/course_repository.dart
@@ -15,6 +15,18 @@ import 'package:tattoo/services/i_school_plus/i_school_plus_service.dart';
 import 'package:tattoo/services/portal/portal_service.dart';
 import 'package:tattoo/utils/localized.dart';
 
+/// One of a course offering's available syllabi, with its authoring teacher.
+///
+/// Content is fetched lazily via [CourseRepository.watchSyllabus]; `fetchedAt`
+/// is null until then.
+typedef OfferingSyllabus = ({
+  int id,
+  String teacherCode,
+  String teacherNameZh,
+  String? teacherNameEn,
+  DateTime? fetchedAt,
+});
+
 /// Detailed data for a single course offering, sufficient to populate the
 /// course-table detail bottom sheet. Composes the [CourseOfferingOverview]
 /// view row (single-value offering+catalog fields) with the offering's
@@ -35,6 +47,9 @@ typedef CourseOfferingDetail = ({
   schedule,
   List<({String code, String nameZh, String? nameEn})> teachers,
   List<({String code, String nameZh, String? nameEn})> classes,
+
+  /// Available syllabi, ordered as in the course list (the UI shows the first).
+  List<OfferingSyllabus> syllabi,
 });
 
 /// Data for a single cell in the course table grid.
@@ -386,10 +401,10 @@ class CourseRepository {
           status: dto.status,
           language: dto.language,
           remarks: dto.remarks,
-          syllabusId: dto.syllabusId,
         );
 
-        // Clear old junctions and schedules for this offering
+        // Clear old junctions and schedules for this offering. Syllabi are
+        // reconciled separately below so cached content survives a refresh.
         await (_database.delete(
           _database.courseOfferingTeachers,
         )..where((t) => t.courseOffering.equals(offeringId))).go();
@@ -477,6 +492,56 @@ class CourseRepository {
                   mode: .insertOrReplace,
                 );
           }
+        }
+
+        // Syllabus stubs — record which teachers have a syllabus (one 查詢 link
+        // each, keyed by the teacher's code). Content is fetched lazily later,
+        // so insertOrIgnore preserves cached rows; only stale authors removed.
+        final syllabusCodes = dto.syllabusIds ?? const <String>[];
+        final syllabusTeacherIds = <int>[];
+        if (syllabusCodes.isNotEmpty) {
+          final teacherRows = await (_database.select(
+            _database.teachers,
+          )..where((t) => t.code.isIn(syllabusCodes))).get();
+          final teacherIdByCode = {for (final t in teacherRows) t.code: t.id};
+          // Keep course-list order (first syllabus = first listed teacher).
+          for (final code in syllabusCodes) {
+            if (teacherIdByCode[code] case final teacherId?) {
+              syllabusTeacherIds.add(teacherId);
+            }
+          }
+        }
+        if (syllabusCodes.isEmpty) {
+          // No syllabi — drop any cached rows.
+          await (_database.delete(
+            _database.syllabuses,
+          )..where((s) => s.courseOffering.equals(offeringId))).go();
+        } else if (syllabusTeacherIds.isNotEmpty) {
+          // Drop syllabi whose author no longer offers one; keep the rest.
+          await (_database.delete(_database.syllabuses)..where(
+                (s) =>
+                    s.courseOffering.equals(offeringId) &
+                    s.teacher.isNotIn(syllabusTeacherIds),
+              ))
+              .go();
+        } else {
+          // Codes present but none resolved to a teacher (invariant violation);
+          // keep cached content rather than wiping it.
+          _firebaseService.recordNonFatal(
+            'Syllabus codes unresolved for offering ${dto.number}: '
+            '$syllabusCodes',
+          );
+        }
+        for (final teacherId in syllabusTeacherIds) {
+          await _database
+              .into(_database.syllabuses)
+              .insert(
+                SyllabusesCompanion.insert(
+                  courseOffering: offeringId,
+                  teacher: teacherId,
+                ),
+                mode: .insertOrIgnore,
+              );
         }
       }
 
@@ -636,106 +701,143 @@ class CourseRepository {
   }
 
   /// Watches a course offering's joined detail (overview + schedule + teachers
-  /// + classes).
-  ///
-  /// Assumes [refreshCourseTable] has already populated the offering and its
-  /// junctions. Emits `null` when the offering is missing; the stream stays
-  /// open so a later insert can surface it.
-  ///
-  /// Refresh behavior on the first non-null emission, gated by
-  /// [CourseOfferings.fetchedAt]:
-  /// - **Never fetched** (`fetchedAt == null`): blocks on [refreshCourseOffering]
-  ///   before yielding so consumers don't render null syllabus fields
-  ///   (`courseType`, `enrolled`, `withdrawn`, `syllabusRemarks`, …). If the
-  ///   refresh fails, falls through and emits the cached row (with whatever's
-  ///   there).
-  /// - **Previously fetched**: yields cached data immediately and fires
-  ///   [refreshCourseOffering] in the background. When that write lands, the
-  ///   view's `.watch()` re-emits with fresh fields.
-  ///
-  /// The refresh decision happens inside the stream loop (rather than as a
-  /// pre-check), so an offering that is inserted *after* subscription still
-  /// gets the blocking first-load behavior on its first appearance.
+  /// + classes + available syllabi), composed from the database — no network.
+  /// Syllabus content is fetched separately via [watchSyllabus]. Emits `null`
+  /// when the offering is missing; re-emits when a syllabus refresh writes the
+  /// offering's header fields.
   Stream<CourseOfferingDetail?> watchCourseOffering(int id) async* {
     final query = _database.select(_database.courseOfferingOverviews)
       ..where((o) => o.id.equals(id));
 
-    var refreshTriggered = false;
     await for (final overview in query.watchSingleOrNull()) {
       if (overview == null) {
         yield null;
         continue;
       }
 
-      if (!refreshTriggered) {
-        refreshTriggered = true;
-        final raw = await (_database.select(
-          _database.courseOfferings,
-        )..where((o) => o.id.equals(id))).getSingleOrNull();
-        if (raw?.fetchedAt == null) {
-          try {
-            await refreshCourseOffering(id);
-            // Wait for the resulting DB write to re-emit a populated row.
-            continue;
-          } catch (_) {
-            // Absorb: fall through and emit the cached row below.
-          }
-        } else {
-          unawaited(refreshCourseOffering(id).catchError((_) {}));
-        }
-      }
-
-      final (schedule, teachers, classes) = await (
+      final (schedule, teachers, classes, syllabi) = await (
         _readOfferingSchedule(id),
         _readOfferingTeachers(id),
         _readOfferingClasses(id),
+        _readOfferingSyllabi(id),
       ).wait;
       yield (
         overview: overview,
         schedule: schedule,
         teachers: teachers,
         classes: classes,
+        syllabi: syllabi,
       );
     }
   }
 
-  /// Fetches a course offering's syllabus from the network and writes it to
-  /// the [CourseOfferings] row.
+  /// Watches a single syllabus, always fetching fresh content once per
+  /// subscription rather than caching.
   ///
-  /// The [watchCourseOffering] stream automatically emits the updated value.
-  /// Network errors propagate to the caller. No-ops when the offering is
-  /// missing or has no `syllabusId` / `number`.
-  Future<void> refreshCourseOffering(int id) async {
-    final raw = await (_database.select(
+  /// Waits on the fetch while the row is still a stub (`fetchedAt == null`) so
+  /// the screen doesn't flash empty content; an already-populated row emits
+  /// first and refreshes in the background. The stream re-emits automatically
+  /// when the DB is updated. Emits `null` when the syllabus is missing.
+  Stream<Syllabus?> watchSyllabus(int id) async* {
+    final query = _database.select(_database.syllabuses)
+      ..where((s) => s.id.equals(id));
+
+    // Fetch once per subscription. The guard stops the refresh's own write
+    // (which stamps `fetchedAt`) from re-triggering the fetch on the re-emit.
+    var refreshed = false;
+    await for (final syllabus in query.watchSingleOrNull()) {
+      if (syllabus == null) {
+        yield null;
+        continue;
+      }
+
+      final refresh = !refreshed;
+      refreshed = true;
+
+      // Stub: fetch before emitting so we don't flash empty content.
+      if (refresh && syllabus.fetchedAt == null) {
+        try {
+          await refreshSyllabus(id);
+        } catch (_) {
+          // Absorb: yield the stub below so UI exits loading state
+        }
+      }
+
+      yield syllabus;
+
+      // Populated: refresh in the background; the stream re-emits when written.
+      if (refresh && syllabus.fetchedAt != null) {
+        try {
+          await refreshSyllabus(id);
+        } catch (_) {
+          // Absorb: stale data is shown via stream
+        }
+      }
+    }
+  }
+
+  /// Fetches a syllabus's content and writes it back: content to the
+  /// [Syllabuses] row, instructor email to [TeacherSemesters], and the shared
+  /// header fields (course type, enrolled, withdrawn) to [CourseOfferings].
+  ///
+  /// No-ops when the syllabus/offering is missing or has no `number`;
+  /// network errors propagate to the caller.
+  Future<void> refreshSyllabus(int id) async {
+    final syllabusRow = await (_database.select(
+      _database.syllabuses,
+    )..where((s) => s.id.equals(id))).getSingleOrNull();
+    if (syllabusRow == null) return;
+
+    final offering = await (_database.select(
       _database.courseOfferings,
-    )..where((o) => o.id.equals(id))).getSingleOrNull();
-    if (raw == null) return;
-    if (raw.syllabusId == null || raw.number == null) return;
+    )..where((o) => o.id.equals(syllabusRow.courseOffering))).getSingleOrNull();
+    if (offering == null || offering.number == null) return;
+
+    final teacher = await (_database.select(
+      _database.teachers,
+    )..where((t) => t.id.equals(syllabusRow.teacher))).getSingle();
 
     final syllabus = await _authRepository.withAuth(
       () => _courseService.getSyllabus(
-        courseNumber: raw.number!,
-        syllabusId: raw.syllabusId!,
+        courseNumber: offering.number!,
+        syllabusId: teacher.code,
       ),
       sso: [.courseService],
     );
 
-    await (_database.update(
-      _database.courseOfferings,
-    )..where((o) => o.id.equals(id))).write(
-      CourseOfferingsCompanion(
-        courseType: Value(syllabus.type),
-        enrolled: Value(syllabus.enrolled),
-        withdrawn: Value(syllabus.withdrawn),
-        syllabusUpdatedAt: Value(syllabus.lastUpdated),
-        objective: Value(syllabus.objective),
-        weeklyPlan: Value(syllabus.weeklyPlan),
-        evaluation: Value(syllabus.evaluation),
-        textbooks: Value(syllabus.materials),
-        syllabusRemarks: Value(syllabus.remarks),
-        fetchedAt: Value(DateTime.now()),
-      ),
-    );
+    await _database.transaction(() async {
+      await (_database.update(
+        _database.syllabuses,
+      )..where((s) => s.id.equals(id))).write(
+        SyllabusesCompanion(
+          updatedAt: Value(syllabus.lastUpdated),
+          objective: Value(syllabus.objective),
+          weeklyPlan: Value(syllabus.weeklyPlan),
+          evaluation: Value(syllabus.evaluation),
+          textbooks: Value(syllabus.materials),
+          remarks: Value(syllabus.remarks),
+          fetchedAt: Value(DateTime.now()),
+        ),
+      );
+
+      await (_database.update(
+        _database.courseOfferings,
+      )..where((o) => o.id.equals(offering.id))).write(
+        CourseOfferingsCompanion(
+          courseType: Value(syllabus.type),
+          enrolled: Value(syllabus.enrolled),
+          withdrawn: Value(syllabus.withdrawn),
+          fetchedAt: Value(DateTime.now()),
+        ),
+      );
+
+      await (_database.update(_database.teacherSemesters)..where(
+            (ts) =>
+                ts.teacher.equals(teacher.id) &
+                ts.semester.equals(offering.semester),
+          ))
+          .write(TeacherSemestersCompanion(email: Value(syllabus.email)));
+    });
   }
 
   Future<
@@ -825,6 +927,31 @@ class CourseRepository {
           code: row.readTable(_database.classes).code,
           nameZh: row.readTable(_database.classes).nameZh,
           nameEn: row.readTable(_database.classes).nameEn,
+        ),
+    ];
+  }
+
+  Future<List<OfferingSyllabus>> _readOfferingSyllabi(int id) async {
+    final rows =
+        await (_database.select(_database.syllabuses).join([
+                innerJoin(
+                  _database.teachers,
+                  _database.teachers.id.equalsExp(
+                    _database.syllabuses.teacher,
+                  ),
+                ),
+              ])
+              ..where(_database.syllabuses.courseOffering.equals(id))
+              ..orderBy([OrderingTerm.asc(_database.syllabuses.id)]))
+            .get();
+    return [
+      for (final row in rows)
+        (
+          id: row.readTable(_database.syllabuses).id,
+          teacherCode: row.readTable(_database.teachers).code,
+          teacherNameZh: row.readTable(_database.teachers).nameZh,
+          teacherNameEn: row.readTable(_database.teachers).nameEn,
+          fetchedAt: row.readTable(_database.syllabuses).fetchedAt,
         ),
     ];
   }

--- a/lib/repositories/course_repository.dart
+++ b/lib/repositories/course_repository.dart
@@ -758,9 +758,15 @@ class CourseRepository {
       if (refresh && syllabus.fetchedAt == null) {
         try {
           await refreshSyllabus(id);
+          final refreshedRow = await (_database.select(
+            _database.syllabuses,
+          )..where((s) => s.id.equals(id))).getSingleOrNull();
+          yield refreshedRow ?? syllabus;
         } catch (_) {
-          // Absorb: yield the stub below so UI exits loading state
+          // Absorb: yield the stub so the UI exits its loading state
+          yield syllabus;
         }
+        continue;
       }
 
       yield syllabus;

--- a/lib/repositories/course_repository.dart
+++ b/lib/repositories/course_repository.dart
@@ -664,13 +664,13 @@ class CourseRepository {
   }
 
   /// Watches the syllabus authored by [teacherId] for offering [offeringId],
-  /// always fetching fresh content once per subscription rather than caching.
+  /// refreshing it once per subscription (no staleness gate).
   ///
-  /// Emits cached content immediately, then refreshes in the background; with
-  /// no cached row it blocks on the first fetch instead, so the UI shows
-  /// content (or a definitive "no syllabus") rather than flashing empty. The
-  /// stream re-emits when the DB is updated. Emits `null` when the teacher
-  /// hasn't submitted a syllabus (尚未登錄) or is unknown.
+  /// Emits the cached row immediately when present, then refreshes in the
+  /// background; with no cached row it blocks on the first fetch instead, so
+  /// the UI shows content (or a definitive "no syllabus") rather than flashing
+  /// empty. The stream re-emits when the DB is updated. Emits `null` when the
+  /// teacher hasn't submitted a syllabus (尚未登錄) or is unknown.
   Stream<Syllabus?> watchSyllabus({
     required int offeringId,
     required String teacherId,
@@ -697,6 +697,10 @@ class CourseRepository {
         refreshed = true;
         try {
           await refreshSyllabus(offeringId: offeringId, teacherId: teacherId);
+          // Emit the freshly fetched row (or null on 尚未登錄) rather than the
+          // stale null snapshot, before the stream re-emits.
+          yield await query.getSingleOrNull();
+          continue;
         } catch (_) {
           // Absorb: yield null below so the UI exits its loading state
         }

--- a/lib/screens/main/course_table/course_table_providers.dart
+++ b/lib/screens/main/course_table/course_table_providers.dart
@@ -28,14 +28,26 @@ final courseTableProvider = StreamProvider.autoDispose
 
 /// Provides the detailed data for a single course offering.
 ///
-/// On a previously-fetched offering, emits cached DB data immediately and
-/// re-emits when the background syllabus refresh lands. On an offering with
-/// no syllabus cached yet, awaits the first refresh before emitting (to
-/// avoid rendering null syllabus fields). Errors during refresh are absorbed
-/// — the stream stays on cached data.
+/// Reads composed offering detail (overview + schedule + teachers + classes +
+/// available syllabi) directly from the database; [refreshCourseTable] keeps
+/// it current. No network fetch — syllabus content is fetched lazily and
+/// separately via [syllabusProvider]. Emits `null` until the offering exists.
 final courseOfferingProvider = StreamProvider.autoDispose
     .family<CourseOfferingDetail?, int>((ref, offeringId) {
       return ref
           .watch(courseRepositoryProvider)
           .watchCourseOffering(offeringId);
     });
+
+/// Provides a single syllabus's content, fetched lazily on first watch.
+///
+/// Keyed by the syllabus row id (from [CourseOfferingDetail.syllabi]). Emits
+/// the stub row immediately when content is cached, blocks on the first fetch
+/// otherwise, and re-emits when a background refresh lands. The detail UI
+/// shows the first syllabus for now.
+final syllabusProvider = StreamProvider.autoDispose.family<Syllabus?, int>((
+  ref,
+  syllabusId,
+) {
+  return ref.watch(courseRepositoryProvider).watchSyllabus(syllabusId);
+});

--- a/lib/screens/main/course_table/course_table_providers.dart
+++ b/lib/screens/main/course_table/course_table_providers.dart
@@ -28,10 +28,10 @@ final courseTableProvider = StreamProvider.autoDispose
 
 /// Provides the detailed data for a single course offering.
 ///
-/// Reads composed offering detail (overview + schedule + teachers + classes +
-/// available syllabi) directly from the database; [refreshCourseTable] keeps
-/// it current. No network fetch — syllabus content is fetched lazily and
-/// separately via [syllabusProvider]. Emits `null` until the offering exists.
+/// Reads composed offering detail (overview + schedule + teachers + classes)
+/// directly from the database; [refreshCourseTable] keeps it current. No
+/// network fetch — a teacher's syllabus is fetched lazily and separately via
+/// [syllabusProvider]. Emits `null` until the offering exists.
 final courseOfferingProvider = StreamProvider.autoDispose
     .family<CourseOfferingDetail?, int>((ref, offeringId) {
       return ref
@@ -39,15 +39,20 @@ final courseOfferingProvider = StreamProvider.autoDispose
           .watchCourseOffering(offeringId);
     });
 
-/// Provides a single syllabus's content, fetched lazily on first watch.
+/// Provides a teacher's syllabus for an offering, fetched lazily on first
+/// watch.
 ///
-/// Keyed by the syllabus row id (from [CourseOfferingDetail.syllabi]). Emits
-/// the stub row immediately when content is cached, blocks on the first fetch
-/// otherwise, and re-emits when a background refresh lands. The detail UI
-/// shows the first syllabus for now.
-final syllabusProvider = StreamProvider.autoDispose.family<Syllabus?, int>((
-  ref,
-  syllabusId,
-) {
-  return ref.watch(courseRepositoryProvider).watchSyllabus(syllabusId);
-});
+/// Keyed by the offering id and the authoring teacher's code (from
+/// [CourseOfferingDetail.teachers]). Emits cached content immediately when
+/// present, blocks on the first fetch otherwise, and emits `null` when the
+/// teacher hasn't submitted a syllabus. The detail UI shows the first
+/// teacher's syllabus for now.
+final syllabusProvider = StreamProvider.autoDispose
+    .family<Syllabus?, ({int offeringId, String teacherId})>((ref, key) {
+      return ref
+          .watch(courseRepositoryProvider)
+          .watchSyllabus(
+            offeringId: key.offeringId,
+            teacherId: key.teacherId,
+          );
+    });

--- a/lib/services/course/course_service.dart
+++ b/lib/services/course/course_service.dart
@@ -49,8 +49,13 @@ typedef ScheduleDto = ({
   /// Language of instruction.
   String? language,
 
-  /// Syllabus identifier for fetching course syllabus.
-  String? syllabusId,
+  /// Syllabus identifiers available for this offering, one per teacher who
+  /// submitted a syllabus (the 查詢 links in the course list).
+  ///
+  /// Each identifier is the authoring teacher's code, so it matches one of the
+  /// `teachers` ids. May be fewer than `teachers` — not every teacher submits
+  /// a syllabus.
+  List<String>? syllabusIds,
 
   /// Additional remarks or notes about the course.
   String? remarks,
@@ -248,8 +253,8 @@ abstract interface class CourseService {
   /// grading policy, and weekly plan.
   ///
   /// The [courseNumber] should be a course offering number (e.g., "346774"),
-  /// and [syllabusId] should be obtained from the `syllabusId` field of a
-  /// [ScheduleDto].
+  /// and [syllabusId] should be one of the `syllabusIds` of a [ScheduleDto]
+  /// (equivalently, an authoring teacher's code).
   ///
   /// Throws an [Exception] if the syllabus tables are not found.
   Future<SyllabusDto> getSyllabus({

--- a/lib/services/course/course_service.dart
+++ b/lib/services/course/course_service.dart
@@ -49,14 +49,6 @@ typedef ScheduleDto = ({
   /// Language of instruction.
   String? language,
 
-  /// Syllabus identifiers available for this offering, one per teacher who
-  /// submitted a syllabus (the 查詢 links in the course list).
-  ///
-  /// Each identifier is the authoring teacher's code, so it matches one of the
-  /// `teachers` ids. May be fewer than `teachers` — not every teacher submits
-  /// a syllabus.
-  List<String>? syllabusIds,
-
   /// Additional remarks or notes about the course.
   String? remarks,
 });
@@ -250,14 +242,15 @@ abstract interface class CourseService {
   /// Fetches the detailed syllabus for a course offering.
   ///
   /// Returns syllabus information including course objectives, textbooks,
-  /// grading policy, and weekly plan.
+  /// grading policy, and weekly plan, or `null` when the authoring teacher
+  /// hasn't submitted one yet (the page shows 尚未登錄).
   ///
   /// The [courseNumber] should be a course offering number (e.g., "346774"),
-  /// and [syllabusId] should be one of the `syllabusIds` of a [ScheduleDto]
-  /// (equivalently, an authoring teacher's code).
+  /// and [syllabusId] is the authoring teacher's code (one of the `teachers`
+  /// ids of a [ScheduleDto]).
   ///
   /// Throws an [Exception] if the syllabus tables are not found.
-  Future<SyllabusDto> getSyllabus({
+  Future<SyllabusDto?> getSyllabus({
     required String courseNumber,
     required String syllabusId,
   });

--- a/lib/services/course/mock_course_service.dart
+++ b/lib/services/course/mock_course_service.dart
@@ -45,7 +45,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: null,
           remarks: null,
         ),
         (
@@ -80,7 +79,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['12442'],
           remarks: null,
         ),
         (
@@ -115,7 +113,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['11437'],
           remarks: '計中電腦教室',
         ),
         (
@@ -145,17 +142,6 @@ class MockCourseService implements CourseService {
           schedule: null,
           status: null,
           language: null,
-          // Not every teacher submits a syllabus: 8 of the 10 here.
-          syllabusIds: [
-            '10605',
-            '11636',
-            '10823',
-            '10459',
-            '11246',
-            '11678',
-            '11130',
-            '12231',
-          ],
           remarks: null,
         ),
         (
@@ -177,7 +163,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['11232'],
           remarks: null,
         ),
         (
@@ -215,7 +200,6 @@ class MockCourseService implements CourseService {
           ],
           status: '撤選',
           language: '中英雙語',
-          syllabusIds: ['12376'],
           remarks: '電子大三合開',
         ),
         (
@@ -253,7 +237,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['12605'],
           remarks: '電子大三合開',
         ),
         (
@@ -288,7 +271,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: '英語',
-          syllabusIds: ['11678'],
           remarks: '半導體二和電子二甲合開',
         ),
         (
@@ -319,7 +301,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['24588'],
           remarks: null,
         ),
         (
@@ -351,7 +332,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['24627'],
           remarks: '創新與創業向度',
         ),
         (
@@ -379,7 +359,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: null,
           remarks: '北醫/自然與科學/教師邱子恒/3001教室',
         ),
       ],
@@ -399,7 +378,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: null,
           remarks: null,
         ),
         (
@@ -437,7 +415,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['12376'],
           remarks: '電子大三合開',
         ),
         (
@@ -459,7 +436,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['10496'],
           remarks: null,
         ),
         (
@@ -488,17 +464,6 @@ class MockCourseService implements CourseService {
           schedule: null,
           status: null,
           language: null,
-          syllabusIds: [
-            '10605',
-            '10823',
-            '10459',
-            '11467',
-            '12376',
-            '11130',
-            '12231',
-            '12245',
-            '12232',
-          ],
           remarks: null,
         ),
         (
@@ -536,7 +501,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['10459'],
           remarks: '電子大三合開',
         ),
         (
@@ -571,7 +535,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['12384'],
           remarks: null,
         ),
         (
@@ -606,7 +569,6 @@ class MockCourseService implements CourseService {
           ],
           status: '撤選',
           language: null,
-          syllabusIds: ['11130'],
           remarks: null,
         ),
         (
@@ -641,7 +603,6 @@ class MockCourseService implements CourseService {
           ],
           status: '撤選',
           language: '英語',
-          syllabusIds: ['11635'],
           remarks: null,
         ),
         (
@@ -676,7 +637,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['12380'],
           remarks: '高級B',
         ),
         (
@@ -714,7 +674,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['12245'],
           remarks: '電子大三合開',
         ),
         (
@@ -746,7 +705,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['24602'],
           remarks: '創新與創業向度',
         ),
         (
@@ -778,7 +736,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['24530'],
           remarks: '社會與法治向度',
         ),
       ],
@@ -798,7 +755,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: null,
           remarks: null,
         ),
         (
@@ -833,7 +789,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['12442'],
           remarks: null,
         ),
         (
@@ -868,7 +823,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['11437'],
           remarks: '計中電腦教室',
         ),
         (
@@ -897,17 +851,6 @@ class MockCourseService implements CourseService {
           schedule: null,
           status: null,
           language: null,
-          syllabusIds: [
-            '10605',
-            '10459',
-            '11246',
-            '10618',
-            '12376',
-            '11130',
-            '12231',
-            '11682',
-            '12245',
-          ],
           remarks: null,
         ),
         (
@@ -929,7 +872,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['10496'],
           remarks: null,
         ),
         (
@@ -967,7 +909,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: '中英雙語',
-          syllabusIds: ['12376'],
           remarks: '電子大三合開',
         ),
         (
@@ -1002,7 +943,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['12239'],
           remarks: '限技優專班同學。',
         ),
         (
@@ -1048,7 +988,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['23969'],
           remarks: '◎限技優學生修習',
         ),
         (
@@ -1080,7 +1019,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['24363'],
           remarks: '人文與藝術向度',
         ),
         (
@@ -1112,7 +1050,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['22465'],
           remarks: '人文與藝術向度',
         ),
       ],
@@ -1132,7 +1069,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: null,
           remarks: null,
         ),
         (
@@ -1167,7 +1103,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: '英語',
-          syllabusIds: ['11635'],
           remarks: '與電資二合開',
         ),
         (
@@ -1202,7 +1137,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['11391'],
           remarks: null,
         ),
         (
@@ -1237,7 +1171,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['11246'],
           remarks: null,
         ),
         (
@@ -1272,7 +1205,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['11010'],
           remarks: null,
         ),
         (
@@ -1307,7 +1239,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['10605'],
           remarks: null,
         ),
         (
@@ -1345,7 +1276,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['11636'],
           remarks: '電子二甲乙合開',
         ),
         (
@@ -1383,7 +1313,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: '中英雙語',
-          syllabusIds: ['12376'],
           remarks: '電子二甲乙合開',
         ),
         (
@@ -1420,7 +1349,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['11967'],
           remarks: '高級',
         ),
         (
@@ -1452,7 +1380,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['23915'],
           remarks: '106-108：創新與創業核心。109(含)後：創新與創業',
         ),
         (
@@ -1484,7 +1411,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['24489'],
           remarks: '106-108：民主與法治選修。109(含)後：社會與法治',
         ),
       ],
@@ -1504,7 +1430,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: null,
           remarks: null,
         ),
         (
@@ -1539,7 +1464,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['24112'],
           remarks: '初級',
         ),
         (
@@ -1564,7 +1488,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['24294'],
           remarks: '*第一週必到，課程地點公告至「北科服務學習網」。',
         ),
         (
@@ -1595,7 +1518,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['12491'],
           remarks: '9/22職能測驗於共科B1',
         ),
         (
@@ -1621,7 +1543,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['12079'],
           remarks: null,
         ),
         (
@@ -1652,7 +1573,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['11145'],
           remarks: null,
         ),
         (
@@ -1683,7 +1603,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['11067'],
           remarks: null,
         ),
         (
@@ -1718,7 +1637,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['11067'],
           remarks: null,
         ),
         (
@@ -1753,7 +1671,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: '英語',
-          syllabusIds: ['11391'],
           remarks: 'EMI英文',
         ),
         (
@@ -1788,7 +1705,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['11437'],
           remarks: '計中電腦教室',
         ),
         (
@@ -1823,7 +1739,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['12376'],
           remarks: null,
         ),
         (
@@ -1847,7 +1762,6 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusIds: ['11172'],
           remarks: '*肢體美學A',
         ),
       ],
@@ -1921,59 +1835,62 @@ class MockCourseService implements CourseService {
   }
 
   @override
-  Future<SyllabusDto> getSyllabus({
+  Future<SyllabusDto?> getSyllabus({
     required String courseNumber,
     required String syllabusId,
   }) async {
-    return syllabusResult ??
-        (
-          type: CourseType.universityCommonRequired,
-          enrolled: 55,
-          withdrawn: 2,
-          email: 'richwang@ntut.edu.tw',
-          lastUpdated: DateTime(2025, 10, 20, 10, 15, 5),
-          objective:
-              '在本課程中，同學將學習到計算機程式語言Python基礎與應用，'
-              '建立Python程式設計的基本概念。透過做中學、學中做，'
-              '建構程式設計的基礎，以及基本程式運算邏輯，'
-              '以培養運算思維、動手做的能力。'
-              '期末以分組方式完成一個與學生專業領域相關應用的專題，'
-              '學習如何運用程式解決與自身相關領域運用上的問題。',
-          weeklyPlan:
-              '第01週\t教育大數據概述及Python開發環境建置\n'
-              '第02週\t數學函式、字元與字串\n'
-              '第03週\t流程控制\n'
-              '第04週\t迴圈及其應用\n'
-              '第05週\t中秋節(放假)\n'
-              '第06週\t串列list, 數組tuple介紹與字串操作\n'
-              '第07週\t函式與模組的應用介紹-1\n'
-              '第08週\t函式與模組的應用介紹-2\n'
-              '第09週\t期中考試\n'
-              '第10週\t字典dict, 集合set介紹\n'
-              '第11週\t共授專家演講\n'
-              '第12週\t正規表示式(Regular Expression)介紹\n'
-              '第13週\t類別與物件\n'
-              '第14週\t檔案與異常處理\n'
-              '第15週\t政府公開相關資料(教育)的擷取介紹\n'
-              '第16週\t政府公開資料(教育)的處理與分析\n'
-              '第17週\tAI簡介與應用介紹\n'
-              '第18週\t期末考試',
-          evaluation:
-              '(*) 資工系同學因系上已有相關課程，所以學分將不認列，請勿選修。\n'
-              '課程參與(20%)\n作業與隨堂考試(30%)\n期中考試(25%)\n期末考試(25%)',
-          materials: '稍後公佈',
-          remarks:
-              '因應疫情發展，本學期教學及授課方式請依照學校網頁所公布之訊息為準：\n'
-              '(https://oaa.ntut.edu.tw/p/404-1008-98622.php?Lang=zh-tw)\n'
-              '1. 同學如有加退選簽核或課程問題，請寫信至 richwang@ntut.edu.tw，'
-              '信件標題 [課程名稱]_班級(或隨班附讀)_名字。\n'
-              '2. 本課程其他資料，將透過北科i學園plus公布。\n'
-              '3. 本課程採實體授課方式，但為因應疫情或其它狀況，'
-              '可能會調整授課內容、授課方式、評分項目與配分比例。\n'
-              '如果無法實體上課，預定使用Teams於原定上課時段進行遠距上課，'
-              '相關細節將再另行公告。\n'
-              '相關防疫或課程上課形式公告，請參考學校網頁: '
-              'https://oaa.ntut.edu.tw/p/404-1008-98622.php?Lang=zh-tw',
-        );
+    if (syllabusResult != null) return syllabusResult;
+    // Some teachers on a team-taught offering haven't submitted a syllabus yet
+    // (the real page shows 尚未登錄); return null to exercise that path.
+    if (const {'11894', '11991'}.contains(syllabusId)) return null;
+    return (
+      type: CourseType.universityCommonRequired,
+      enrolled: 55,
+      withdrawn: 2,
+      email: 'richwang@ntut.edu.tw',
+      lastUpdated: DateTime(2025, 10, 20, 10, 15, 5),
+      objective:
+          '在本課程中，同學將學習到計算機程式語言Python基礎與應用，'
+          '建立Python程式設計的基本概念。透過做中學、學中做，'
+          '建構程式設計的基礎，以及基本程式運算邏輯，'
+          '以培養運算思維、動手做的能力。'
+          '期末以分組方式完成一個與學生專業領域相關應用的專題，'
+          '學習如何運用程式解決與自身相關領域運用上的問題。',
+      weeklyPlan:
+          '第01週\t教育大數據概述及Python開發環境建置\n'
+          '第02週\t數學函式、字元與字串\n'
+          '第03週\t流程控制\n'
+          '第04週\t迴圈及其應用\n'
+          '第05週\t中秋節(放假)\n'
+          '第06週\t串列list, 數組tuple介紹與字串操作\n'
+          '第07週\t函式與模組的應用介紹-1\n'
+          '第08週\t函式與模組的應用介紹-2\n'
+          '第09週\t期中考試\n'
+          '第10週\t字典dict, 集合set介紹\n'
+          '第11週\t共授專家演講\n'
+          '第12週\t正規表示式(Regular Expression)介紹\n'
+          '第13週\t類別與物件\n'
+          '第14週\t檔案與異常處理\n'
+          '第15週\t政府公開相關資料(教育)的擷取介紹\n'
+          '第16週\t政府公開資料(教育)的處理與分析\n'
+          '第17週\tAI簡介與應用介紹\n'
+          '第18週\t期末考試',
+      evaluation:
+          '(*) 資工系同學因系上已有相關課程，所以學分將不認列，請勿選修。\n'
+          '課程參與(20%)\n作業與隨堂考試(30%)\n期中考試(25%)\n期末考試(25%)',
+      materials: '稍後公佈',
+      remarks:
+          '因應疫情發展，本學期教學及授課方式請依照學校網頁所公布之訊息為準：\n'
+          '(https://oaa.ntut.edu.tw/p/404-1008-98622.php?Lang=zh-tw)\n'
+          '1. 同學如有加退選簽核或課程問題，請寫信至 richwang@ntut.edu.tw，'
+          '信件標題 [課程名稱]_班級(或隨班附讀)_名字。\n'
+          '2. 本課程其他資料，將透過北科i學園plus公布。\n'
+          '3. 本課程採實體授課方式，但為因應疫情或其它狀況，'
+          '可能會調整授課內容、授課方式、評分項目與配分比例。\n'
+          '如果無法實體上課，預定使用Teams於原定上課時段進行遠距上課，'
+          '相關細節將再另行公告。\n'
+          '相關防疫或課程上課形式公告，請參考學校網頁: '
+          'https://oaa.ntut.edu.tw/p/404-1008-98622.php?Lang=zh-tw',
+    );
   }
 }

--- a/lib/services/course/mock_course_service.dart
+++ b/lib/services/course/mock_course_service.dart
@@ -45,7 +45,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: null,
+          syllabusIds: null,
           remarks: null,
         ),
         (
@@ -80,7 +80,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '12442',
+          syllabusIds: ['12442'],
           remarks: null,
         ),
         (
@@ -115,7 +115,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '11437',
+          syllabusIds: ['11437'],
           remarks: '計中電腦教室',
         ),
         (
@@ -145,7 +145,17 @@ class MockCourseService implements CourseService {
           schedule: null,
           status: null,
           language: null,
-          syllabusId: '10605',
+          // Not every teacher submits a syllabus: 8 of the 10 here.
+          syllabusIds: [
+            '10605',
+            '11636',
+            '10823',
+            '10459',
+            '11246',
+            '11678',
+            '11130',
+            '12231',
+          ],
           remarks: null,
         ),
         (
@@ -167,7 +177,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '11232',
+          syllabusIds: ['11232'],
           remarks: null,
         ),
         (
@@ -205,7 +215,7 @@ class MockCourseService implements CourseService {
           ],
           status: '撤選',
           language: '中英雙語',
-          syllabusId: '12376',
+          syllabusIds: ['12376'],
           remarks: '電子大三合開',
         ),
         (
@@ -243,7 +253,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '12605',
+          syllabusIds: ['12605'],
           remarks: '電子大三合開',
         ),
         (
@@ -278,7 +288,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: '英語',
-          syllabusId: '11678',
+          syllabusIds: ['11678'],
           remarks: '半導體二和電子二甲合開',
         ),
         (
@@ -309,7 +319,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '24588',
+          syllabusIds: ['24588'],
           remarks: null,
         ),
         (
@@ -341,7 +351,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '24627',
+          syllabusIds: ['24627'],
           remarks: '創新與創業向度',
         ),
         (
@@ -369,7 +379,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: null,
+          syllabusIds: null,
           remarks: '北醫/自然與科學/教師邱子恒/3001教室',
         ),
       ],
@@ -389,7 +399,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: null,
+          syllabusIds: null,
           remarks: null,
         ),
         (
@@ -427,7 +437,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '12376',
+          syllabusIds: ['12376'],
           remarks: '電子大三合開',
         ),
         (
@@ -449,7 +459,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '10496',
+          syllabusIds: ['10496'],
           remarks: null,
         ),
         (
@@ -478,7 +488,17 @@ class MockCourseService implements CourseService {
           schedule: null,
           status: null,
           language: null,
-          syllabusId: '10605',
+          syllabusIds: [
+            '10605',
+            '10823',
+            '10459',
+            '11467',
+            '12376',
+            '11130',
+            '12231',
+            '12245',
+            '12232',
+          ],
           remarks: null,
         ),
         (
@@ -516,7 +536,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '10459',
+          syllabusIds: ['10459'],
           remarks: '電子大三合開',
         ),
         (
@@ -551,7 +571,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '12384',
+          syllabusIds: ['12384'],
           remarks: null,
         ),
         (
@@ -586,7 +606,7 @@ class MockCourseService implements CourseService {
           ],
           status: '撤選',
           language: null,
-          syllabusId: '11130',
+          syllabusIds: ['11130'],
           remarks: null,
         ),
         (
@@ -621,7 +641,7 @@ class MockCourseService implements CourseService {
           ],
           status: '撤選',
           language: '英語',
-          syllabusId: '11635',
+          syllabusIds: ['11635'],
           remarks: null,
         ),
         (
@@ -656,7 +676,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '12380',
+          syllabusIds: ['12380'],
           remarks: '高級B',
         ),
         (
@@ -694,7 +714,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '12245',
+          syllabusIds: ['12245'],
           remarks: '電子大三合開',
         ),
         (
@@ -726,7 +746,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '24602',
+          syllabusIds: ['24602'],
           remarks: '創新與創業向度',
         ),
         (
@@ -758,7 +778,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '24530',
+          syllabusIds: ['24530'],
           remarks: '社會與法治向度',
         ),
       ],
@@ -778,7 +798,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: null,
+          syllabusIds: null,
           remarks: null,
         ),
         (
@@ -813,7 +833,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '12442',
+          syllabusIds: ['12442'],
           remarks: null,
         ),
         (
@@ -848,7 +868,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '11437',
+          syllabusIds: ['11437'],
           remarks: '計中電腦教室',
         ),
         (
@@ -877,7 +897,17 @@ class MockCourseService implements CourseService {
           schedule: null,
           status: null,
           language: null,
-          syllabusId: '10605',
+          syllabusIds: [
+            '10605',
+            '10459',
+            '11246',
+            '10618',
+            '12376',
+            '11130',
+            '12231',
+            '11682',
+            '12245',
+          ],
           remarks: null,
         ),
         (
@@ -899,7 +929,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '10496',
+          syllabusIds: ['10496'],
           remarks: null,
         ),
         (
@@ -937,7 +967,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: '中英雙語',
-          syllabusId: '12376',
+          syllabusIds: ['12376'],
           remarks: '電子大三合開',
         ),
         (
@@ -972,7 +1002,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '12239',
+          syllabusIds: ['12239'],
           remarks: '限技優專班同學。',
         ),
         (
@@ -1018,7 +1048,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '23969',
+          syllabusIds: ['23969'],
           remarks: '◎限技優學生修習',
         ),
         (
@@ -1050,7 +1080,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '24363',
+          syllabusIds: ['24363'],
           remarks: '人文與藝術向度',
         ),
         (
@@ -1082,7 +1112,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '22465',
+          syllabusIds: ['22465'],
           remarks: '人文與藝術向度',
         ),
       ],
@@ -1102,7 +1132,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: null,
+          syllabusIds: null,
           remarks: null,
         ),
         (
@@ -1137,7 +1167,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: '英語',
-          syllabusId: '11635',
+          syllabusIds: ['11635'],
           remarks: '與電資二合開',
         ),
         (
@@ -1172,7 +1202,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '11391',
+          syllabusIds: ['11391'],
           remarks: null,
         ),
         (
@@ -1207,7 +1237,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '11246',
+          syllabusIds: ['11246'],
           remarks: null,
         ),
         (
@@ -1242,7 +1272,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '11010',
+          syllabusIds: ['11010'],
           remarks: null,
         ),
         (
@@ -1277,7 +1307,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '10605',
+          syllabusIds: ['10605'],
           remarks: null,
         ),
         (
@@ -1315,7 +1345,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '11636',
+          syllabusIds: ['11636'],
           remarks: '電子二甲乙合開',
         ),
         (
@@ -1353,7 +1383,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: '中英雙語',
-          syllabusId: '12376',
+          syllabusIds: ['12376'],
           remarks: '電子二甲乙合開',
         ),
         (
@@ -1390,7 +1420,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '11967',
+          syllabusIds: ['11967'],
           remarks: '高級',
         ),
         (
@@ -1422,7 +1452,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '23915',
+          syllabusIds: ['23915'],
           remarks: '106-108：創新與創業核心。109(含)後：創新與創業',
         ),
         (
@@ -1454,7 +1484,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '24489',
+          syllabusIds: ['24489'],
           remarks: '106-108：民主與法治選修。109(含)後：社會與法治',
         ),
       ],
@@ -1474,7 +1504,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: null,
+          syllabusIds: null,
           remarks: null,
         ),
         (
@@ -1509,7 +1539,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '24112',
+          syllabusIds: ['24112'],
           remarks: '初級',
         ),
         (
@@ -1534,7 +1564,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '24294',
+          syllabusIds: ['24294'],
           remarks: '*第一週必到，課程地點公告至「北科服務學習網」。',
         ),
         (
@@ -1565,7 +1595,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '12491',
+          syllabusIds: ['12491'],
           remarks: '9/22職能測驗於共科B1',
         ),
         (
@@ -1591,7 +1621,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '12079',
+          syllabusIds: ['12079'],
           remarks: null,
         ),
         (
@@ -1622,7 +1652,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '11145',
+          syllabusIds: ['11145'],
           remarks: null,
         ),
         (
@@ -1653,7 +1683,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '11067',
+          syllabusIds: ['11067'],
           remarks: null,
         ),
         (
@@ -1688,7 +1718,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '11067',
+          syllabusIds: ['11067'],
           remarks: null,
         ),
         (
@@ -1723,7 +1753,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: '英語',
-          syllabusId: '11391',
+          syllabusIds: ['11391'],
           remarks: 'EMI英文',
         ),
         (
@@ -1758,7 +1788,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '11437',
+          syllabusIds: ['11437'],
           remarks: '計中電腦教室',
         ),
         (
@@ -1793,7 +1823,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '12376',
+          syllabusIds: ['12376'],
           remarks: null,
         ),
         (
@@ -1817,7 +1847,7 @@ class MockCourseService implements CourseService {
           ],
           status: null,
           language: null,
-          syllabusId: '11172',
+          syllabusIds: ['11172'],
           remarks: '*肢體美學A',
         ),
       ],

--- a/lib/services/course/ntut_course_service.dart
+++ b/lib/services/course/ntut_course_service.dart
@@ -135,7 +135,7 @@ class NtutCourseService implements CourseService {
         schedule: dto.schedule,
         status: dto.status,
         language: dto.language,
-        syllabusId: dto.syllabusId,
+        syllabusIds: dto.syllabusIds,
         remarks: dto.remarks,
       );
     }).toList();
@@ -259,7 +259,7 @@ class NtutCourseService implements CourseService {
 
       final status = _parseCellText(cells[16]);
       final language = _parseCellText(cells[17]);
-      final syllabusId = _parseCellRef(cells[18]).id;
+      final syllabusIds = _parseSyllabusIds(cells[18]);
       final remarks = _parseCellText(cells[19]);
 
       return (
@@ -282,7 +282,7 @@ class NtutCourseService implements CourseService {
         schedule: schedule,
         status: status,
         language: language,
-        syllabusId: syllabusId,
+        syllabusIds: syllabusIds,
         remarks: remarks,
       );
     }).toList();
@@ -600,6 +600,22 @@ class NtutCourseService implements CourseService {
     }
     final text = cell.text.trim();
     return text.isNotEmpty ? [text] : <String>[];
+  }
+
+  /// Parses the available syllabus identifiers from the 查詢 column.
+  ///
+  /// Each anchor links to a teacher's syllabus; its `code` query parameter is
+  /// the authoring teacher's id. Returns null when no syllabus is available.
+  List<String>? _parseSyllabusIds(Element cell) {
+    final ids = cell
+        .querySelectorAll('a')
+        .map((a) {
+          final href = a.attributes['href'];
+          return href != null ? Uri.parse(href).queryParameters['code'] : null;
+        })
+        .nonNulls
+        .toList();
+    return ids.isNotEmpty ? ids : null;
   }
 
   ReferenceDto _parseAnchorRef(Element anchor) {

--- a/lib/services/course/ntut_course_service.dart
+++ b/lib/services/course/ntut_course_service.dart
@@ -135,7 +135,6 @@ class NtutCourseService implements CourseService {
         schedule: dto.schedule,
         status: dto.status,
         language: dto.language,
-        syllabusIds: dto.syllabusIds,
         remarks: dto.remarks,
       );
     }).toList();
@@ -259,7 +258,6 @@ class NtutCourseService implements CourseService {
 
       final status = _parseCellText(cells[16]);
       final language = _parseCellText(cells[17]);
-      final syllabusIds = _parseSyllabusIds(cells[18]);
       final remarks = _parseCellText(cells[19]);
 
       return (
@@ -282,7 +280,6 @@ class NtutCourseService implements CourseService {
         schedule: schedule,
         status: status,
         language: language,
-        syllabusIds: syllabusIds,
         remarks: remarks,
       );
     }).toList();
@@ -512,7 +509,7 @@ class NtutCourseService implements CourseService {
   }
 
   @override
-  Future<SyllabusDto> getSyllabus({
+  Future<SyllabusDto?> getSyllabus({
     required String courseNumber,
     required String syllabusId,
   }) async {
@@ -522,6 +519,14 @@ class NtutCourseService implements CourseService {
     );
 
     final document = parse(response.data);
+
+    // When the teacher hasn't submitted a syllabus, the page shows a red
+    // "尚未登錄" marker in place of the 教學大綱與進度 content.
+    final notSubmitted = document
+        .querySelectorAll('font')
+        .any((f) => f.text.trim() == '尚未登錄');
+    if (notSubmitted) return null;
+
     final tables = document.querySelectorAll('table');
     if (tables.length < 2) {
       throw Exception('Syllabus tables not found.');
@@ -606,18 +611,6 @@ class NtutCourseService implements CourseService {
   ///
   /// Each anchor links to a teacher's syllabus; its `code` query parameter is
   /// the authoring teacher's id. Returns null when no syllabus is available.
-  List<String>? _parseSyllabusIds(Element cell) {
-    final ids = cell
-        .querySelectorAll('a')
-        .map((a) {
-          final href = a.attributes['href'];
-          return href != null ? Uri.parse(href).queryParameters['code'] : null;
-        })
-        .nonNulls
-        .toList();
-    return ids.isNotEmpty ? ids : null;
-  }
-
   ReferenceDto _parseAnchorRef(Element anchor) {
     final name = anchor.text.trim();
     final href = anchor.attributes['href'];

--- a/test/services/course_service_test.dart
+++ b/test/services/course_service_test.dart
@@ -368,34 +368,34 @@ void main() {
     });
 
     group('getSyllabus', () {
-      test('should parse syllabus fields correctly', () async {
+      // A syllabus's code is its author's teacher code, so any teacher may have
+      // one. Scans the course table for the first teacher who has submitted a
+      // syllabus (others return null — the page shows 尚未登錄).
+      Future<SyllabusDto> firstSyllabus() async {
         final semesters = await courseService.getCourseSemesterList();
         final courseTable = await courseService.getCourseTable(
           username: TestCredentials.username,
           semester: semesters.pickRandom(),
         );
+        for (final schedule in courseTable) {
+          final number = schedule.number;
+          if (number == null || number.isEmpty) continue;
+          for (final teacher in schedule.teachers ?? const []) {
+            final code = teacher.id;
+            if (code == null) continue;
+            await respectfulDelay();
+            final syllabus = await courseService.getSyllabus(
+              courseNumber: number,
+              syllabusId: code,
+            );
+            if (syllabus != null) return syllabus;
+          }
+        }
+        fail('No submitted syllabus found in the selected semester');
+      }
 
-        // Find a course with a syllabus ID
-        final coursesWithSyllabus = courseTable
-            .where(
-              (schedule) =>
-                  schedule.number != null &&
-                  schedule.number!.isNotEmpty &&
-                  (schedule.syllabusIds?.isNotEmpty ?? false),
-            )
-            .toList();
-
-        expect(
-          coursesWithSyllabus,
-          isNotEmpty,
-          reason: 'Should have at least one course with a syllabus',
-        );
-
-        final course = coursesWithSyllabus.pickRandom();
-        final syllabus = await courseService.getSyllabus(
-          courseNumber: course.number!,
-          syllabusId: course.syllabusIds!.pickRandom(),
-        );
+      test('should parse syllabus fields correctly', () async {
+        final syllabus = await firstSyllabus();
 
         // Verify course type is a valid enum value
         expect(
@@ -434,26 +434,7 @@ void main() {
       });
 
       test('should parse syllabus content fields', () async {
-        final semesters = await courseService.getCourseSemesterList();
-        final courseTable = await courseService.getCourseTable(
-          username: TestCredentials.username,
-          semester: semesters.pickRandom(),
-        );
-
-        final coursesWithSyllabus = courseTable
-            .where(
-              (schedule) =>
-                  schedule.number != null &&
-                  schedule.number!.isNotEmpty &&
-                  (schedule.syllabusIds?.isNotEmpty ?? false),
-            )
-            .toList();
-
-        final course = coursesWithSyllabus.pickRandom();
-        final syllabus = await courseService.getSyllabus(
-          courseNumber: course.number!,
-          syllabusId: course.syllabusIds!.pickRandom(),
-        );
+        final syllabus = await firstSyllabus();
 
         // At least some content fields should be populated
         final hasContent =
@@ -484,26 +465,7 @@ void main() {
       });
 
       test('should parse email when available', () async {
-        final semesters = await courseService.getCourseSemesterList();
-        final courseTable = await courseService.getCourseTable(
-          username: TestCredentials.username,
-          semester: semesters.pickRandom(),
-        );
-
-        final coursesWithSyllabus = courseTable
-            .where(
-              (schedule) =>
-                  schedule.number != null &&
-                  schedule.number!.isNotEmpty &&
-                  (schedule.syllabusIds?.isNotEmpty ?? false),
-            )
-            .toList();
-
-        final course = coursesWithSyllabus.pickRandom();
-        final syllabus = await courseService.getSyllabus(
-          courseNumber: course.number!,
-          syllabusId: course.syllabusIds!.pickRandom(),
-        );
+        final syllabus = await firstSyllabus();
 
         // Email should contain @ if present
         if (syllabus.email != null) {

--- a/test/services/course_service_test.dart
+++ b/test/services/course_service_test.dart
@@ -394,7 +394,7 @@ void main() {
         final course = coursesWithSyllabus.pickRandom();
         final syllabus = await courseService.getSyllabus(
           courseNumber: course.number!,
-          syllabusId: course.syllabusIds!.first,
+          syllabusId: course.syllabusIds!.pickRandom(),
         );
 
         // Verify course type is a valid enum value
@@ -452,7 +452,7 @@ void main() {
         final course = coursesWithSyllabus.pickRandom();
         final syllabus = await courseService.getSyllabus(
           courseNumber: course.number!,
-          syllabusId: course.syllabusIds!.first,
+          syllabusId: course.syllabusIds!.pickRandom(),
         );
 
         // At least some content fields should be populated
@@ -502,7 +502,7 @@ void main() {
         final course = coursesWithSyllabus.pickRandom();
         final syllabus = await courseService.getSyllabus(
           courseNumber: course.number!,
-          syllabusId: course.syllabusIds!.first,
+          syllabusId: course.syllabusIds!.pickRandom(),
         );
 
         // Email should contain @ if present

--- a/test/services/course_service_test.dart
+++ b/test/services/course_service_test.dart
@@ -381,7 +381,7 @@ void main() {
               (schedule) =>
                   schedule.number != null &&
                   schedule.number!.isNotEmpty &&
-                  schedule.syllabusId != null,
+                  (schedule.syllabusIds?.isNotEmpty ?? false),
             )
             .toList();
 
@@ -394,7 +394,7 @@ void main() {
         final course = coursesWithSyllabus.pickRandom();
         final syllabus = await courseService.getSyllabus(
           courseNumber: course.number!,
-          syllabusId: course.syllabusId!,
+          syllabusId: course.syllabusIds!.first,
         );
 
         // Verify course type is a valid enum value
@@ -445,14 +445,14 @@ void main() {
               (schedule) =>
                   schedule.number != null &&
                   schedule.number!.isNotEmpty &&
-                  schedule.syllabusId != null,
+                  (schedule.syllabusIds?.isNotEmpty ?? false),
             )
             .toList();
 
         final course = coursesWithSyllabus.pickRandom();
         final syllabus = await courseService.getSyllabus(
           courseNumber: course.number!,
-          syllabusId: course.syllabusId!,
+          syllabusId: course.syllabusIds!.first,
         );
 
         // At least some content fields should be populated
@@ -495,14 +495,14 @@ void main() {
               (schedule) =>
                   schedule.number != null &&
                   schedule.number!.isNotEmpty &&
-                  schedule.syllabusId != null,
+                  (schedule.syllabusIds?.isNotEmpty ?? false),
             )
             .toList();
 
         final course = coursesWithSyllabus.pickRandom();
         final syllabus = await courseService.getSyllabus(
           courseNumber: course.number!,
-          syllabusId: course.syllabusId!,
+          syllabusId: course.syllabusIds!.first,
         );
 
         // Email should contain @ if present


### PR DESCRIPTION
## What

A course offering can have multiple syllabi — one per teacher who submits one. A syllabus's code is the authoring teacher's code, so each syllabus maps to a teacher.

## Changes

- New `Syllabuses` table holding per-teacher syllabus content (one row per offering + teacher); it replaces the offering's flat syllabus columns, while the shared header fields (course type, enrolled, withdrawn) stay on `CourseOfferings`.
- Syllabi are fetched lazily per teacher via a `watchSyllabus`/`refreshSyllabus` pair keyed by `(offeringId, teacherId)`: a row is created on the first successful fetch and deleted when the teacher hasn't submitted one; the refresh also writes the offering header fields and the instructor email.
- `getSyllabus` returns `null` when the teacher hasn't submitted a syllabus (the page shows 尚未登錄, distinct from the session-expiry 尚未登錄入口網站).
- The course offering detail exposes its teachers; the UI fetches each teacher's syllabus on demand (shows the first for now).

## Testing

- `flutter analyze` clean; generated Drift code regenerated.
- Course service integration tests pass against real NTUT; verified a team-taught offering (10 teachers) and the 尚未登錄 (no-syllabus) path.

## Temporary syllabus UI (debug)

Temporary debug UI in `course_table_detail_sheet.dart` listing the offering's teachers, each expandable to lazily fetch and dump its syllabus fields (or 查無大綱 when the teacher hasn't submitted one). Marked `// TODO: temporary`. Patch:

<details>
<summary>course_table_detail_sheet.dart.patch</summary>

```diff
diff --git a/lib/screens/main/course_table/course_table_detail_sheet.dart b/lib/screens/main/course_table/course_table_detail_sheet.dart
index fd0fe91..ded7e5e 100644
--- a/lib/screens/main/course_table/course_table_detail_sheet.dart
+++ b/lib/screens/main/course_table/course_table_detail_sheet.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tattoo/database/database.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/course_repository.dart';
+import 'package:tattoo/screens/main/course_table/course_table_providers.dart';
+import 'package:tattoo/utils/localized.dart';
 
 Future<void> showCourseTableDetailSheet(
   BuildContext context, {
@@ -19,7 +23,7 @@ Future<void> showCourseTableDetailSheet(
   );
 }
 
-class CourseTableDetailSheet extends StatelessWidget {
+class CourseTableDetailSheet extends ConsumerWidget {
   const CourseTableDetailSheet({
     super.key,
     required this.cell,
@@ -28,12 +32,12 @@ class CourseTableDetailSheet extends StatelessWidget {
   final CourseTableCellData cell;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
 
     return SafeArea(
       top: false,
-      child: Padding(
+      child: SingleChildScrollView(
         padding: .fromLTRB(16, 8, 16, 16),
         child: Column(
           mainAxisSize: .min,
@@ -81,6 +85,8 @@ class CourseTableDetailSheet extends StatelessWidget {
                 ),
               ),
             ),
+            // TODO: temporary — replace with proper syllabus UI.
+            _SyllabiSection(offeringId: cell.id),
             SizedBox(height: MediaQuery.viewInsetsOf(context).bottom),
             // TODO: scroll up to show more course query features like classmate, course outline, etc.
           ],
@@ -89,3 +95,123 @@ class CourseTableDetailSheet extends StatelessWidget {
     );
   }
 }
+
+/// Temporary debug UI: lists the offering's teachers, each expandable to fetch
+/// and show that teacher's syllabus via [syllabusProvider].
+class _SyllabiSection extends ConsumerWidget {
+  const _SyllabiSection({required this.offeringId});
+
+  final int offeringId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final detail = ref.watch(courseOfferingProvider(offeringId));
+
+    return switch (detail) {
+      AsyncData(:final value?) when value.teachers.isNotEmpty => Column(
+        crossAxisAlignment: .start,
+        spacing: 8,
+        children: [
+          Text(
+            '課程大綱 (${value.teachers.length})',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          for (final teacher in value.teachers)
+            _SyllabusTile(offeringId: offeringId, teacher: teacher),
+        ],
+      ),
+      _ => const SizedBox.shrink(),
+    };
+  }
+}
+
+class _SyllabusTile extends ConsumerWidget {
+  const _SyllabusTile({required this.offeringId, required this.teacher});
+
+  final int offeringId;
+  final ({String code, String nameZh, String? nameEn}) teacher;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final teacherName = localized(teacher.nameZh, teacher.nameEn);
+
+    return Card(
+      margin: .zero,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: .circular(12),
+        side: BorderSide(color: theme.colorScheme.outlineVariant),
+      ),
+      color: theme.colorScheme.surfaceContainer,
+      clipBehavior: .antiAlias,
+      child: ExpansionTile(
+        title: Text(teacherName),
+        subtitle: Text(teacher.code),
+        childrenPadding: .fromLTRB(16, 0, 16, 16),
+        expandedCrossAxisAlignment: .start,
+        children: [
+          _SyllabusContent(offeringId: offeringId, teacherId: teacher.code),
+        ],
+      ),
+    );
+  }
+}
+
+class _SyllabusContent extends ConsumerWidget {
+  const _SyllabusContent({required this.offeringId, required this.teacherId});
+
+  final int offeringId;
+  final String teacherId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final syllabus = ref.watch(
+      syllabusProvider((offeringId: offeringId, teacherId: teacherId)),
+    );
+
+    return switch (syllabus) {
+      AsyncData(:final value?) => _SyllabusFields(syllabus: value),
+      AsyncData() => const Text('查無大綱'),
+      AsyncError(:final error) => Text('載入失敗: $error'),
+      _ => const Padding(
+        padding: .all(8),
+        child: Center(child: CircularProgressIndicator()),
+      ),
+    };
+  }
+}
+
+class _SyllabusFields extends StatelessWidget {
+  const _SyllabusFields({required this.syllabus});
+
+  final Syllabus syllabus;
+
+  @override
+  Widget build(BuildContext context) {
+    final fields = <(String, String?)>[
+      ('最後更新', syllabus.updatedAt?.toString()),
+      ('課程大綱', syllabus.objective),
+      ('課程進度', syllabus.weeklyPlan),
+      ('評量方式', syllabus.evaluation),
+      ('使用教材', syllabus.textbooks),
+      ('備註', syllabus.remarks),
+    ];
+
+    return Column(
+      crossAxisAlignment: .start,
+      spacing: 8,
+      children: [
+        for (final (label, value) in fields)
+          if (value != null && value.isNotEmpty)
+            Column(
+              crossAxisAlignment: .start,
+              children: [
+                Text(label, style: Theme.of(context).textTheme.labelLarge),
+                Text(value),
+              ],
+            ),
+      ],
+    );
+  }
+}
```

</details>
