### PR TITLE
chore: disable Renovate PR hourly limit

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
     "schedule:monthly"
   ],
   "timezone": "Asia/Taipei",
+  "prHourlyLimit": 0,
   "constraints": {
     "flutter": "3.44.4"
   },


### PR DESCRIPTION
## Problem

Only 2 Renovate PRs get opened per month, while the rest sit in *Awaiting Schedule* until the next month.

Two settings multiply:

- `schedule:monthly` resolves to `* 0-3 1 * *` — Renovate may only create branches/PRs between 00:00–03:59 Asia/Taipei on the 1st of the month.
- `prHourlyLimit` defaults to **2**. It is a Renovate global default, not something `config:best-practices` sets.

The Mend hosted app polls the repo irregularly (job gaps of 2–3h, occasionally 12h+). When a single job lands in that 4-hour window, it opens 2 PRs and everything else waits a full month.

The PR history matches exactly (times in Asia/Taipei) — never more than 2 per clock-hour:

| Window | PRs created |
| --- | --- |
| Aug 1 | 2 (02:40) |
| Jul 1 | 2 (00:45) |
| May 1 | 4 (00:37 ×2, 01:07 ×2 — two job runs) |
| Apr 1 | 4 (02:25 ×2, 03:06 ×2) |
| Mar 1 | 4 (01:00 ×2, 03:44 ×2) |

As of writing, 4 groups are stuck until Sep 1: Flutter SDK 3.44.8, Android dependencies, Flutter dependencies, and CI majors.

## Change

Set `prHourlyLimit: 0`, so the first job inside the window opens every pending group at once. `packageRules` already collapse everything into ~6 groups, so `schedule:monthly` remains the noise control. The schedule is unchanged.