### PR TITLE
ci: pin CocoaPods to the bundled version for iOS builds

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -39,6 +39,14 @@ runs:
       env:
         BUNDLE_FROZEN: "true"
 
+    - name: Use bundled CocoaPods
+      if: ${{ inputs.platform == 'ios' }}
+      shell: bash
+      run: |
+        BUNDLE_BIN="$RUNNER_TEMP/bin" bundle binstubs cocoapods --force
+        echo "BUNDLE_GEMFILE=$GITHUB_WORKSPACE/Gemfile" >> "$GITHUB_ENV"
+        echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
     - name: Setup Flutter pub cache
       uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
@@ -126,6 +134,5 @@ runs:
       if: ${{ inputs.platform == 'ios' && steps.ios-drift.outputs.changed == 'true' }}
       shell: bash
       run: |
-        XCODE_VERSION=$(xcodebuild -version | head -1)
-        echo "::error::ios/ drifted after flutter build ios --config-only (CI ${XCODE_VERSION}). Mismatched local Xcode is the usual cause; otherwise apply ios-drift.patch from artifacts."
+        echo "::error::ios/ drifted after flutter build ios --config-only (CI Xcode ${{ steps.xcode_version.outputs.xcode_version }}). Mismatched local Xcode is the usual cause; otherwise apply ios-drift.patch from artifacts."
         exit 1


### PR DESCRIPTION
## Problem

The iOS job started failing on the drift check ([run 30376511670](https://github.com/NTUT-NPC/tattoo/actions/runs/30376511670/job/90333488588)). The uploaded `ios-drift.patch` was a single line:

```diff
-COCOAPODS: 1.16.2
+COCOAPODS: 1.17.0
```

`Gemfile` pins `cocoapods "~> 1.16.2"`, but that pin never applied. Flutter shells out to bare `pod`, not `bundle exec pod` ([cocoapods.dart:352](https://github.com/flutter/flutter/blob/3.44.4/packages/flutter_tools/lib/src/macos/cocoapods.dart#L352)), and `ruby/setup-ruby` doesn't put bundled binstubs on `PATH` — so `flutter build ios --config-only` used whatever CocoaPods the runner image ships.

The image versions line up exactly:

| Run | Image | CocoaPods | Result |
| --- | --- | --- | --- |
| Jul 16 (green) | `macos-26-arm64/20260630.0213` | 1.16.2 | passes |
| Jul 28 (red) | `macos-26-arm64/20260720.0258` | **1.17.0** | drift |

It looked intermittent only because GitHub rolls new macOS images across the pool gradually. Once `20260720` is fully deployed it would fail every time.

Separately, the failure step's `::error::` annotation never printed — CI showed only `Process completed with exit code 134`. `xcodebuild -version | head -1` has `head` exit after one line and close the pipe; `xcodebuild` then hits `EPIPE`, and Foundation raises `NSFileHandleOperationException` → `abort()`. Under `set -e -o pipefail` that killed the step before the `echo` on the next line.

## Changes

- Generate a CocoaPods binstub after `setup-ruby` and prepend it to `PATH`, so Flutter's bare `pod` resolves to the `Gemfile.lock` pin. `BUNDLE_GEMFILE` is set explicitly because binstubs otherwise resolve the Gemfile through a baked-in relative path, which breaks outside the workspace.
- Drop the second `xcodebuild` call in the drift failure step; the version is already captured as `steps.xcode_version.outputs.xcode_version`.

## Testing

Binstub generation verified locally against Ruby 4.0.5 with gems installed to a throwaway path: `pod --version` through the binstub reports `1.16.2`, and with the directory prepended `which pod` resolves to it. No `.bundle/config` is written, so the working tree stays clean.

Not verified locally: the end-to-end result — `flutter build ios --config-only` leaving `ios/Podfile.lock` untouched on the 1.17.0 image — needs a real iOS job. Worth watching this PR's own run before merging, since the runner that picks it up may still be on either image.

## Notes

- Local `flutter build ios` still uses the developer's own `pod`, so drift can still be committed; CI just catches it. Unchanged from before.
- The drift check diffs all of `ios/`, so an image bump touching anything else there fails the same way. This only removes the CocoaPods-version cause.