### PR TITLE
docs: add VS Code Flutter SDK switching notes

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -29,6 +29,22 @@ Shared launch configurations for the project:
 - **`USE_FIREBASE`** — enables Firebase Analytics and Crashlytics (requires Firebase configs from `tool/credentials.dart`)
 - **`cronetHttpNoPlay`** — bundles Cronet directly instead of using Google Play Services (~2MB APK increase), so AOSP devices (e.g., GrapheneOS) work on campus Wi-Fi
 
+## Switching Flutter SDK after a bump
+
+When `mise.toml`'s `flutter` version changes (e.g. a Renovate bump), VS Code keeps using its previously-resolved SDK. To switch:
+
+1. Set `dart.flutterSdkPaths` in your `settings.json` to the mise tarball directory so VS Code can discover installed SDKs:
+
+   ```json
+   {
+     "dart.flutterSdkPaths": ["~/.local/share/mise/http-tarballs/"]
+   }
+   ```
+
+   On Windows, use `~/AppData/Local/mise/http-tarballs/` instead. Use `~` and `/` separators even on Windows.
+
+2. Run **Dart: Change Flutter SDK** from the command palette and pick the version matching `mise.toml`. Reload the window if prompted.
+
 ## Optional Configuration
 
 ### `settings.json`


### PR DESCRIPTION
## Summary

VS Code keeps its previously-resolved Flutter SDK after an `mise.toml` version bump (e.g. a Renovate bump), so it can keep building against the old SDK. Adds a `.vscode/README.md` section explaining how to switch:

- Set `dart.flutterSdkPaths` to the mise tarball directory so VS Code can discover installed SDKs (with the Windows path variant)
- Run **Dart: Change Flutter SDK** (`dart.changeFlutterSdk`) to pick the version matching `mise.toml`

## Test plan

Docs only.