### PR TITLE
Add workflow concurrency control to analysis checks

### DIFF
--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add workflow-level concurrency for the analysis pipeline
- Group runs by workflow and PR/ref so newer runs can cancel in-progress ones on pull requests
- Keep `push` runs on `main` serialized without canceling in-progress jobs

## Testing
- Not run (not requested)