### PR TITLE
ci: make Gemini model configurable in generate-changelog

### DIFF
--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -21,6 +21,11 @@ inputs:
     description: 'owner/repo'
     required: false
     default: ${{ github.repository }}
+  model:
+    description: 'Google Gemini model to use'
+    required: false
+    default: 'gemini-3.5-flash'
+
 
 outputs:
   changelog:
@@ -43,6 +48,7 @@ runs:
         BASE: ${{ inputs.last_sha }}
         HEAD_REF: ${{ inputs.head_ref }}
         FALLBACK: ${{ inputs.fallback_message }}
+        MODEL: ${{ inputs.model }}
       run: |
         set -uo pipefail
 
@@ -181,7 +187,7 @@ runs:
 
         OUT=$(mktemp)
         CODE=$(curl -sS -o "$OUT" -w '%{http_code}' --max-time 60 \
-          -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent?key=$GEMINI_API_KEY" \
+          -X POST "https://generativelanguage.googleapis.com/v1beta/models/$MODEL:generateContent?key=$GEMINI_API_KEY" \
           -H "Content-Type: application/json" \
           -d "$REQ" || echo "000")
 

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -127,6 +127,7 @@ jobs:
           last_sha: ${{ steps.check-changes.outputs.last_sha }}
           head_ref: ${{ steps.set-ref.outputs.ref }}
           fallback_message: ${{ steps.summary.outputs.message }}
+          model: ${{ vars.GEMINI_MODEL || 'gemini-3.5-flash' }}
 
       - name: Find or create pre-release
         if: steps.check-changes.outputs.skip != 'true' && inputs.dry_run != true


### PR DESCRIPTION
This PR makes the Google Gemini model configurable in the `generate-changelog` action instead of hardcoding it. 

### Changes
- Added a `model` input parameter to the `generate-changelog` composite action, defaulting to `gemini-3.5-flash`.
- Updated the API curl command to use the `$MODEL` environment variable.
- Configured `daily-release.yaml` to pass `model: ${{ vars.GEMINI_MODEL || 'gemini-3.5-flash' }}` to the action.
