### PR TITLE
feat: show graduated status on profile card

### DIFF
--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -12116,11 +12116,13 @@ class UserRegistration extends DataClass {
   final int term;
   final String? className;
   final EnrollmentStatus? enrollmentStatus;
+  final bool? graduated;
   const UserRegistration({
     required this.year,
     required this.term,
     this.className,
     this.enrollmentStatus,
+    this.graduated,
   });
   factory UserRegistration.fromJson(
     Map<String, dynamic> json, {
@@ -12133,6 +12135,7 @@ class UserRegistration extends DataClass {
       className: serializer.fromJson<String?>(json['className']),
       enrollmentStatus: $UserSemesterSummariesTable.$converterenrollmentStatusn
           .fromJson(serializer.fromJson<String?>(json['enrollmentStatus'])),
+      graduated: serializer.fromJson<bool?>(json['graduated']),
     );
   }
   @override
@@ -12147,6 +12150,7 @@ class UserRegistration extends DataClass {
           enrollmentStatus,
         ),
       ),
+      'graduated': serializer.toJson<bool?>(graduated),
     };
   }
 
@@ -12155,6 +12159,7 @@ class UserRegistration extends DataClass {
     int? term,
     Value<String?> className = const Value.absent(),
     Value<EnrollmentStatus?> enrollmentStatus = const Value.absent(),
+    Value<bool?> graduated = const Value.absent(),
   }) => UserRegistration(
     year: year ?? this.year,
     term: term ?? this.term,
@@ -12162,6 +12167,7 @@ class UserRegistration extends DataClass {
     enrollmentStatus: enrollmentStatus.present
         ? enrollmentStatus.value
         : this.enrollmentStatus,
+    graduated: graduated.present ? graduated.value : this.graduated,
   );
   @override
   String toString() {
@@ -12169,13 +12175,15 @@ class UserRegistration extends DataClass {
           ..write('year: $year, ')
           ..write('term: $term, ')
           ..write('className: $className, ')
-          ..write('enrollmentStatus: $enrollmentStatus')
+          ..write('enrollmentStatus: $enrollmentStatus, ')
+          ..write('graduated: $graduated')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(year, term, className, enrollmentStatus);
+  int get hashCode =>
+      Object.hash(year, term, className, enrollmentStatus, graduated);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -12183,7 +12191,8 @@ class UserRegistration extends DataClass {
           other.year == this.year &&
           other.term == this.term &&
           other.className == this.className &&
-          other.enrollmentStatus == this.enrollmentStatus);
+          other.enrollmentStatus == this.enrollmentStatus &&
+          other.graduated == this.graduated);
 }
 
 class $UserRegistrationsView
@@ -12202,6 +12211,7 @@ class $UserRegistrationsView
     term,
     className,
     enrollmentStatus,
+    graduated,
   ];
   @override
   String get aliasedName => _alias ?? entityName;
@@ -12234,6 +12244,10 @@ class $UserRegistrationsView
               data['${effectivePrefix}enrollment_status'],
             ),
           ),
+      graduated: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}graduated'],
+      ),
     );
   }
 
@@ -12269,6 +12283,16 @@ class $UserRegistrationsView
       ).withConverter<EnrollmentStatus?>(
         $UserSemesterSummariesTable.$converterenrollmentStatusn,
       );
