### PR TITLE
chore: normalize i18n YAML quoting and fix Weblate-flagged strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ Dart 3 idioms not yet covered by linter rules (see [#288](https://github.com/NTU
 ## Typography & i18n
 
 - **No CJK–Latin spaces in source; space at render time:** Never put literal spaces between CJK and alphanumeric characters in i18n strings or UI text — spacing is a rendering concern. Instead apply the `String.spaced` extension (`lib/utils/auto_spacing.dart`) where CJK-mixed text is displayed (i18n and dynamic NTUT content); for parameterized strings call it on the interpolated result. GitHub discussions should still use spaces for readability.
+- **Leave i18n YAML values unquoted unless YAML requires quotes** (a `:` followed by a space, a trailing `:`, a leading indicator character, or numeric-looking map keys like `'201'`). Slang parses both forms identically, but double quotes turn `\n` into a real newline, which Weblate then renders inconsistently across locales.
 
 ## HTML Snapshot Capture
 

--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -33,11 +33,11 @@ intro:
 login:
   welcomeLine1: Welcome to
   welcomeLine2: Campus Life
-  instruction(rich): "Sign in with your ${portalLink(NTUT Portal)} account credentials."
+  instruction(rich): Sign in with your ${portalLink(NTUT Portal)} account credentials.
   studentId: Student ID
   password: Password
   loginButton: Sign In
-  privacyNotice(rich): "Your credentials are stored securely on your device\nBy signing in, you agree to our ${privacyPolicy(Privacy Policy)}."
+  privacyNotice(rich): Your credentials are stored securely on your device\nBy signing in, you agree to our ${privacyPolicy(Privacy Policy)}.
   errors:
     emptyFields: Please enter your student ID and password
     useStudentId: Please use your student ID to sign in, not an email address
@@ -146,7 +146,7 @@ profile:
     fireMessage: Bar is on fire
     barOpen: The bar is now open
     barClosed: The bar has closed down
-    goAction: "Go to the bar and ${action}"
+    goAction: Go to the bar and ${action}
     actions:
       - order 0 beers
       - order 999999999 beers
@@ -160,7 +160,7 @@ profile:
     clearPreferences: Clear Preferences
     clearCredentials: Clear Credentials
     clearUserData: Clear User Data
-    cleared: "${item} cleared"
+    cleared: ${item} cleared
     clearFailed: Failed to clear ${item}
     items:
       cache: Cache
@@ -187,7 +187,7 @@ scanner:
     '205': Already logged in. Log out from the portal first to switch users.
     '206': The QR code has expired. Please refresh the page on your computer.
     unknown: Login failed. Please check the QR code or refresh the page.
-  howTo: "Open i.ntut.club on your computer and select QR code login"
+  howTo: Open i.ntut.club on your computer and select QR code login
   guide:
     title: How to login?
     step1: "1. Go to the following URL on your computer:"
@@ -218,7 +218,7 @@ about:
   viewPrivacyPolicy: View our privacy policy
   openSourceLicenses: Open Source Licenses
   viewOpenSourceLicenses: TAT's implementation is made possible by the open source community
-  copyright: "© 2025 NTUT Programming Club\nLicensed under the GNU GPL v3.0"
+  copyright: © 2025 NTUT Programming Club\nLicensed under the GNU GPL v3.0
 regedit:
   title: Registry Editor
   fetch: Fetch from remote

--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -205,7 +205,7 @@ kioskLogin:
 enrollmentStatus:
   learning: Enrolled
   leaveOfAbsence: Leave of Absence
-  droppedOut: Withdrawn
+  droppedOut: Dropped Out
   graduated: Graduated
 about:
   description: Project Tattoo (TAT) is an unofficial campus life assistant for National Taipei University of Technology (NTUT). Our goal is to provide a better student experience through a modern and user-friendly interface.

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -275,7 +275,7 @@ class _Translations$enrollmentStatus$en_US extends Translations$enrollmentStatus
 	// Translations
 	@override String get learning => 'Enrolled';
 	@override String get leaveOfAbsence => 'Leave of Absence';
-	@override String get droppedOut => 'Withdrawn';
+	@override String get droppedOut => 'Dropped Out';
 	@override String get graduated => 'Graduated';
 }
 
@@ -785,7 +785,7 @@ extension on TranslationsEnUs {
 			'kioskLogin.invalidSsoUrl' => 'The login URL is invalid. Unable to generate the login code.',
 			'enrollmentStatus.learning' => 'Enrolled',
 			'enrollmentStatus.leaveOfAbsence' => 'Leave of Absence',
-			'enrollmentStatus.droppedOut' => 'Withdrawn',
+			'enrollmentStatus.droppedOut' => 'Dropped Out',
 			'enrollmentStatus.graduated' => 'Graduated',
 			'about.description' => 'Project Tattoo (TAT) is an unofficial campus life assistant for National Taipei University of Technology (NTUT). Our goal is to provide a better student experience through a modern and user-friendly interface.',
 			'about.developers' => 'Developers',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -172,7 +172,7 @@ class Translations$login$zh_TW {
 	/// zh-TW: '登入'
 	String get loginButton => '登入';
 
-	/// zh-TW: '登入資訊將被安全地儲存在您的裝置中 登入即表示您同意我們的${privacyPolicy(隱私條款)}'
+	/// zh-TW: '登入資訊將被安全地儲存在您的裝置中\n登入即表示您同意我們的${privacyPolicy(隱私條款)}'
 	TextSpan privacyNotice({required InlineSpanBuilder privacyPolicy}) => TextSpan(children: [
 		const TextSpan(text: '登入資訊將被安全地儲存在您的裝置中\n登入即表示您同意我們的'),
 		privacyPolicy('隱私條款'),

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -33,11 +33,11 @@ intro:
 login:
   welcomeLine1: 歡迎加入
   welcomeLine2: 北科生活
-  instruction(rich): "請使用${portalLink(北科校園入口網站)}的帳號密碼登入。"
+  instruction(rich): 請使用${portalLink(北科校園入口網站)}的帳號密碼登入。
   studentId: 學號
   password: 密碼
   loginButton: 登入
-  privacyNotice(rich): "登入資訊將被安全地儲存在您的裝置中\n登入即表示您同意我們的${privacyPolicy(隱私條款)}"
+  privacyNotice(rich): 登入資訊將被安全地儲存在您的裝置中\n登入即表示您同意我們的${privacyPolicy(隱私條款)}
   errors:
     emptyFields: 請填寫學號與密碼
     useStudentId: 請直接使用學號登入，不要使用電子郵件
@@ -146,7 +146,7 @@ profile:
     fireMessage: 酒吧陷入火海
     barOpen: 酒吧開門了
     barClosed: 酒吧倒閉了
-    goAction: "去酒吧${action}"
+    goAction: 去酒吧${action}
     actions:
       - 點0杯啤酒
       - 點999999999杯啤酒
@@ -187,13 +187,13 @@ scanner:
     '205': 已登入，要切換使用者必須先登出網頁
     '206': QR code已過期，請在電腦上重新整理頁面
     unknown: 登入失敗，請確認 QR code 是否正確或從電腦頁面刷新
-  howTo: "在電腦開啟i.ntut.club並點選QR code登入"
+  howTo: 在電腦開啟i.ntut.club並點選QR code登入
   guide:
     title: 如何掃碼登入？
-    step1: "1. 電腦前往下列網址："
+    step1: 1. 電腦前往下列網址：
     url: https://i.ntut.club
-    step2: "2. 點擊導覽列的「外校人士登入」"
-    step3: "3. 點擊「QR Code 登入」"
+    step2: 2. 點擊導覽列的「外校人士登入」
+    step3: 3. 點擊「QR Code 登入」
     button: 我知道了
   invalidUrl: 無效的網址
 kioskLogin:


### PR DESCRIPTION
## What

- Removed unnecessary quotes from 13 i18n YAML values so both locale files follow one convention.
- Changed en-US `enrollmentStatus.droppedOut` from `Withdrawn` to `Dropped Out`.
- Documented the quoting convention in `CONTRIBUTING.md`.

## Why

`about.copyright` was double-quoted in en-US but unquoted in zh-TW. Slang parses both forms identically, but YAML does not: a double-quoted `\n` is a real newline, while an unquoted one is the two literal characters. Weblate therefore rendered the same string differently per locale and reported a false **Mismatched `\n`** failure on that unit.

Separately, 撤選 (dropping a course) and 退學 (leaving the university) were both translated as `Withdrawn`, which Weblate flagged as a **Reused translation** — and which is genuinely ambiguous next to `Enrolled` / `Leave of Absence` / `Graduated`.

## Quoting rule

Values stay unquoted unless YAML requires quotes. Three sets of quotes remain:

| Kept quoted | Why |
| --- | --- |
| `score.courseNumber` (both locales) | Contains a `:` followed by a space, which terminates a plain scalar |
| `scanner.guide.step1` (en-US only) | Ends with `:` before the line break |
| `scanner.errors` keys `'201'`–`'206'` | Would otherwise parse as integers |

zh-TW's `step1` ends with a full-width `：`, which is not a YAML indicator, hence the asymmetry on that key.

## Verification

Regenerated with `dart run slang`. Every runtime line in the generated Dart is unchanged apart from the intended `droppedOut` string — the only other diff is one `///` doc comment for `login.privacyNotice`, which previously flattened its embedded newline to a space and now shows `\n`.

## Weblate notes

- Clears 2 of the 11 currently failing checks (`escaped_newline` on `about->copyright`, `reused` on the Withdrawn pair).
- `login.privacyNotice`'s zh-TW source value changed (real newline → literal `\n`), so Weblate will mark its English translation for review on the next sync. Both sides moved together, so no new check fires.
- The remaining 9 failures are intentional (課表/查課表 → "Courses", 成績/看成績 → "Scores", and CJK punctuation mismatches). They need dismissal in Weblate rather than code changes.
