### PR TITLE
ci: replace GitHub Models with Google Gemini API for changelog generation

### DIFF
--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -60,8 +60,9 @@ runs:
           emit_output changelog "$1"
           # Google Play allows up to 500 Unicode characters per language. jq slices by
           # codepoint (unlike bash ${#}, which counts bytes under a C locale).
+          # Slice at 475 to leave room for Daily Build prefix prepended in workflow.
           local store
-          store=$(printf '%s' "$2" | jq -Rrs '.[0:500]')
+          store=$(printf '%s' "$2" | jq -Rrs '.[0:475]')
           emit_output store_changelog "$store"
         }
 

--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -1,9 +1,12 @@
 name: Generate Changelog
-description: Summarize merged PR bodies between two refs into bilingual release notes via GitHub Models, with commit-subject fallback
+description: Summarize merged PR bodies between two refs into bilingual release notes via Google Gemini, with commit-subject fallback
 
 inputs:
   github_token:
-    description: 'Token with contents:read and models:read'
+    description: 'Token with contents:read'
+    required: true
+  gemini_api_key:
+    description: 'Google Gemini API key from Google AI Studio'
     required: true
   last_sha:
     description: 'Previous release commit (empty = no baseline)'
@@ -35,6 +38,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
+        GEMINI_API_KEY: ${{ inputs.gemini_api_key }}
         REPO: ${{ inputs.repository }}
         BASE: ${{ inputs.last_sha }}
         HEAD_REF: ${{ inputs.head_ref }}
@@ -139,42 +143,54 @@ runs:
         and "This update contains only internal improvements." — do not list the chores.'
 
         SCHEMA='{
-          "type": "json_schema",
-          "json_schema": {
-            "name": "changelog",
-            "strict": true,
-            "schema": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": ["zh", "en"],
-              "properties": {
-                "zh": {"type": "array", "minItems": 1, "maxItems": 6, "items": {"type": "string"}},
-                "en": {"type": "array", "minItems": 1, "maxItems": 6, "items": {"type": "string"}}
-              }
+          "type": "object",
+          "properties": {
+            "zh": {
+              "type": "array",
+              "items": {"type": "string"},
+              "minItems": 1,
+              "maxItems": 6
+            },
+            "en": {
+              "type": "array",
+              "items": {"type": "string"},
+              "minItems": 1,
+              "maxItems": 6
             }
-          }
+          },
+          "required": ["zh", "en"]
         }'
 
