### PR TITLE
ci: improve Flutter dependency cache coverage

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -55,7 +55,7 @@ runs:
       if: ${{ inputs.platform == 'android' }}
       uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        key: ${{ runner.os }}-gradle-${{ hashFiles('android/**/*.gradle*', 'android/**/gradle.properties', 'android/gradle/wrapper/gradle-wrapper.properties') }}
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
@@ -74,9 +74,23 @@ runs:
           ${{ runner.os }}-android-sdk-
 
     - name: Select Xcode version
+      id: xcode_version
       if: ${{ inputs.platform == 'ios' }}
       shell: bash
-      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
+      run: |
+        sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
+        XCODE_VERSION=$(xcodebuild -version | sed -n 's/^Xcode //p')
+        echo "xcode_version=$XCODE_VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: Setup Swift Package Manager cache
+      if: ${{ inputs.platform == 'ios' }}
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        key: ${{ runner.os }}-spm-${{ runner.arch }}-xcode-${{ steps.xcode_version.outputs.xcode_version }}-${{ hashFiles('ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+        path: ~/Library/Developer/Xcode/DerivedData/*/SourcePackages
+        restore-keys: |
+          ${{ runner.os }}-spm-${{ runner.arch }}-xcode-${{ steps.xcode_version.outputs.xcode_version }}-
+          ${{ runner.os }}-spm-${{ runner.arch }}-
 
     - name: Setup CocoaPods cache
       if: ${{ inputs.platform == 'ios' }}

--- a/.github/workflows/seed-caches.yaml
+++ b/.github/workflows/seed-caches.yaml
@@ -1,8 +1,13 @@
 name: Seed Caches
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - mise.toml
   schedule:
-    - cron: "0 0 * * 0" # Weekly on Sunday midnight UTC
+    - cron: "17 0 * * 0" # Weekly on Sunday at 00:17 UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Cache Xcode Swift Package Manager `SourcePackages` using runner architecture, Xcode version, and `Package.resolved`.
- Include Android `gradle.properties` in the Gradle cache key so Kotlin/AGP configuration changes invalidate the cache.
- Run the cache-seeding workflow on pushes to `main` when `mise.toml` changes, while retaining the weekly schedule and manual dispatch.
- Offset the weekly seed run to 00:17 UTC to avoid the top-of-hour burst.
- Keep the existing CocoaPods cache for dependencies that still use CocoaPods.

## Why

Recent iOS jobs had no cross-job SwiftPM cache, and the Gradle cache key omitted an Android Gradle configuration input. Cache seeding also did not automatically run after a Flutter toolchain change.