+  late final GeneratedColumn<bool> graduated = GeneratedColumn<bool>(
+    'graduated',
+    aliasedName,
+    true,
+    generatedAs: GeneratedAs(userSemesterSummaries.graduated, false),
+    type: DriftSqlType.bool,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("graduated" IN (0, 1))',
+    ),
+  );
   @override
   $UserRegistrationsView createAlias(String alias) {
     return $UserRegistrationsView(attachedDatabase, alias);

--- a/lib/database/views.dart
+++ b/lib/database/views.dart
@@ -14,6 +14,7 @@ abstract class UserRegistrations extends View {
         semesters.term,
         userSemesterSummaries.className,
         userSemesterSummaries.enrollmentStatus,
+        userSemesterSummaries.graduated,
       ]).from(userSemesterSummaries).join([
         innerJoin(
           semesters,

--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -206,6 +206,7 @@ enrollmentStatus:
   learning: Enrolled
   leaveOfAbsence: Leave of Absence
   droppedOut: Withdrawn
+  graduated: Graduated
 about:
   description: Project Tattoo (TAT) is an unofficial campus life assistant for National Taipei University of Technology (NTUT). Our goal is to provide a better student experience through a modern and user-friendly interface.
   developers: Developers

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 380 (190 per locale)
+/// Strings: 382 (191 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -276,6 +276,7 @@ class _Translations$enrollmentStatus$en_US extends Translations$enrollmentStatus
 	@override String get learning => 'Enrolled';
 	@override String get leaveOfAbsence => 'Leave of Absence';
 	@override String get droppedOut => 'Withdrawn';
+	@override String get graduated => 'Graduated';
 }
 
 // Path: about
@@ -785,6 +786,7 @@ extension on TranslationsEnUs {
 			'enrollmentStatus.learning' => 'Enrolled',
 			'enrollmentStatus.leaveOfAbsence' => 'Leave of Absence',
 			'enrollmentStatus.droppedOut' => 'Withdrawn',
+			'enrollmentStatus.graduated' => 'Graduated',
 			'about.description' => 'Project Tattoo (TAT) is an unofficial campus life assistant for National Taipei University of Technology (NTUT). Our goal is to provide a better student experience through a modern and user-friendly interface.',
 			'about.developers' => 'Developers',
 			'about.helpTranslate' => 'Help us translate TAT!',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -408,6 +408,9 @@ class Translations$enrollmentStatus$zh_TW {
 
 	/// zh-TW: '退學'
 	String get droppedOut => '退學';
+
+	/// zh-TW: '畢業'
+	String get graduated => '畢業';
 }
 
 // Path: about
@@ -1126,6 +1129,7 @@ extension on Translations {
 			'enrollmentStatus.learning' => '在學',
 			'enrollmentStatus.leaveOfAbsence' => '休學',
 			'enrollmentStatus.droppedOut' => '退學',
+			'enrollmentStatus.graduated' => '畢業',
 			'about.description' => 'Project Tattoo (TAT)是國立臺北科技大學(NTUT)的非官方校園生活小幫手。我們致力於透過現代化且使用者友善的介面，提供更便利的校園生活體驗。',
 			'about.developers' => '開發團隊',
 			'about.helpTranslate' => '幫助我們翻譯TAT!',

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -206,6 +206,7 @@ enrollmentStatus:
   learning: 在學
   leaveOfAbsence: 休學
   droppedOut: 退學
+  graduated: 畢業
 about:
   description: Project Tattoo (TAT)是國立臺北科技大學(NTUT)的非官方校園生活小幫手。我們致力於透過現代化且使用者友善的介面，提供更便利的校園生活體驗。
   developers: 開發團隊

--- a/lib/screens/main/profile/profile_card.dart
+++ b/lib/screens/main/profile/profile_card.dart
@@ -134,8 +134,10 @@ class ProfileContent extends StatelessWidget {
                 right: width * 0.095,
                 top: height * 0.018,
                 child: Text(
-                  registration?.enrollmentStatus?.toLabel() ??
-                      t.general.student,
+                  registration?.graduated == true
+                      ? t.enrollmentStatus.graduated
+                      : (registration?.enrollmentStatus?.toLabel() ??
+                            t.general.student),
                   textAlign: .left,
                   style: textTheme.bodyMedium?.copyWith(
                     color: Color(0xFF3B3B3B),

--- a/lib/services/student_query/ntut_student_query_service.dart
+++ b/lib/services/student_query/ntut_student_query_service.dart
@@ -334,7 +334,7 @@ class NtutStudentQueryService implements StudentQueryService {
       final className = _parseCellText(cells[1]);
       final enrollmentStatus = _parseEnrollmentStatus(_parseCellText(cells[2]));
       final registered = cells[3].text.contains('※');
-      final graduated = cells[4].text.contains('※');
+      final graduated = cells[4].text.contains('◎');
 
       // Tutor names are <a> links to CourseService's Teach.jsp with ?code=teacherId
       final tutors = cells[5].querySelectorAll('a').map((a) {


### PR DESCRIPTION
## Summary

Show the correct "Graduated" label on the profile card for students who have graduated.

## Changes

- **Fix graduated detection** in `NtutStudentQueryService`: the HTML uses `◎` (not `※`) to mark the graduated column
- **Add `graduated` to `UserRegistrations` view** so the profile screen can read it from the DB
- **Profile card** now checks `graduated == true` first and shows the localized "Graduated" label, falling back to `enrollmentStatus` as before
- **i18n**: add `enrollmentStatus.graduated` in both `en-US` and `zh-TW` YAMLs
- **Regenerated** `database.g.dart`, `strings_en_US.g.dart`, `strings_zh_TW.g.dart`