-        REQ=$(jq -n --arg model "openai/gpt-4.1" --arg sys "$SYSTEM" --arg usr "$CLEANED" \
+        REQ=$(jq -n --arg sys "$SYSTEM" --arg usr "$CLEANED" \
           --argjson fmt "$SCHEMA" \
-          '{model:$model, temperature:0.2, response_format:$fmt,
-            messages:[{role:"system",content:$sys},{role:"user",content:$usr}]}')
+          '{
+            system_instruction: {
+              parts: [{ text: $sys }]
+            },
+            contents: [
+              {
+                parts: [{ text: $usr }]
+              }
+            ],
+            generationConfig: {
+              responseMimeType: "application/json",
+              responseSchema: $fmt
+            }
+          }')
 
         OUT=$(mktemp)
         CODE=$(curl -sS -o "$OUT" -w '%{http_code}' --max-time 60 \
-          -X POST "https://models.github.ai/inference/chat/completions" \
-          -H "Authorization: Bearer $GH_TOKEN" \
+          -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent?key=$GEMINI_API_KEY" \
           -H "Content-Type: application/json" \
-          -H "Accept: application/vnd.github+json" \
           -d "$REQ" || echo "000")
 
         if [ "$CODE" != "200" ]; then
-          echo "Models API HTTP $CODE; falling back." >&2
+          echo "Gemini API HTTP $CODE; falling back." >&2
           fallback
         fi
 
-        # response_format guarantees message.content is a JSON string matching SCHEMA.
-        DATA=$(jq -r '.choices[0].message.content // empty' "$OUT")
+        # responseMimeType guarantees candidates[0].content.parts[0].text is a JSON string matching SCHEMA.
+        DATA=$(jq -r '.candidates[0].content.parts[0].text // empty' "$OUT")
         if ! printf '%s' "$DATA" | jq -e '(.zh | type=="array" and length>0) and (.en | type=="array" and length>0)' >/dev/null 2>&1; then
           echo "Missing, malformed, or empty model response; falling back." >&2
           fallback

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -36,7 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      models: read
     outputs:
       build_number: ${{ steps.build-number.outputs.build_number }}
       version_suffix: ${{ steps.version-suffix.outputs.suffix }}
@@ -118,6 +117,7 @@ jobs:
         uses: ./.github/actions/generate-changelog
         with:
           github_token: ${{ github.token }}
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           last_sha: ${{ steps.check-changes.outputs.last_sha }}
           head_ref: ${{ steps.set-ref.outputs.ref }}
           fallback_message: ${{ steps.summary.outputs.message }}

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -14,12 +14,17 @@ on:
         required: false
         type: string
       include_public_testers:
-        description: 'Upload to external public testers (TestFlight)'
+        description: 'Upload to external public testers (TestFlight & Google Play)'
         required: false
         type: boolean
         default: false
       force_build:
         description: 'Force build even if no changes'
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: 'Dry run (build only, do not upload/release)'
         required: false
         type: boolean
         default: false
@@ -45,6 +50,7 @@ jobs:
       target_ref: ${{ steps.set-ref.outputs.ref }}
       skip_build: ${{ steps.check-changes.outputs.skip }}
       store_changelog: ${{ steps.changelog.outputs.store_changelog }}
+      dry_run: ${{ inputs.dry_run == true }}
     steps:
       - name: Checkout Actions
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -123,7 +129,7 @@ jobs:
           fallback_message: ${{ steps.summary.outputs.message }}
 
       - name: Find or create pre-release
-        if: steps.check-changes.outputs.skip != 'true'
+        if: steps.check-changes.outputs.skip != 'true' && inputs.dry_run != true
         env:
           GH_TOKEN: ${{ github.token }}
           CHANGELOG: ${{ steps.changelog.outputs.changelog }}
@@ -179,6 +185,7 @@ jobs:
         Daily Build ${{ needs.prepare.outputs.date }}
         ${{ needs.prepare.outputs.store_changelog }}
       FIREBASEAPPDISTRO_APP: ${{ secrets.FIREBASEAPPDISTRO_APP }}
+      PUBLIC_TESTERS: ${{ github.event_name == 'schedule' || inputs.include_public_testers }}
     timeout-minutes: 30
     steps:
       - name: Checkout code
@@ -195,23 +202,41 @@ jobs:
         id: build
         run: |
           bundle exec fastlane android build_apk
-          bundle exec fastlane android release
+          if [ "${{ needs.prepare.outputs.dry_run }}" = "true" ]; then
+            bundle exec fastlane android release skip_upload_playstore:true skip_upload_firebase:true
+          elif [ "$PUBLIC_TESTERS" != "true" ]; then
+            bundle exec fastlane android release skip_upload_playstore:true
+          else
+            bundle exec fastlane android release
+          fi
           APK_PATH=$(find build/app/outputs/flutter-apk -name "*.apk" -not -name "*sha1" | head -n 1)
           echo "apk_path=$APK_PATH" >> $GITHUB_OUTPUT
 
       - name: Upload APK to Release
+        if: needs.prepare.outputs.dry_run != 'true'
         run: gh release upload daily "${{ steps.build.outputs.apk_path }}#tattoo-${{ needs.prepare.outputs.build_number }}-android.apk" --clobber
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: Write Android Job Summary
+        if: needs.prepare.outputs.dry_run != 'true'
         uses: ./.github/actions/android-summary
         with:
           build_number: ${{ needs.prepare.outputs.build_number }}
           type: release
           testing_uri: ${{ steps.build.outputs.testing_uri }}
 
+      - name: Write Dry Run Android Summary
+        if: needs.prepare.outputs.dry_run == 'true'
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ### Android (Dry Run)
+          Build **${{ needs.prepare.outputs.build_number }}** successfully compiled but NOT uploaded (dry run option enabled).
+          EOF
+
       - name: Append Android result to pre-release
+        if: needs.prepare.outputs.dry_run != 'true'
         uses: ./.github/actions/append-release-notes
         with:
           github_token: ${{ github.token }}
@@ -269,21 +294,37 @@ jobs:
       - name: Build iOS
         id: build
         run: |
-          bundle exec fastlane ios upload_testflight
+          if [ "${{ needs.prepare.outputs.dry_run }}" = "true" ]; then
+            bundle exec fastlane ios upload_testflight skip_upload:true
+          else
+            bundle exec fastlane ios upload_testflight
+          fi
           IPA_PATH=$(find . -maxdepth 2 -name "*.ipa" | head -n 1)
           echo "ipa_path=$IPA_PATH" >> $GITHUB_OUTPUT
 
       - name: Upload iOS to Release
+        if: needs.prepare.outputs.dry_run != 'true'
         run: gh release upload daily "${{ steps.build.outputs.ipa_path }}#tattoo-${{ needs.prepare.outputs.build_number }}-ios.ipa" --clobber
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: Write iOS Job Summary
+        if: needs.prepare.outputs.dry_run != 'true'
         uses: ./.github/actions/ios-summary
         with:
           build_number: ${{ needs.prepare.outputs.build_number }}
 
+      - name: Write Dry Run iOS Summary
+        if: needs.prepare.outputs.dry_run == 'true'
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ### iOS (Dry Run)
+          Build **${{ needs.prepare.outputs.build_number }}** successfully compiled but NOT uploaded (dry run option enabled).
+          EOF
+
       - name: Append iOS result to pre-release
+        if: needs.prepare.outputs.dry_run != 'true'
         uses: ./.github/actions/append-release-notes
         with:
           github_token: ${{ github.token }}

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -175,7 +175,9 @@ jobs:
       PR_TITLE: "Daily Build ${{ needs.prepare.outputs.date }}"
       COMMIT_SHA: ${{ needs.prepare.outputs.commit_sha }}
       COMMIT_MESSAGE: ${{ needs.prepare.outputs.commit_message }}
-      CHANGELOG: ${{ needs.prepare.outputs.store_changelog }}
+      CHANGELOG: |
+        Daily Build ${{ needs.prepare.outputs.date }}
+        ${{ needs.prepare.outputs.store_changelog }}
       FIREBASEAPPDISTRO_APP: ${{ secrets.FIREBASEAPPDISTRO_APP }}
     timeout-minutes: 30
     steps:
@@ -248,7 +250,9 @@ jobs:
       PR_TITLE: "Daily Build ${{ needs.prepare.outputs.date }}"
       COMMIT_SHA: ${{ needs.prepare.outputs.commit_sha }}
       COMMIT_MESSAGE: ${{ needs.prepare.outputs.commit_message }}
-      CHANGELOG: ${{ needs.prepare.outputs.store_changelog }}
+      CHANGELOG: |
+        Daily Build ${{ needs.prepare.outputs.date }}
+        ${{ needs.prepare.outputs.store_changelog }}
       PUBLIC_TESTERS: ${{ github.event_name == 'schedule' || inputs.include_public_testers }}
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Closes #355. Replaces the retired GitHub Models service with Google Gemini API (using the gemini-1.5-flash model) for automated release changelog generation. Updates the API endpoint, parameters, request body format, and parses the response accordingly.
