### PR TITLE
Add dynamic portal application catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ MVVM pattern with Riverpod for DI and reactive state (manual providers, no codeg
 **Services:**
 
 - **Architecture:** NTUT services (Portal, Course, ISchoolPlus, StudentQuery) use `abstract interface class` with concrete implementations (e.g., `NtutPortalService`). Files are grouped by subdirectory (e.g., `lib/services/portal/`). Interfaces, DTOs, and providers live in the interface file, while logic lives in the implementation file. Consumers only import the interface file. Service providers check `isDemoProvider` — when true, they return mock implementations instead of real NTUT clients.
-- PortalService — Portal auth, SSO, user profile (avatar, password), academic calendar events (calModeApp.do JSON API), and the bilingual, recursively parsed application catalog (apPopupFull.do HTML). Catalog refreshes serialize the portal's server-side locale switches with SSO, use Chinese as the canonical structure, enrich English names by distinguished name / `apOu`, and restore the user's original portal locale before returning.
+- PortalService — Portal auth, SSO, user profile (avatar, password). Also serves academic calendar events (calModeApp.do JSON API) and portal Apps.
 - CourseService — 課程系統 (`aa_0010-oauth`). Course catalog, schedules, teacher profiles, syllabi. All HTML-parsed.
 - ISchoolPlusService — 北科i學園PLUS (`ischool_plus_oauth`). Course rosters and materials.
 - StudentQueryService — 學生查詢專區 (`sa_003_oauth`). Academic records, GPA, rankings, registration history.
@@ -76,7 +76,6 @@ MVVM pattern with Riverpod for DI and reactive state (manual providers, no codeg
 - PreferencesRepository — Typed `PrefKey<T>` enum resolved through a source stack (forced > local override > Remote Config > declared default). Feature flags are unified here: Remote Config is a control layer over `PrefKey`, not a separate system. App-scoped; cloud sync embeds only the user's explicitly-set values in the avatar payload, and runs only while logged in.
 - CourseRepository — Course catalog, schedules, and offering details. Normalizes bilingual names from multiple sources (catalog vs offering). Layout computation for course table grid (multi-period spans, noon-crossing, unscheduled courses).
 - CalendarRepository — Academic calendar events from NTUT portal. Sliding window caching keyed to enrolled semesters.
-- PortalRepository — User-scoped bilingual portal application catalog cache with one-day TTL and app-local favorites. Optional English names survive transient English-source failures; portal bookmark state is not synchronized.
 - StudentRepository — Academic records, GPA, rankings. Parallel course code resolution via CourseRepository.getCourse().
 - **Method pattern:** `watchX()` returns a `Stream` backed by Drift `.watch()` — emits cached data immediately, then background-fetches if empty or stale (each method has its own hard-coded TTL `const`). Network errors are absorbed (stale data preferred over errors). `refreshX()` is the imperative counterpart for pull-to-refresh — fetches from network, writes to DB, and lets the stream re-emit.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ MVVM pattern with Riverpod for DI and reactive state (manual providers, no codeg
 **Services:**
 
 - **Architecture:** NTUT services (Portal, Course, ISchoolPlus, StudentQuery) use `abstract interface class` with concrete implementations (e.g., `NtutPortalService`). Files are grouped by subdirectory (e.g., `lib/services/portal/`). Interfaces, DTOs, and providers live in the interface file, while logic lives in the implementation file. Consumers only import the interface file. Service providers check `isDemoProvider` — when true, they return mock implementations instead of real NTUT clients.
-- PortalService — Portal auth, SSO, user profile (avatar, password). Also serves academic calendar events (calModeApp.do JSON API)
+- PortalService — Portal auth, SSO, user profile (avatar, password), academic calendar events (calModeApp.do JSON API), and the recursively parsed application catalog (apPopupFull.do HTML).
 - CourseService — 課程系統 (`aa_0010-oauth`). Course catalog, schedules, teacher profiles, syllabi. All HTML-parsed.
 - ISchoolPlusService — 北科i學園PLUS (`ischool_plus_oauth`). Course rosters and materials.
 - StudentQueryService — 學生查詢專區 (`sa_003_oauth`). Academic records, GPA, rankings, registration history.
@@ -76,6 +76,7 @@ MVVM pattern with Riverpod for DI and reactive state (manual providers, no codeg
 - PreferencesRepository — Typed `PrefKey<T>` enum resolved through a source stack (forced > local override > Remote Config > declared default). Feature flags are unified here: Remote Config is a control layer over `PrefKey`, not a separate system. App-scoped; cloud sync embeds only the user's explicitly-set values in the avatar payload, and runs only while logged in.
 - CourseRepository — Course catalog, schedules, and offering details. Normalizes bilingual names from multiple sources (catalog vs offering). Layout computation for course table grid (multi-period spans, noon-crossing, unscheduled courses).
 - CalendarRepository — Academic calendar events from NTUT portal. Sliding window caching keyed to enrolled semesters.
+- PortalRepository — User-scoped portal application catalog cache with one-day TTL and app-local favorites. Portal bookmark state is not synchronized.
 - StudentRepository — Academic records, GPA, rankings. Parallel course code resolution via CourseRepository.getCourse().
 - **Method pattern:** `watchX()` returns a `Stream` backed by Drift `.watch()` — emits cached data immediately, then background-fetches if empty or stale (each method has its own hard-coded TTL `const`). Network errors are absorbed (stale data preferred over errors). `refreshX()` is the imperative counterpart for pull-to-refresh — fetches from network, writes to DB, and lets the stream re-emit.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ MVVM pattern with Riverpod for DI and reactive state (manual providers, no codeg
 **Services:**
 
 - **Architecture:** NTUT services (Portal, Course, ISchoolPlus, StudentQuery) use `abstract interface class` with concrete implementations (e.g., `NtutPortalService`). Files are grouped by subdirectory (e.g., `lib/services/portal/`). Interfaces, DTOs, and providers live in the interface file, while logic lives in the implementation file. Consumers only import the interface file. Service providers check `isDemoProvider` — when true, they return mock implementations instead of real NTUT clients.
-- PortalService — Portal auth, SSO, user profile (avatar, password), academic calendar events (calModeApp.do JSON API), and the recursively parsed application catalog (apPopupFull.do HTML).
+- PortalService — Portal auth, SSO, user profile (avatar, password), academic calendar events (calModeApp.do JSON API), and the bilingual, recursively parsed application catalog (apPopupFull.do HTML). Catalog refreshes serialize the portal's server-side locale switches, use Chinese as the canonical structure, enrich English names by distinguished name / `apOu`, and restore `zh_TW` before returning.
 - CourseService — 課程系統 (`aa_0010-oauth`). Course catalog, schedules, teacher profiles, syllabi. All HTML-parsed.
 - ISchoolPlusService — 北科i學園PLUS (`ischool_plus_oauth`). Course rosters and materials.
 - StudentQueryService — 學生查詢專區 (`sa_003_oauth`). Academic records, GPA, rankings, registration history.
@@ -76,7 +76,7 @@ MVVM pattern with Riverpod for DI and reactive state (manual providers, no codeg
 - PreferencesRepository — Typed `PrefKey<T>` enum resolved through a source stack (forced > local override > Remote Config > declared default). Feature flags are unified here: Remote Config is a control layer over `PrefKey`, not a separate system. App-scoped; cloud sync embeds only the user's explicitly-set values in the avatar payload, and runs only while logged in.
 - CourseRepository — Course catalog, schedules, and offering details. Normalizes bilingual names from multiple sources (catalog vs offering). Layout computation for course table grid (multi-period spans, noon-crossing, unscheduled courses).
 - CalendarRepository — Academic calendar events from NTUT portal. Sliding window caching keyed to enrolled semesters.
-- PortalRepository — User-scoped portal application catalog cache with one-day TTL and app-local favorites. Portal bookmark state is not synchronized.
+- PortalRepository — User-scoped bilingual portal application catalog cache with one-day TTL and app-local favorites. Optional English names survive transient English-source failures; portal bookmark state is not synchronized.
 - StudentRepository — Academic records, GPA, rankings. Parallel course code resolution via CourseRepository.getCourse().
 - **Method pattern:** `watchX()` returns a `Stream` backed by Drift `.watch()` — emits cached data immediately, then background-fetches if empty or stale (each method has its own hard-coded TTL `const`). Network errors are absorbed (stale data preferred over errors). `refreshX()` is the imperative counterpart for pull-to-refresh — fetches from network, writes to DB, and lets the stream re-emit.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ MVVM pattern with Riverpod for DI and reactive state (manual providers, no codeg
 **Services:**
 
 - **Architecture:** NTUT services (Portal, Course, ISchoolPlus, StudentQuery) use `abstract interface class` with concrete implementations (e.g., `NtutPortalService`). Files are grouped by subdirectory (e.g., `lib/services/portal/`). Interfaces, DTOs, and providers live in the interface file, while logic lives in the implementation file. Consumers only import the interface file. Service providers check `isDemoProvider` — when true, they return mock implementations instead of real NTUT clients.
-- PortalService — Portal auth, SSO, user profile (avatar, password), academic calendar events (calModeApp.do JSON API), and the bilingual, recursively parsed application catalog (apPopupFull.do HTML). Catalog refreshes serialize the portal's server-side locale switches, use Chinese as the canonical structure, enrich English names by distinguished name / `apOu`, and restore `zh_TW` before returning.
+- PortalService — Portal auth, SSO, user profile (avatar, password), academic calendar events (calModeApp.do JSON API), and the bilingual, recursively parsed application catalog (apPopupFull.do HTML). Catalog refreshes serialize the portal's server-side locale switches with SSO, use Chinese as the canonical structure, enrich English names by distinguished name / `apOu`, and restore the user's original portal locale before returning.
 - CourseService — 課程系統 (`aa_0010-oauth`). Course catalog, schedules, teacher profiles, syllabi. All HTML-parsed.
 - ISchoolPlusService — 北科i學園PLUS (`ischool_plus_oauth`). Course rosters and materials.
 - StudentQueryService — 學生查詢專區 (`sa_003_oauth`). Academic records, GPA, rankings, registration history.

--- a/lib/database/actions.dart
+++ b/lib/database/actions.dart
@@ -25,7 +25,9 @@ extension DatabaseActions on AppDatabase {
   Future<void> deleteCachedData() async {
     await transaction(() async {
       for (final entity in allSchemaEntities.toList().reversed) {
-        if (entity is TableInfo && entity != users) {
+        if (entity is TableInfo &&
+            entity != users &&
+            entity != portalApplicationFavorites) {
           await delete(entity).go();
         }
       }
@@ -36,6 +38,7 @@ extension DatabaseActions on AppDatabase {
           semestersFetchedAt: Value(null),
           scoreDataFetchedAt: Value(null),
           calendarFetchedAt: Value(null),
+          applicationCatalogFetchedAt: Value(null),
         ),
       );
     });

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -26,6 +26,9 @@ final databaseProvider = Provider<AppDatabase>((ref) {
   tables: [
     // Base tables
     Users,
+    PortalApplicationCategories,
+    PortalApplications,
+    PortalApplicationFavorites,
     Students,
     Semesters,
     Courses,

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -181,6 +181,17 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
         type: DriftSqlType.dateTime,
         requiredDuringInsert: false,
       );
+  static const VerificationMeta _applicationCatalogFetchedAtMeta =
+      const VerificationMeta('applicationCatalogFetchedAt');
+  @override
+  late final GeneratedColumn<DateTime> applicationCatalogFetchedAt =
+      GeneratedColumn<DateTime>(
+        'application_catalog_fetched_at',
+        aliasedName,
+        true,
+        type: DriftSqlType.dateTime,
+        requiredDuringInsert: false,
+      );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -199,6 +210,7 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
     semestersFetchedAt,
     scoreDataFetchedAt,
     calendarFetchedAt,
+    applicationCatalogFetchedAt,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -337,6 +349,15 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
         ),
       );
     }
+    if (data.containsKey('application_catalog_fetched_at')) {
+      context.handle(
+        _applicationCatalogFetchedAtMeta,
+        applicationCatalogFetchedAt.isAcceptableOrUnknown(
+          data['application_catalog_fetched_at']!,
+          _applicationCatalogFetchedAtMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -410,6 +431,10 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
         DriftSqlType.dateTime,
         data['${effectivePrefix}calendar_fetched_at'],
       ),
+      applicationCatalogFetchedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}application_catalog_fetched_at'],
+      ),
     );
   }
 
@@ -477,6 +502,9 @@ class User extends DataClass implements Insertable<User> {
 
   /// When the academic calendar was last fetched from the portal.
   final DateTime? calendarFetchedAt;
+
+  /// When the portal application catalog was last fetched.
+  final DateTime? applicationCatalogFetchedAt;
   const User({
     required this.id,
     this.fetchedAt,
@@ -494,6 +522,7 @@ class User extends DataClass implements Insertable<User> {
     this.semestersFetchedAt,
     this.scoreDataFetchedAt,
     this.calendarFetchedAt,
+    this.applicationCatalogFetchedAt,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -535,6 +564,11 @@ class User extends DataClass implements Insertable<User> {
     }
     if (!nullToAbsent || calendarFetchedAt != null) {
       map['calendar_fetched_at'] = Variable<DateTime>(calendarFetchedAt);
+    }
+    if (!nullToAbsent || applicationCatalogFetchedAt != null) {
+      map['application_catalog_fetched_at'] = Variable<DateTime>(
+        applicationCatalogFetchedAt,
+      );
     }
     return map;
   }
@@ -579,6 +613,10 @@ class User extends DataClass implements Insertable<User> {
       calendarFetchedAt: calendarFetchedAt == null && nullToAbsent
           ? const Value.absent()
           : Value(calendarFetchedAt),
+      applicationCatalogFetchedAt:
+          applicationCatalogFetchedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(applicationCatalogFetchedAt),
     );
   }
 
@@ -612,6 +650,9 @@ class User extends DataClass implements Insertable<User> {
       calendarFetchedAt: serializer.fromJson<DateTime?>(
         json['calendarFetchedAt'],
       ),
+      applicationCatalogFetchedAt: serializer.fromJson<DateTime?>(
+        json['applicationCatalogFetchedAt'],
+      ),
     );
   }
   @override
@@ -634,6 +675,9 @@ class User extends DataClass implements Insertable<User> {
       'semestersFetchedAt': serializer.toJson<DateTime?>(semestersFetchedAt),
       'scoreDataFetchedAt': serializer.toJson<DateTime?>(scoreDataFetchedAt),
       'calendarFetchedAt': serializer.toJson<DateTime?>(calendarFetchedAt),
+      'applicationCatalogFetchedAt': serializer.toJson<DateTime?>(
+        applicationCatalogFetchedAt,
+      ),
     };
   }
 
@@ -654,6 +698,7 @@ class User extends DataClass implements Insertable<User> {
     Value<DateTime?> semestersFetchedAt = const Value.absent(),
     Value<DateTime?> scoreDataFetchedAt = const Value.absent(),
     Value<DateTime?> calendarFetchedAt = const Value.absent(),
+    Value<DateTime?> applicationCatalogFetchedAt = const Value.absent(),
   }) => User(
     id: id ?? this.id,
     fetchedAt: fetchedAt.present ? fetchedAt.value : this.fetchedAt,
@@ -679,6 +724,9 @@ class User extends DataClass implements Insertable<User> {
     calendarFetchedAt: calendarFetchedAt.present
         ? calendarFetchedAt.value
         : this.calendarFetchedAt,
+    applicationCatalogFetchedAt: applicationCatalogFetchedAt.present
+        ? applicationCatalogFetchedAt.value
+        : this.applicationCatalogFetchedAt,
   );
   User copyWithCompanion(UsersCompanion data) {
     return User(
@@ -714,6 +762,9 @@ class User extends DataClass implements Insertable<User> {
       calendarFetchedAt: data.calendarFetchedAt.present
           ? data.calendarFetchedAt.value
           : this.calendarFetchedAt,
+      applicationCatalogFetchedAt: data.applicationCatalogFetchedAt.present
+          ? data.applicationCatalogFetchedAt.value
+          : this.applicationCatalogFetchedAt,
     );
   }
 
@@ -735,7 +786,8 @@ class User extends DataClass implements Insertable<User> {
           ..write('passwordExpiresInDays: $passwordExpiresInDays, ')
           ..write('semestersFetchedAt: $semestersFetchedAt, ')
           ..write('scoreDataFetchedAt: $scoreDataFetchedAt, ')
-          ..write('calendarFetchedAt: $calendarFetchedAt')
+          ..write('calendarFetchedAt: $calendarFetchedAt, ')
+          ..write('applicationCatalogFetchedAt: $applicationCatalogFetchedAt')
           ..write(')'))
         .toString();
   }
@@ -758,6 +810,7 @@ class User extends DataClass implements Insertable<User> {
     semestersFetchedAt,
     scoreDataFetchedAt,
     calendarFetchedAt,
+    applicationCatalogFetchedAt,
   );
   @override
   bool operator ==(Object other) =>
@@ -778,7 +831,9 @@ class User extends DataClass implements Insertable<User> {
           other.passwordExpiresInDays == this.passwordExpiresInDays &&
           other.semestersFetchedAt == this.semestersFetchedAt &&
           other.scoreDataFetchedAt == this.scoreDataFetchedAt &&
-          other.calendarFetchedAt == this.calendarFetchedAt);
+          other.calendarFetchedAt == this.calendarFetchedAt &&
+          other.applicationCatalogFetchedAt ==
+              this.applicationCatalogFetchedAt);
 }
 
 class UsersCompanion extends UpdateCompanion<User> {
@@ -798,6 +853,7 @@ class UsersCompanion extends UpdateCompanion<User> {
   final Value<DateTime?> semestersFetchedAt;
   final Value<DateTime?> scoreDataFetchedAt;
   final Value<DateTime?> calendarFetchedAt;
+  final Value<DateTime?> applicationCatalogFetchedAt;
   const UsersCompanion({
     this.id = const Value.absent(),
     this.fetchedAt = const Value.absent(),
@@ -815,6 +871,7 @@ class UsersCompanion extends UpdateCompanion<User> {
     this.semestersFetchedAt = const Value.absent(),
     this.scoreDataFetchedAt = const Value.absent(),
     this.calendarFetchedAt = const Value.absent(),
+    this.applicationCatalogFetchedAt = const Value.absent(),
   });
   UsersCompanion.insert({
     this.id = const Value.absent(),
@@ -833,6 +890,7 @@ class UsersCompanion extends UpdateCompanion<User> {
     this.semestersFetchedAt = const Value.absent(),
     this.scoreDataFetchedAt = const Value.absent(),
     this.calendarFetchedAt = const Value.absent(),
+    this.applicationCatalogFetchedAt = const Value.absent(),
   }) : studentId = Value(studentId),
        nameZh = Value(nameZh),
        avatarFilename = Value(avatarFilename),
@@ -854,6 +912,7 @@ class UsersCompanion extends UpdateCompanion<User> {
     Expression<DateTime>? semestersFetchedAt,
     Expression<DateTime>? scoreDataFetchedAt,
     Expression<DateTime>? calendarFetchedAt,
+    Expression<DateTime>? applicationCatalogFetchedAt,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -875,6 +934,8 @@ class UsersCompanion extends UpdateCompanion<User> {
       if (scoreDataFetchedAt != null)
         'score_data_fetched_at': scoreDataFetchedAt,
       if (calendarFetchedAt != null) 'calendar_fetched_at': calendarFetchedAt,
+      if (applicationCatalogFetchedAt != null)
+        'application_catalog_fetched_at': applicationCatalogFetchedAt,
     });
   }
 
@@ -895,6 +956,7 @@ class UsersCompanion extends UpdateCompanion<User> {
     Value<DateTime?>? semestersFetchedAt,
     Value<DateTime?>? scoreDataFetchedAt,
     Value<DateTime?>? calendarFetchedAt,
+    Value<DateTime?>? applicationCatalogFetchedAt,
   }) {
     return UsersCompanion(
       id: id ?? this.id,
@@ -914,6 +976,8 @@ class UsersCompanion extends UpdateCompanion<User> {
       semestersFetchedAt: semestersFetchedAt ?? this.semestersFetchedAt,
       scoreDataFetchedAt: scoreDataFetchedAt ?? this.scoreDataFetchedAt,
       calendarFetchedAt: calendarFetchedAt ?? this.calendarFetchedAt,
+      applicationCatalogFetchedAt:
+          applicationCatalogFetchedAt ?? this.applicationCatalogFetchedAt,
     );
   }
 
@@ -974,6 +1038,11 @@ class UsersCompanion extends UpdateCompanion<User> {
     if (calendarFetchedAt.present) {
       map['calendar_fetched_at'] = Variable<DateTime>(calendarFetchedAt.value);
     }
+    if (applicationCatalogFetchedAt.present) {
+      map['application_catalog_fetched_at'] = Variable<DateTime>(
+        applicationCatalogFetchedAt.value,
+      );
+    }
     return map;
   }
 
@@ -995,7 +1064,1042 @@ class UsersCompanion extends UpdateCompanion<User> {
           ..write('passwordExpiresInDays: $passwordExpiresInDays, ')
           ..write('semestersFetchedAt: $semestersFetchedAt, ')
           ..write('scoreDataFetchedAt: $scoreDataFetchedAt, ')
-          ..write('calendarFetchedAt: $calendarFetchedAt')
+          ..write('calendarFetchedAt: $calendarFetchedAt, ')
+          ..write('applicationCatalogFetchedAt: $applicationCatalogFetchedAt')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $PortalApplicationCategoriesTable extends PortalApplicationCategories
+    with
+        TableInfo<
+          $PortalApplicationCategoriesTable,
+          PortalApplicationCategory
+        > {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PortalApplicationCategoriesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _userMeta = const VerificationMeta('user');
+  @override
+  late final GeneratedColumn<int> user = GeneratedColumn<int>(
+    'user',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES users (id) ON DELETE CASCADE',
+    ),
+  );
+  static const VerificationMeta _distinguishedNameMeta = const VerificationMeta(
+    'distinguishedName',
+  );
+  @override
+  late final GeneratedColumn<String> distinguishedName =
+      GeneratedColumn<String>(
+        'distinguished_name',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _positionMeta = const VerificationMeta(
+    'position',
+  );
+  @override
+  late final GeneratedColumn<int> position = GeneratedColumn<int>(
+    'position',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    user,
+    distinguishedName,
+    name,
+    position,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'portal_application_categories';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<PortalApplicationCategory> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('user')) {
+      context.handle(
+        _userMeta,
+        user.isAcceptableOrUnknown(data['user']!, _userMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_userMeta);
+    }
+    if (data.containsKey('distinguished_name')) {
+      context.handle(
+        _distinguishedNameMeta,
+        distinguishedName.isAcceptableOrUnknown(
+          data['distinguished_name']!,
+          _distinguishedNameMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_distinguishedNameMeta);
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('position')) {
+      context.handle(
+        _positionMeta,
+        position.isAcceptableOrUnknown(data['position']!, _positionMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_positionMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  List<Set<GeneratedColumn>> get uniqueKeys => [
+    {user, distinguishedName},
+  ];
+  @override
+  PortalApplicationCategory map(
+    Map<String, dynamic> data, {
+    String? tablePrefix,
+  }) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PortalApplicationCategory(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      user: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}user'],
+      )!,
+      distinguishedName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}distinguished_name'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      )!,
+      position: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}position'],
+      )!,
+    );
+  }
+
+  @override
+  $PortalApplicationCategoriesTable createAlias(String alias) {
+    return $PortalApplicationCategoriesTable(attachedDatabase, alias);
+  }
+}
+
+class PortalApplicationCategory extends DataClass
+    implements Insertable<PortalApplicationCategory> {
+  /// Auto-incrementing primary key.
+  final int id;
+
+  /// User whose portal account exposed this category.
+  final int user;
+
+  /// LDAP distinguished name used by the portal to fetch this category.
+  final String distinguishedName;
+
+  /// Category display name supplied by the portal.
+  final String name;
+
+  /// Display order supplied by the portal.
+  final int position;
+  const PortalApplicationCategory({
+    required this.id,
+    required this.user,
+    required this.distinguishedName,
+    required this.name,
+    required this.position,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['user'] = Variable<int>(user);
+    map['distinguished_name'] = Variable<String>(distinguishedName);
+    map['name'] = Variable<String>(name);
+    map['position'] = Variable<int>(position);
+    return map;
+  }
+
+  PortalApplicationCategoriesCompanion toCompanion(bool nullToAbsent) {
+    return PortalApplicationCategoriesCompanion(
+      id: Value(id),
+      user: Value(user),
+      distinguishedName: Value(distinguishedName),
+      name: Value(name),
+      position: Value(position),
+    );
+  }
+
+  factory PortalApplicationCategory.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PortalApplicationCategory(
+      id: serializer.fromJson<int>(json['id']),
+      user: serializer.fromJson<int>(json['user']),
+      distinguishedName: serializer.fromJson<String>(json['distinguishedName']),
+      name: serializer.fromJson<String>(json['name']),
+      position: serializer.fromJson<int>(json['position']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'user': serializer.toJson<int>(user),
+      'distinguishedName': serializer.toJson<String>(distinguishedName),
+      'name': serializer.toJson<String>(name),
+      'position': serializer.toJson<int>(position),
+    };
+  }
+
+  PortalApplicationCategory copyWith({
+    int? id,
+    int? user,
+    String? distinguishedName,
+    String? name,
+    int? position,
+  }) => PortalApplicationCategory(
+    id: id ?? this.id,
+    user: user ?? this.user,
+    distinguishedName: distinguishedName ?? this.distinguishedName,
+    name: name ?? this.name,
+    position: position ?? this.position,
+  );
+  PortalApplicationCategory copyWithCompanion(
+    PortalApplicationCategoriesCompanion data,
+  ) {
+    return PortalApplicationCategory(
+      id: data.id.present ? data.id.value : this.id,
+      user: data.user.present ? data.user.value : this.user,
+      distinguishedName: data.distinguishedName.present
+          ? data.distinguishedName.value
+          : this.distinguishedName,
+      name: data.name.present ? data.name.value : this.name,
+      position: data.position.present ? data.position.value : this.position,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PortalApplicationCategory(')
+          ..write('id: $id, ')
+          ..write('user: $user, ')
+          ..write('distinguishedName: $distinguishedName, ')
+          ..write('name: $name, ')
+          ..write('position: $position')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, user, distinguishedName, name, position);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PortalApplicationCategory &&
+          other.id == this.id &&
+          other.user == this.user &&
+          other.distinguishedName == this.distinguishedName &&
+          other.name == this.name &&
+          other.position == this.position);
+}
+
+class PortalApplicationCategoriesCompanion
+    extends UpdateCompanion<PortalApplicationCategory> {
+  final Value<int> id;
+  final Value<int> user;
+  final Value<String> distinguishedName;
+  final Value<String> name;
+  final Value<int> position;
+  const PortalApplicationCategoriesCompanion({
+    this.id = const Value.absent(),
+    this.user = const Value.absent(),
+    this.distinguishedName = const Value.absent(),
+    this.name = const Value.absent(),
+    this.position = const Value.absent(),
+  });
+  PortalApplicationCategoriesCompanion.insert({
+    this.id = const Value.absent(),
+    required int user,
+    required String distinguishedName,
+    required String name,
+    required int position,
+  }) : user = Value(user),
+       distinguishedName = Value(distinguishedName),
+       name = Value(name),
+       position = Value(position);
+  static Insertable<PortalApplicationCategory> custom({
+    Expression<int>? id,
+    Expression<int>? user,
+    Expression<String>? distinguishedName,
+    Expression<String>? name,
+    Expression<int>? position,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (user != null) 'user': user,
+      if (distinguishedName != null) 'distinguished_name': distinguishedName,
+      if (name != null) 'name': name,
+      if (position != null) 'position': position,
+    });
+  }
+
+  PortalApplicationCategoriesCompanion copyWith({
+    Value<int>? id,
+    Value<int>? user,
+    Value<String>? distinguishedName,
+    Value<String>? name,
+    Value<int>? position,
+  }) {
+    return PortalApplicationCategoriesCompanion(
+      id: id ?? this.id,
+      user: user ?? this.user,
+      distinguishedName: distinguishedName ?? this.distinguishedName,
+      name: name ?? this.name,
+      position: position ?? this.position,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (user.present) {
+      map['user'] = Variable<int>(user.value);
+    }
+    if (distinguishedName.present) {
+      map['distinguished_name'] = Variable<String>(distinguishedName.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (position.present) {
+      map['position'] = Variable<int>(position.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PortalApplicationCategoriesCompanion(')
+          ..write('id: $id, ')
+          ..write('user: $user, ')
+          ..write('distinguishedName: $distinguishedName, ')
+          ..write('name: $name, ')
+          ..write('position: $position')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $PortalApplicationsTable extends PortalApplications
+    with TableInfo<$PortalApplicationsTable, PortalApplication> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PortalApplicationsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _categoryMeta = const VerificationMeta(
+    'category',
+  );
+  @override
+  late final GeneratedColumn<int> category = GeneratedColumn<int>(
+    'category',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES portal_application_categories (id) ON DELETE CASCADE',
+    ),
+  );
+  static const VerificationMeta _codeMeta = const VerificationMeta('code');
+  @override
+  late final GeneratedColumn<String> code = GeneratedColumn<String>(
+    'code',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _iconUrlMeta = const VerificationMeta(
+    'iconUrl',
+  );
+  @override
+  late final GeneratedColumn<String> iconUrl = GeneratedColumn<String>(
+    'icon_url',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _positionMeta = const VerificationMeta(
+    'position',
+  );
+  @override
+  late final GeneratedColumn<int> position = GeneratedColumn<int>(
+    'position',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    category,
+    code,
+    name,
+    iconUrl,
+    position,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'portal_applications';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<PortalApplication> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('category')) {
+      context.handle(
+        _categoryMeta,
+        category.isAcceptableOrUnknown(data['category']!, _categoryMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_categoryMeta);
+    }
+    if (data.containsKey('code')) {
+      context.handle(
+        _codeMeta,
+        code.isAcceptableOrUnknown(data['code']!, _codeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_codeMeta);
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('icon_url')) {
+      context.handle(
+        _iconUrlMeta,
+        iconUrl.isAcceptableOrUnknown(data['icon_url']!, _iconUrlMeta),
+      );
+    }
+    if (data.containsKey('position')) {
+      context.handle(
+        _positionMeta,
+        position.isAcceptableOrUnknown(data['position']!, _positionMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_positionMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  List<Set<GeneratedColumn>> get uniqueKeys => [
+    {category, code},
+  ];
+  @override
+  PortalApplication map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PortalApplication(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      category: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}category'],
+      )!,
+      code: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}code'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      )!,
+      iconUrl: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}icon_url'],
+      ),
+      position: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}position'],
+      )!,
+    );
+  }
+
+  @override
+  $PortalApplicationsTable createAlias(String alias) {
+    return $PortalApplicationsTable(attachedDatabase, alias);
+  }
+}
+
+class PortalApplication extends DataClass
+    implements Insertable<PortalApplication> {
+  /// Auto-incrementing primary key.
+  final int id;
+
+  /// Category containing this application.
+  final int category;
+
+  /// Portal SSO target identifier (`apOu`).
+  final String code;
+
+  /// Application display name supplied by the portal.
+  final String name;
+
+  /// Absolute URL of the portal-provided application icon.
+  final String? iconUrl;
+
+  /// Display order within the category.
+  final int position;
+  const PortalApplication({
+    required this.id,
+    required this.category,
+    required this.code,
+    required this.name,
+    this.iconUrl,
+    required this.position,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['category'] = Variable<int>(category);
+    map['code'] = Variable<String>(code);
+    map['name'] = Variable<String>(name);
+    if (!nullToAbsent || iconUrl != null) {
+      map['icon_url'] = Variable<String>(iconUrl);
+    }
+    map['position'] = Variable<int>(position);
+    return map;
+  }
+
+  PortalApplicationsCompanion toCompanion(bool nullToAbsent) {
+    return PortalApplicationsCompanion(
+      id: Value(id),
+      category: Value(category),
+      code: Value(code),
+      name: Value(name),
+      iconUrl: iconUrl == null && nullToAbsent
+          ? const Value.absent()
+          : Value(iconUrl),
+      position: Value(position),
+    );
+  }
+
+  factory PortalApplication.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PortalApplication(
+      id: serializer.fromJson<int>(json['id']),
+      category: serializer.fromJson<int>(json['category']),
+      code: serializer.fromJson<String>(json['code']),
+      name: serializer.fromJson<String>(json['name']),
+      iconUrl: serializer.fromJson<String?>(json['iconUrl']),
+      position: serializer.fromJson<int>(json['position']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'category': serializer.toJson<int>(category),
+      'code': serializer.toJson<String>(code),
+      'name': serializer.toJson<String>(name),
+      'iconUrl': serializer.toJson<String?>(iconUrl),
+      'position': serializer.toJson<int>(position),
+    };
+  }
+
+  PortalApplication copyWith({
+    int? id,
+    int? category,
+    String? code,
+    String? name,
+    Value<String?> iconUrl = const Value.absent(),
+    int? position,
+  }) => PortalApplication(
+    id: id ?? this.id,
+    category: category ?? this.category,
+    code: code ?? this.code,
+    name: name ?? this.name,
+    iconUrl: iconUrl.present ? iconUrl.value : this.iconUrl,
+    position: position ?? this.position,
+  );
+  PortalApplication copyWithCompanion(PortalApplicationsCompanion data) {
+    return PortalApplication(
+      id: data.id.present ? data.id.value : this.id,
+      category: data.category.present ? data.category.value : this.category,
+      code: data.code.present ? data.code.value : this.code,
+      name: data.name.present ? data.name.value : this.name,
+      iconUrl: data.iconUrl.present ? data.iconUrl.value : this.iconUrl,
+      position: data.position.present ? data.position.value : this.position,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PortalApplication(')
+          ..write('id: $id, ')
+          ..write('category: $category, ')
+          ..write('code: $code, ')
+          ..write('name: $name, ')
+          ..write('iconUrl: $iconUrl, ')
+          ..write('position: $position')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, category, code, name, iconUrl, position);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PortalApplication &&
+          other.id == this.id &&
+          other.category == this.category &&
+          other.code == this.code &&
+          other.name == this.name &&
+          other.iconUrl == this.iconUrl &&
+          other.position == this.position);
+}
+
+class PortalApplicationsCompanion extends UpdateCompanion<PortalApplication> {
+  final Value<int> id;
+  final Value<int> category;
+  final Value<String> code;
+  final Value<String> name;
+  final Value<String?> iconUrl;
+  final Value<int> position;
+  const PortalApplicationsCompanion({
+    this.id = const Value.absent(),
+    this.category = const Value.absent(),
+    this.code = const Value.absent(),
+    this.name = const Value.absent(),
+    this.iconUrl = const Value.absent(),
+    this.position = const Value.absent(),
+  });
+  PortalApplicationsCompanion.insert({
+    this.id = const Value.absent(),
+    required int category,
+    required String code,
+    required String name,
+    this.iconUrl = const Value.absent(),
+    required int position,
+  }) : category = Value(category),
+       code = Value(code),
+       name = Value(name),
+       position = Value(position);
+  static Insertable<PortalApplication> custom({
+    Expression<int>? id,
+    Expression<int>? category,
+    Expression<String>? code,
+    Expression<String>? name,
+    Expression<String>? iconUrl,
+    Expression<int>? position,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (category != null) 'category': category,
+      if (code != null) 'code': code,
+      if (name != null) 'name': name,
+      if (iconUrl != null) 'icon_url': iconUrl,
+      if (position != null) 'position': position,
+    });
+  }
+
+  PortalApplicationsCompanion copyWith({
+    Value<int>? id,
+    Value<int>? category,
+    Value<String>? code,
+    Value<String>? name,
+    Value<String?>? iconUrl,
+    Value<int>? position,
+  }) {
+    return PortalApplicationsCompanion(
+      id: id ?? this.id,
+      category: category ?? this.category,
+      code: code ?? this.code,
+      name: name ?? this.name,
+      iconUrl: iconUrl ?? this.iconUrl,
+      position: position ?? this.position,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (category.present) {
+      map['category'] = Variable<int>(category.value);
+    }
+    if (code.present) {
+      map['code'] = Variable<String>(code.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (iconUrl.present) {
+      map['icon_url'] = Variable<String>(iconUrl.value);
+    }
+    if (position.present) {
+      map['position'] = Variable<int>(position.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PortalApplicationsCompanion(')
+          ..write('id: $id, ')
+          ..write('category: $category, ')
+          ..write('code: $code, ')
+          ..write('name: $name, ')
+          ..write('iconUrl: $iconUrl, ')
+          ..write('position: $position')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $PortalApplicationFavoritesTable extends PortalApplicationFavorites
+    with
+        TableInfo<$PortalApplicationFavoritesTable, PortalApplicationFavorite> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PortalApplicationFavoritesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _userMeta = const VerificationMeta('user');
+  @override
+  late final GeneratedColumn<int> user = GeneratedColumn<int>(
+    'user',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES users (id) ON DELETE CASCADE',
+    ),
+  );
+  static const VerificationMeta _applicationCodeMeta = const VerificationMeta(
+    'applicationCode',
+  );
+  @override
+  late final GeneratedColumn<String> applicationCode = GeneratedColumn<String>(
+    'application_code',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [user, applicationCode];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'portal_application_favorites';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<PortalApplicationFavorite> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('user')) {
+      context.handle(
+        _userMeta,
+        user.isAcceptableOrUnknown(data['user']!, _userMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_userMeta);
+    }
+    if (data.containsKey('application_code')) {
+      context.handle(
+        _applicationCodeMeta,
+        applicationCode.isAcceptableOrUnknown(
+          data['application_code']!,
+          _applicationCodeMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_applicationCodeMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {user, applicationCode};
+  @override
+  PortalApplicationFavorite map(
+    Map<String, dynamic> data, {
+    String? tablePrefix,
+  }) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PortalApplicationFavorite(
+      user: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}user'],
+      )!,
+      applicationCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}application_code'],
+      )!,
+    );
+  }
+
+  @override
+  $PortalApplicationFavoritesTable createAlias(String alias) {
+    return $PortalApplicationFavoritesTable(attachedDatabase, alias);
+  }
+}
+
+class PortalApplicationFavorite extends DataClass
+    implements Insertable<PortalApplicationFavorite> {
+  /// User who selected this favorite.
+  final int user;
+
+  /// Portal SSO target identifier (`apOu`).
+  final String applicationCode;
+  const PortalApplicationFavorite({
+    required this.user,
+    required this.applicationCode,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['user'] = Variable<int>(user);
+    map['application_code'] = Variable<String>(applicationCode);
+    return map;
+  }
+
+  PortalApplicationFavoritesCompanion toCompanion(bool nullToAbsent) {
+    return PortalApplicationFavoritesCompanion(
+      user: Value(user),
+      applicationCode: Value(applicationCode),
+    );
+  }
+
+  factory PortalApplicationFavorite.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PortalApplicationFavorite(
+      user: serializer.fromJson<int>(json['user']),
+      applicationCode: serializer.fromJson<String>(json['applicationCode']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'user': serializer.toJson<int>(user),
+      'applicationCode': serializer.toJson<String>(applicationCode),
+    };
+  }
+
+  PortalApplicationFavorite copyWith({int? user, String? applicationCode}) =>
+      PortalApplicationFavorite(
+        user: user ?? this.user,
+        applicationCode: applicationCode ?? this.applicationCode,
+      );
+  PortalApplicationFavorite copyWithCompanion(
+    PortalApplicationFavoritesCompanion data,
+  ) {
+    return PortalApplicationFavorite(
+      user: data.user.present ? data.user.value : this.user,
+      applicationCode: data.applicationCode.present
+          ? data.applicationCode.value
+          : this.applicationCode,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PortalApplicationFavorite(')
+          ..write('user: $user, ')
+          ..write('applicationCode: $applicationCode')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(user, applicationCode);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PortalApplicationFavorite &&
+          other.user == this.user &&
+          other.applicationCode == this.applicationCode);
+}
+
+class PortalApplicationFavoritesCompanion
+    extends UpdateCompanion<PortalApplicationFavorite> {
+  final Value<int> user;
+  final Value<String> applicationCode;
+  final Value<int> rowid;
+  const PortalApplicationFavoritesCompanion({
+    this.user = const Value.absent(),
+    this.applicationCode = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  PortalApplicationFavoritesCompanion.insert({
+    required int user,
+    required String applicationCode,
+    this.rowid = const Value.absent(),
+  }) : user = Value(user),
+       applicationCode = Value(applicationCode);
+  static Insertable<PortalApplicationFavorite> custom({
+    Expression<int>? user,
+    Expression<String>? applicationCode,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (user != null) 'user': user,
+      if (applicationCode != null) 'application_code': applicationCode,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  PortalApplicationFavoritesCompanion copyWith({
+    Value<int>? user,
+    Value<String>? applicationCode,
+    Value<int>? rowid,
+  }) {
+    return PortalApplicationFavoritesCompanion(
+      user: user ?? this.user,
+      applicationCode: applicationCode ?? this.applicationCode,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (user.present) {
+      map['user'] = Variable<int>(user.value);
+    }
+    if (applicationCode.present) {
+      map['application_code'] = Variable<String>(applicationCode.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PortalApplicationFavoritesCompanion(')
+          ..write('user: $user, ')
+          ..write('applicationCode: $applicationCode, ')
+          ..write('rowid: $rowid')
           ..write(')'))
         .toString();
   }
@@ -12316,6 +13420,12 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
   late final $UsersTable users = $UsersTable(this);
+  late final $PortalApplicationCategoriesTable portalApplicationCategories =
+      $PortalApplicationCategoriesTable(this);
+  late final $PortalApplicationsTable portalApplications =
+      $PortalApplicationsTable(this);
+  late final $PortalApplicationFavoritesTable portalApplicationFavorites =
+      $PortalApplicationFavoritesTable(this);
   late final $StudentsTable students = $StudentsTable(this);
   late final $SemestersTable semesters = $SemestersTable(this);
   late final $CoursesTable courses = $CoursesTable(this);
@@ -12403,6 +13513,9 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   @override
   List<DatabaseSchemaEntity> get allSchemaEntities => [
     users,
+    portalApplicationCategories,
+    portalApplications,
+    portalApplicationFavorites,
     students,
     semesters,
     courses,
@@ -12442,6 +13555,31 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'users',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [
+        TableUpdate('portal_application_categories', kind: UpdateKind.delete),
+      ],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'portal_application_categories',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('portal_applications', kind: UpdateKind.delete)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'users',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [
+        TableUpdate('portal_application_favorites', kind: UpdateKind.delete),
+      ],
+    ),
     WritePropagation(
       on: TableUpdateQuery.onTableName(
         'course_offerings',
@@ -12551,6 +13689,7 @@ typedef $$UsersTableCreateCompanionBuilder =
       Value<DateTime?> semestersFetchedAt,
       Value<DateTime?> scoreDataFetchedAt,
       Value<DateTime?> calendarFetchedAt,
+      Value<DateTime?> applicationCatalogFetchedAt,
     });
 typedef $$UsersTableUpdateCompanionBuilder =
     UsersCompanion Function({
@@ -12570,11 +13709,62 @@ typedef $$UsersTableUpdateCompanionBuilder =
       Value<DateTime?> semestersFetchedAt,
       Value<DateTime?> scoreDataFetchedAt,
       Value<DateTime?> calendarFetchedAt,
+      Value<DateTime?> applicationCatalogFetchedAt,
     });
 
 final class $$UsersTableReferences
     extends BaseReferences<_$AppDatabase, $UsersTable, User> {
   $$UsersTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<
+    $PortalApplicationCategoriesTable,
+    List<PortalApplicationCategory>
+  >
+  _portalApplicationCategoriesRefsTable(_$AppDatabase db) =>
+      MultiTypedResultKey.fromTable(
+        db.portalApplicationCategories,
+        aliasName: 'users__id__portal_application_categories__user',
+      );
+
+  $$PortalApplicationCategoriesTableProcessedTableManager
+  get portalApplicationCategoriesRefs {
+    final manager = $$PortalApplicationCategoriesTableTableManager(
+      $_db,
+      $_db.portalApplicationCategories,
+    ).filter((f) => f.user.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _portalApplicationCategoriesRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+
+  static MultiTypedResultKey<
+    $PortalApplicationFavoritesTable,
+    List<PortalApplicationFavorite>
+  >
+  _portalApplicationFavoritesRefsTable(_$AppDatabase db) =>
+      MultiTypedResultKey.fromTable(
+        db.portalApplicationFavorites,
+        aliasName: 'users__id__portal_application_favorites__user',
+      );
+
+  $$PortalApplicationFavoritesTableProcessedTableManager
+  get portalApplicationFavoritesRefs {
+    final manager = $$PortalApplicationFavoritesTableTableManager(
+      $_db,
+      $_db.portalApplicationFavorites,
+    ).filter((f) => f.user.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _portalApplicationFavoritesRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
 
   static MultiTypedResultKey<$ScoresTable, List<Score>> _scoresRefsTable(
     _$AppDatabase db,
@@ -12708,6 +13898,67 @@ class $$UsersTableFilterComposer extends Composer<_$AppDatabase, $UsersTable> {
     column: $table.calendarFetchedAt,
     builder: (column) => ColumnFilters(column),
   );
+
+  ColumnFilters<DateTime> get applicationCatalogFetchedAt => $composableBuilder(
+    column: $table.applicationCatalogFetchedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  Expression<bool> portalApplicationCategoriesRefs(
+    Expression<bool> Function(
+      $$PortalApplicationCategoriesTableFilterComposer f,
+    )
+    f,
+  ) {
+    final $$PortalApplicationCategoriesTableFilterComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.portalApplicationCategories,
+          getReferencedColumn: (t) => t.user,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$PortalApplicationCategoriesTableFilterComposer(
+                $db: $db,
+                $table: $db.portalApplicationCategories,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return f(composer);
+  }
+
+  Expression<bool> portalApplicationFavoritesRefs(
+    Expression<bool> Function($$PortalApplicationFavoritesTableFilterComposer f)
+    f,
+  ) {
+    final $$PortalApplicationFavoritesTableFilterComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.portalApplicationFavorites,
+          getReferencedColumn: (t) => t.user,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$PortalApplicationFavoritesTableFilterComposer(
+                $db: $db,
+                $table: $db.portalApplicationFavorites,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return f(composer);
+  }
 
   Expression<bool> scoresRefs(
     Expression<bool> Function($$ScoresTableFilterComposer f) f,
@@ -12849,6 +14100,12 @@ class $$UsersTableOrderingComposer
     column: $table.calendarFetchedAt,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<DateTime> get applicationCatalogFetchedAt =>
+      $composableBuilder(
+        column: $table.applicationCatalogFetchedAt,
+        builder: (column) => ColumnOrderings(column),
+      );
 }
 
 class $$UsersTableAnnotationComposer
@@ -12924,6 +14181,70 @@ class $$UsersTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<DateTime> get applicationCatalogFetchedAt =>
+      $composableBuilder(
+        column: $table.applicationCatalogFetchedAt,
+        builder: (column) => column,
+      );
+
+  Expression<T> portalApplicationCategoriesRefs<T extends Object>(
+    Expression<T> Function(
+      $$PortalApplicationCategoriesTableAnnotationComposer a,
+    )
+    f,
+  ) {
+    final $$PortalApplicationCategoriesTableAnnotationComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.portalApplicationCategories,
+          getReferencedColumn: (t) => t.user,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$PortalApplicationCategoriesTableAnnotationComposer(
+                $db: $db,
+                $table: $db.portalApplicationCategories,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return f(composer);
+  }
+
+  Expression<T> portalApplicationFavoritesRefs<T extends Object>(
+    Expression<T> Function(
+      $$PortalApplicationFavoritesTableAnnotationComposer a,
+    )
+    f,
+  ) {
+    final $$PortalApplicationFavoritesTableAnnotationComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.portalApplicationFavorites,
+          getReferencedColumn: (t) => t.user,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$PortalApplicationFavoritesTableAnnotationComposer(
+                $db: $db,
+                $table: $db.portalApplicationFavorites,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return f(composer);
+  }
+
   Expression<T> scoresRefs<T extends Object>(
     Expression<T> Function($$ScoresTableAnnotationComposer a) f,
   ) {
@@ -12990,6 +14311,8 @@ class $$UsersTableTableManager
           (User, $$UsersTableReferences),
           User,
           PrefetchHooks Function({
+            bool portalApplicationCategoriesRefs,
+            bool portalApplicationFavoritesRefs,
             bool scoresRefs,
             bool userSemesterSummariesRefs,
           })
@@ -13023,6 +14346,8 @@ class $$UsersTableTableManager
                 Value<DateTime?> semestersFetchedAt = const Value.absent(),
                 Value<DateTime?> scoreDataFetchedAt = const Value.absent(),
                 Value<DateTime?> calendarFetchedAt = const Value.absent(),
+                Value<DateTime?> applicationCatalogFetchedAt =
+                    const Value.absent(),
               }) => UsersCompanion(
                 id: id,
                 fetchedAt: fetchedAt,
@@ -13040,6 +14365,7 @@ class $$UsersTableTableManager
                 semestersFetchedAt: semestersFetchedAt,
                 scoreDataFetchedAt: scoreDataFetchedAt,
                 calendarFetchedAt: calendarFetchedAt,
+                applicationCatalogFetchedAt: applicationCatalogFetchedAt,
               ),
           createCompanionCallback:
               ({
@@ -13059,6 +14385,8 @@ class $$UsersTableTableManager
                 Value<DateTime?> semestersFetchedAt = const Value.absent(),
                 Value<DateTime?> scoreDataFetchedAt = const Value.absent(),
                 Value<DateTime?> calendarFetchedAt = const Value.absent(),
+                Value<DateTime?> applicationCatalogFetchedAt =
+                    const Value.absent(),
               }) => UsersCompanion.insert(
                 id: id,
                 fetchedAt: fetchedAt,
@@ -13076,6 +14404,7 @@ class $$UsersTableTableManager
                 semestersFetchedAt: semestersFetchedAt,
                 scoreDataFetchedAt: scoreDataFetchedAt,
                 calendarFetchedAt: calendarFetchedAt,
+                applicationCatalogFetchedAt: applicationCatalogFetchedAt,
               ),
           withReferenceMapper: (p0) => p0
               .map(
@@ -13084,16 +14413,67 @@ class $$UsersTableTableManager
               )
               .toList(),
           prefetchHooksCallback:
-              ({scoresRefs = false, userSemesterSummariesRefs = false}) {
+              ({
+                portalApplicationCategoriesRefs = false,
+                portalApplicationFavoritesRefs = false,
+                scoresRefs = false,
+                userSemesterSummariesRefs = false,
+              }) {
                 return PrefetchHooks(
                   db: db,
                   explicitlyWatchedTables: [
+                    if (portalApplicationCategoriesRefs)
+                      db.portalApplicationCategories,
+                    if (portalApplicationFavoritesRefs)
+                      db.portalApplicationFavorites,
                     if (scoresRefs) db.scores,
                     if (userSemesterSummariesRefs) db.userSemesterSummaries,
                   ],
                   addJoins: null,
                   getPrefetchedDataCallback: (items) async {
                     return [
+                      if (portalApplicationCategoriesRefs)
+                        await $_getPrefetchedData<
+                          User,
+                          $UsersTable,
+                          PortalApplicationCategory
+                        >(
+                          currentTable: table,
+                          referencedTable: $$UsersTableReferences
+                              ._portalApplicationCategoriesRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$UsersTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).portalApplicationCategoriesRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.user == item.id,
+                              ),
+                          typedResults: items,
+                        ),
+                      if (portalApplicationFavoritesRefs)
+                        await $_getPrefetchedData<
+                          User,
+                          $UsersTable,
+                          PortalApplicationFavorite
+                        >(
+                          currentTable: table,
+                          referencedTable: $$UsersTableReferences
+                              ._portalApplicationFavoritesRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$UsersTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).portalApplicationFavoritesRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.user == item.id,
+                              ),
+                          typedResults: items,
+                        ),
                       if (scoresRefs)
                         await $_getPrefetchedData<User, $UsersTable, Score>(
                           currentTable: table,
@@ -13148,7 +14528,1084 @@ typedef $$UsersTableProcessedTableManager =
       $$UsersTableUpdateCompanionBuilder,
       (User, $$UsersTableReferences),
       User,
-      PrefetchHooks Function({bool scoresRefs, bool userSemesterSummariesRefs})
+      PrefetchHooks Function({
+        bool portalApplicationCategoriesRefs,
+        bool portalApplicationFavoritesRefs,
+        bool scoresRefs,
+        bool userSemesterSummariesRefs,
+      })
+    >;
+typedef $$PortalApplicationCategoriesTableCreateCompanionBuilder =
+    PortalApplicationCategoriesCompanion Function({
+      Value<int> id,
+      required int user,
+      required String distinguishedName,
+      required String name,
+      required int position,
+    });
+typedef $$PortalApplicationCategoriesTableUpdateCompanionBuilder =
+    PortalApplicationCategoriesCompanion Function({
+      Value<int> id,
+      Value<int> user,
+      Value<String> distinguishedName,
+      Value<String> name,
+      Value<int> position,
+    });
+
+final class $$PortalApplicationCategoriesTableReferences
+    extends
+        BaseReferences<
+          _$AppDatabase,
+          $PortalApplicationCategoriesTable,
+          PortalApplicationCategory
+        > {
+  $$PortalApplicationCategoriesTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static $UsersTable _userTable(_$AppDatabase db) =>
+      db.users.createAlias('portal_application_categories__user__users__id');
+
+  $$UsersTableProcessedTableManager get user {
+    final $_column = $_itemColumn<int>('user')!;
+
+    final manager = $$UsersTableTableManager(
+      $_db,
+      $_db.users,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_userTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static MultiTypedResultKey<$PortalApplicationsTable, List<PortalApplication>>
+  _portalApplicationsRefsTable(_$AppDatabase db) =>
+      MultiTypedResultKey.fromTable(
+        db.portalApplications,
+        aliasName:
+            'portal_application_categories__id__portal_applications__category',
+      );
+
+  $$PortalApplicationsTableProcessedTableManager get portalApplicationsRefs {
+    final manager = $$PortalApplicationsTableTableManager(
+      $_db,
+      $_db.portalApplications,
+    ).filter((f) => f.category.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _portalApplicationsRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
+
+class $$PortalApplicationCategoriesTableFilterComposer
+    extends Composer<_$AppDatabase, $PortalApplicationCategoriesTable> {
+  $$PortalApplicationCategoriesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get distinguishedName => $composableBuilder(
+    column: $table.distinguishedName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get position => $composableBuilder(
+    column: $table.position,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$UsersTableFilterComposer get user {
+    final $$UsersTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.user,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableFilterComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  Expression<bool> portalApplicationsRefs(
+    Expression<bool> Function($$PortalApplicationsTableFilterComposer f) f,
+  ) {
+    final $$PortalApplicationsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.portalApplications,
+      getReferencedColumn: (t) => t.category,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$PortalApplicationsTableFilterComposer(
+            $db: $db,
+            $table: $db.portalApplications,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$PortalApplicationCategoriesTableOrderingComposer
+    extends Composer<_$AppDatabase, $PortalApplicationCategoriesTable> {
+  $$PortalApplicationCategoriesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get distinguishedName => $composableBuilder(
+    column: $table.distinguishedName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get position => $composableBuilder(
+    column: $table.position,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$UsersTableOrderingComposer get user {
+    final $$UsersTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.user,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableOrderingComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$PortalApplicationCategoriesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $PortalApplicationCategoriesTable> {
+  $$PortalApplicationCategoriesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get distinguishedName => $composableBuilder(
+    column: $table.distinguishedName,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get name =>
+      $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumn<int> get position =>
+      $composableBuilder(column: $table.position, builder: (column) => column);
+
+  $$UsersTableAnnotationComposer get user {
+    final $$UsersTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.user,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableAnnotationComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  Expression<T> portalApplicationsRefs<T extends Object>(
+    Expression<T> Function($$PortalApplicationsTableAnnotationComposer a) f,
+  ) {
+    final $$PortalApplicationsTableAnnotationComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.portalApplications,
+          getReferencedColumn: (t) => t.category,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$PortalApplicationsTableAnnotationComposer(
+                $db: $db,
+                $table: $db.portalApplications,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return f(composer);
+  }
+}
+
+class $$PortalApplicationCategoriesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $PortalApplicationCategoriesTable,
+          PortalApplicationCategory,
+          $$PortalApplicationCategoriesTableFilterComposer,
+          $$PortalApplicationCategoriesTableOrderingComposer,
+          $$PortalApplicationCategoriesTableAnnotationComposer,
+          $$PortalApplicationCategoriesTableCreateCompanionBuilder,
+          $$PortalApplicationCategoriesTableUpdateCompanionBuilder,
+          (
+            PortalApplicationCategory,
+            $$PortalApplicationCategoriesTableReferences,
+          ),
+          PortalApplicationCategory,
+          PrefetchHooks Function({bool user, bool portalApplicationsRefs})
+        > {
+  $$PortalApplicationCategoriesTableTableManager(
+    _$AppDatabase db,
+    $PortalApplicationCategoriesTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PortalApplicationCategoriesTableFilterComposer(
+                $db: db,
+                $table: table,
+              ),
+          createOrderingComposer: () =>
+              $$PortalApplicationCategoriesTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$PortalApplicationCategoriesTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<int> user = const Value.absent(),
+                Value<String> distinguishedName = const Value.absent(),
+                Value<String> name = const Value.absent(),
+                Value<int> position = const Value.absent(),
+              }) => PortalApplicationCategoriesCompanion(
+                id: id,
+                user: user,
+                distinguishedName: distinguishedName,
+                name: name,
+                position: position,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required int user,
+                required String distinguishedName,
+                required String name,
+                required int position,
+              }) => PortalApplicationCategoriesCompanion.insert(
+                id: id,
+                user: user,
+                distinguishedName: distinguishedName,
+                name: name,
+                position: position,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$PortalApplicationCategoriesTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({user = false, portalApplicationsRefs = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [
+                if (portalApplicationsRefs) db.portalApplications,
+              ],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (user) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.user,
+                                referencedTable:
+                                    $$PortalApplicationCategoriesTableReferences
+                                        ._userTable(db),
+                                referencedColumn:
+                                    $$PortalApplicationCategoriesTableReferences
+                                        ._userTable(db)
+                                        .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [
+                  if (portalApplicationsRefs)
+                    await $_getPrefetchedData<
+                      PortalApplicationCategory,
+                      $PortalApplicationCategoriesTable,
+                      PortalApplication
+                    >(
+                      currentTable: table,
+                      referencedTable:
+                          $$PortalApplicationCategoriesTableReferences
+                              ._portalApplicationsRefsTable(db),
+                      managerFromTypedResult: (p0) =>
+                          $$PortalApplicationCategoriesTableReferences(
+                            db,
+                            table,
+                            p0,
+                          ).portalApplicationsRefs,
+                      referencedItemsForCurrentItem: (item, referencedItems) =>
+                          referencedItems.where((e) => e.category == item.id),
+                      typedResults: items,
+                    ),
+                ];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$PortalApplicationCategoriesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $PortalApplicationCategoriesTable,
+      PortalApplicationCategory,
+      $$PortalApplicationCategoriesTableFilterComposer,
+      $$PortalApplicationCategoriesTableOrderingComposer,
+      $$PortalApplicationCategoriesTableAnnotationComposer,
+      $$PortalApplicationCategoriesTableCreateCompanionBuilder,
+      $$PortalApplicationCategoriesTableUpdateCompanionBuilder,
+      (PortalApplicationCategory, $$PortalApplicationCategoriesTableReferences),
+      PortalApplicationCategory,
+      PrefetchHooks Function({bool user, bool portalApplicationsRefs})
+    >;
+typedef $$PortalApplicationsTableCreateCompanionBuilder =
+    PortalApplicationsCompanion Function({
+      Value<int> id,
+      required int category,
+      required String code,
+      required String name,
+      Value<String?> iconUrl,
+      required int position,
+    });
+typedef $$PortalApplicationsTableUpdateCompanionBuilder =
+    PortalApplicationsCompanion Function({
+      Value<int> id,
+      Value<int> category,
+      Value<String> code,
+      Value<String> name,
+      Value<String?> iconUrl,
+      Value<int> position,
+    });
+
+final class $$PortalApplicationsTableReferences
+    extends
+        BaseReferences<
+          _$AppDatabase,
+          $PortalApplicationsTable,
+          PortalApplication
+        > {
+  $$PortalApplicationsTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static $PortalApplicationCategoriesTable _categoryTable(_$AppDatabase db) =>
+      db.portalApplicationCategories.createAlias(
+        'portal_applications__category__portal_application_categories__id',
+      );
+
+  $$PortalApplicationCategoriesTableProcessedTableManager get category {
+    final $_column = $_itemColumn<int>('category')!;
+
+    final manager = $$PortalApplicationCategoriesTableTableManager(
+      $_db,
+      $_db.portalApplicationCategories,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_categoryTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$PortalApplicationsTableFilterComposer
+    extends Composer<_$AppDatabase, $PortalApplicationsTable> {
+  $$PortalApplicationsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get code => $composableBuilder(
+    column: $table.code,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get iconUrl => $composableBuilder(
+    column: $table.iconUrl,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get position => $composableBuilder(
+    column: $table.position,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$PortalApplicationCategoriesTableFilterComposer get category {
+    final $$PortalApplicationCategoriesTableFilterComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.category,
+          referencedTable: $db.portalApplicationCategories,
+          getReferencedColumn: (t) => t.id,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$PortalApplicationCategoriesTableFilterComposer(
+                $db: $db,
+                $table: $db.portalApplicationCategories,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return composer;
+  }
+}
+
+class $$PortalApplicationsTableOrderingComposer
+    extends Composer<_$AppDatabase, $PortalApplicationsTable> {
+  $$PortalApplicationsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get code => $composableBuilder(
+    column: $table.code,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get iconUrl => $composableBuilder(
+    column: $table.iconUrl,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get position => $composableBuilder(
+    column: $table.position,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$PortalApplicationCategoriesTableOrderingComposer get category {
+    final $$PortalApplicationCategoriesTableOrderingComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.category,
+          referencedTable: $db.portalApplicationCategories,
+          getReferencedColumn: (t) => t.id,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$PortalApplicationCategoriesTableOrderingComposer(
+                $db: $db,
+                $table: $db.portalApplicationCategories,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return composer;
+  }
+}
+
+class $$PortalApplicationsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $PortalApplicationsTable> {
+  $$PortalApplicationsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get code =>
+      $composableBuilder(column: $table.code, builder: (column) => column);
+
+  GeneratedColumn<String> get name =>
+      $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumn<String> get iconUrl =>
+      $composableBuilder(column: $table.iconUrl, builder: (column) => column);
+
+  GeneratedColumn<int> get position =>
+      $composableBuilder(column: $table.position, builder: (column) => column);
+
+  $$PortalApplicationCategoriesTableAnnotationComposer get category {
+    final $$PortalApplicationCategoriesTableAnnotationComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.category,
+          referencedTable: $db.portalApplicationCategories,
+          getReferencedColumn: (t) => t.id,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$PortalApplicationCategoriesTableAnnotationComposer(
+                $db: $db,
+                $table: $db.portalApplicationCategories,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return composer;
+  }
+}
+
+class $$PortalApplicationsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $PortalApplicationsTable,
+          PortalApplication,
+          $$PortalApplicationsTableFilterComposer,
+          $$PortalApplicationsTableOrderingComposer,
+          $$PortalApplicationsTableAnnotationComposer,
+          $$PortalApplicationsTableCreateCompanionBuilder,
+          $$PortalApplicationsTableUpdateCompanionBuilder,
+          (PortalApplication, $$PortalApplicationsTableReferences),
+          PortalApplication,
+          PrefetchHooks Function({bool category})
+        > {
+  $$PortalApplicationsTableTableManager(
+    _$AppDatabase db,
+    $PortalApplicationsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PortalApplicationsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PortalApplicationsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$PortalApplicationsTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<int> category = const Value.absent(),
+                Value<String> code = const Value.absent(),
+                Value<String> name = const Value.absent(),
+                Value<String?> iconUrl = const Value.absent(),
+                Value<int> position = const Value.absent(),
+              }) => PortalApplicationsCompanion(
+                id: id,
+                category: category,
+                code: code,
+                name: name,
+                iconUrl: iconUrl,
+                position: position,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required int category,
+                required String code,
+                required String name,
+                Value<String?> iconUrl = const Value.absent(),
+                required int position,
+              }) => PortalApplicationsCompanion.insert(
+                id: id,
+                category: category,
+                code: code,
+                name: name,
+                iconUrl: iconUrl,
+                position: position,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$PortalApplicationsTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({category = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (category) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.category,
+                                referencedTable:
+                                    $$PortalApplicationsTableReferences
+                                        ._categoryTable(db),
+                                referencedColumn:
+                                    $$PortalApplicationsTableReferences
+                                        ._categoryTable(db)
+                                        .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$PortalApplicationsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $PortalApplicationsTable,
+      PortalApplication,
+      $$PortalApplicationsTableFilterComposer,
+      $$PortalApplicationsTableOrderingComposer,
+      $$PortalApplicationsTableAnnotationComposer,
+      $$PortalApplicationsTableCreateCompanionBuilder,
+      $$PortalApplicationsTableUpdateCompanionBuilder,
+      (PortalApplication, $$PortalApplicationsTableReferences),
+      PortalApplication,
+      PrefetchHooks Function({bool category})
+    >;
+typedef $$PortalApplicationFavoritesTableCreateCompanionBuilder =
+    PortalApplicationFavoritesCompanion Function({
+      required int user,
+      required String applicationCode,
+      Value<int> rowid,
+    });
+typedef $$PortalApplicationFavoritesTableUpdateCompanionBuilder =
+    PortalApplicationFavoritesCompanion Function({
+      Value<int> user,
+      Value<String> applicationCode,
+      Value<int> rowid,
+    });
+
+final class $$PortalApplicationFavoritesTableReferences
+    extends
+        BaseReferences<
+          _$AppDatabase,
+          $PortalApplicationFavoritesTable,
+          PortalApplicationFavorite
+        > {
+  $$PortalApplicationFavoritesTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static $UsersTable _userTable(_$AppDatabase db) =>
+      db.users.createAlias('portal_application_favorites__user__users__id');
+
+  $$UsersTableProcessedTableManager get user {
+    final $_column = $_itemColumn<int>('user')!;
+
+    final manager = $$UsersTableTableManager(
+      $_db,
+      $_db.users,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_userTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$PortalApplicationFavoritesTableFilterComposer
+    extends Composer<_$AppDatabase, $PortalApplicationFavoritesTable> {
+  $$PortalApplicationFavoritesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get applicationCode => $composableBuilder(
+    column: $table.applicationCode,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$UsersTableFilterComposer get user {
+    final $$UsersTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.user,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableFilterComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$PortalApplicationFavoritesTableOrderingComposer
+    extends Composer<_$AppDatabase, $PortalApplicationFavoritesTable> {
+  $$PortalApplicationFavoritesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get applicationCode => $composableBuilder(
+    column: $table.applicationCode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$UsersTableOrderingComposer get user {
+    final $$UsersTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.user,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableOrderingComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$PortalApplicationFavoritesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $PortalApplicationFavoritesTable> {
+  $$PortalApplicationFavoritesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get applicationCode => $composableBuilder(
+    column: $table.applicationCode,
+    builder: (column) => column,
+  );
+
+  $$UsersTableAnnotationComposer get user {
+    final $$UsersTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.user,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableAnnotationComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$PortalApplicationFavoritesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $PortalApplicationFavoritesTable,
+          PortalApplicationFavorite,
+          $$PortalApplicationFavoritesTableFilterComposer,
+          $$PortalApplicationFavoritesTableOrderingComposer,
+          $$PortalApplicationFavoritesTableAnnotationComposer,
+          $$PortalApplicationFavoritesTableCreateCompanionBuilder,
+          $$PortalApplicationFavoritesTableUpdateCompanionBuilder,
+          (
+            PortalApplicationFavorite,
+            $$PortalApplicationFavoritesTableReferences,
+          ),
+          PortalApplicationFavorite,
+          PrefetchHooks Function({bool user})
+        > {
+  $$PortalApplicationFavoritesTableTableManager(
+    _$AppDatabase db,
+    $PortalApplicationFavoritesTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PortalApplicationFavoritesTableFilterComposer(
+                $db: db,
+                $table: table,
+              ),
+          createOrderingComposer: () =>
+              $$PortalApplicationFavoritesTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$PortalApplicationFavoritesTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<int> user = const Value.absent(),
+                Value<String> applicationCode = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => PortalApplicationFavoritesCompanion(
+                user: user,
+                applicationCode: applicationCode,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required int user,
+                required String applicationCode,
+                Value<int> rowid = const Value.absent(),
+              }) => PortalApplicationFavoritesCompanion.insert(
+                user: user,
+                applicationCode: applicationCode,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$PortalApplicationFavoritesTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({user = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (user) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.user,
+                                referencedTable:
+                                    $$PortalApplicationFavoritesTableReferences
+                                        ._userTable(db),
+                                referencedColumn:
+                                    $$PortalApplicationFavoritesTableReferences
+                                        ._userTable(db)
+                                        .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$PortalApplicationFavoritesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $PortalApplicationFavoritesTable,
+      PortalApplicationFavorite,
+      $$PortalApplicationFavoritesTableFilterComposer,
+      $$PortalApplicationFavoritesTableOrderingComposer,
+      $$PortalApplicationFavoritesTableAnnotationComposer,
+      $$PortalApplicationFavoritesTableCreateCompanionBuilder,
+      $$PortalApplicationFavoritesTableUpdateCompanionBuilder,
+      (PortalApplicationFavorite, $$PortalApplicationFavoritesTableReferences),
+      PortalApplicationFavorite,
+      PrefetchHooks Function({bool user})
     >;
 typedef $$StudentsTableCreateCompanionBuilder =
     StudentsCompanion Function({
@@ -23571,6 +26028,20 @@ class $AppDatabaseManager {
   $AppDatabaseManager(this._db);
   $$UsersTableTableManager get users =>
       $$UsersTableTableManager(_db, _db.users);
+  $$PortalApplicationCategoriesTableTableManager
+  get portalApplicationCategories =>
+      $$PortalApplicationCategoriesTableTableManager(
+        _db,
+        _db.portalApplicationCategories,
+      );
+  $$PortalApplicationsTableTableManager get portalApplications =>
+      $$PortalApplicationsTableTableManager(_db, _db.portalApplications);
+  $$PortalApplicationFavoritesTableTableManager
+  get portalApplicationFavorites =>
+      $$PortalApplicationFavoritesTableTableManager(
+        _db,
+        _db.portalApplicationFavorites,
+      );
   $$StudentsTableTableManager get students =>
       $$StudentsTableTableManager(_db, _db.students);
   $$SemestersTableTableManager get semesters =>

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -1118,14 +1118,23 @@ class $PortalApplicationCategoriesTable extends PortalApplicationCategories
         type: DriftSqlType.string,
         requiredDuringInsert: true,
       );
-  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  static const VerificationMeta _nameZhMeta = const VerificationMeta('nameZh');
   @override
-  late final GeneratedColumn<String> name = GeneratedColumn<String>(
-    'name',
+  late final GeneratedColumn<String> nameZh = GeneratedColumn<String>(
+    'name_zh',
     aliasedName,
     false,
     type: DriftSqlType.string,
     requiredDuringInsert: true,
+  );
+  static const VerificationMeta _nameEnMeta = const VerificationMeta('nameEn');
+  @override
+  late final GeneratedColumn<String> nameEn = GeneratedColumn<String>(
+    'name_en',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
   );
   static const VerificationMeta _positionMeta = const VerificationMeta(
     'position',
@@ -1143,7 +1152,8 @@ class $PortalApplicationCategoriesTable extends PortalApplicationCategories
     id,
     user,
     distinguishedName,
-    name,
+    nameZh,
+    nameEn,
     position,
   ];
   @override
@@ -1180,13 +1190,19 @@ class $PortalApplicationCategoriesTable extends PortalApplicationCategories
     } else if (isInserting) {
       context.missing(_distinguishedNameMeta);
     }
-    if (data.containsKey('name')) {
+    if (data.containsKey('name_zh')) {
       context.handle(
-        _nameMeta,
-        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+        _nameZhMeta,
+        nameZh.isAcceptableOrUnknown(data['name_zh']!, _nameZhMeta),
       );
     } else if (isInserting) {
-      context.missing(_nameMeta);
+      context.missing(_nameZhMeta);
+    }
+    if (data.containsKey('name_en')) {
+      context.handle(
+        _nameEnMeta,
+        nameEn.isAcceptableOrUnknown(data['name_en']!, _nameEnMeta),
+      );
     }
     if (data.containsKey('position')) {
       context.handle(
@@ -1224,10 +1240,14 @@ class $PortalApplicationCategoriesTable extends PortalApplicationCategories
         DriftSqlType.string,
         data['${effectivePrefix}distinguished_name'],
       )!,
-      name: attachedDatabase.typeMapping.read(
+      nameZh: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
-        data['${effectivePrefix}name'],
+        data['${effectivePrefix}name_zh'],
       )!,
+      nameEn: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name_en'],
+      ),
       position: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}position'],
@@ -1252,8 +1272,11 @@ class PortalApplicationCategory extends DataClass
   /// LDAP distinguished name used by the portal to fetch this category.
   final String distinguishedName;
 
-  /// Category display name supplied by the portal.
-  final String name;
+  /// Chinese category display name supplied by the portal.
+  final String nameZh;
+
+  /// English category display name supplied by the portal.
+  final String? nameEn;
 
   /// Display order supplied by the portal.
   final int position;
@@ -1261,7 +1284,8 @@ class PortalApplicationCategory extends DataClass
     required this.id,
     required this.user,
     required this.distinguishedName,
-    required this.name,
+    required this.nameZh,
+    this.nameEn,
     required this.position,
   });
   @override
@@ -1270,7 +1294,10 @@ class PortalApplicationCategory extends DataClass
     map['id'] = Variable<int>(id);
     map['user'] = Variable<int>(user);
     map['distinguished_name'] = Variable<String>(distinguishedName);
-    map['name'] = Variable<String>(name);
+    map['name_zh'] = Variable<String>(nameZh);
+    if (!nullToAbsent || nameEn != null) {
+      map['name_en'] = Variable<String>(nameEn);
+    }
     map['position'] = Variable<int>(position);
     return map;
   }
@@ -1280,7 +1307,10 @@ class PortalApplicationCategory extends DataClass
       id: Value(id),
       user: Value(user),
       distinguishedName: Value(distinguishedName),
-      name: Value(name),
+      nameZh: Value(nameZh),
+      nameEn: nameEn == null && nullToAbsent
+          ? const Value.absent()
+          : Value(nameEn),
       position: Value(position),
     );
   }
@@ -1294,7 +1324,8 @@ class PortalApplicationCategory extends DataClass
       id: serializer.fromJson<int>(json['id']),
       user: serializer.fromJson<int>(json['user']),
       distinguishedName: serializer.fromJson<String>(json['distinguishedName']),
-      name: serializer.fromJson<String>(json['name']),
+      nameZh: serializer.fromJson<String>(json['nameZh']),
+      nameEn: serializer.fromJson<String?>(json['nameEn']),
       position: serializer.fromJson<int>(json['position']),
     );
   }
@@ -1305,7 +1336,8 @@ class PortalApplicationCategory extends DataClass
       'id': serializer.toJson<int>(id),
       'user': serializer.toJson<int>(user),
       'distinguishedName': serializer.toJson<String>(distinguishedName),
-      'name': serializer.toJson<String>(name),
+      'nameZh': serializer.toJson<String>(nameZh),
+      'nameEn': serializer.toJson<String?>(nameEn),
       'position': serializer.toJson<int>(position),
     };
   }
@@ -1314,13 +1346,15 @@ class PortalApplicationCategory extends DataClass
     int? id,
     int? user,
     String? distinguishedName,
-    String? name,
+    String? nameZh,
+    Value<String?> nameEn = const Value.absent(),
     int? position,
   }) => PortalApplicationCategory(
     id: id ?? this.id,
     user: user ?? this.user,
     distinguishedName: distinguishedName ?? this.distinguishedName,
-    name: name ?? this.name,
+    nameZh: nameZh ?? this.nameZh,
+    nameEn: nameEn.present ? nameEn.value : this.nameEn,
     position: position ?? this.position,
   );
   PortalApplicationCategory copyWithCompanion(
@@ -1332,7 +1366,8 @@ class PortalApplicationCategory extends DataClass
       distinguishedName: data.distinguishedName.present
           ? data.distinguishedName.value
           : this.distinguishedName,
-      name: data.name.present ? data.name.value : this.name,
+      nameZh: data.nameZh.present ? data.nameZh.value : this.nameZh,
+      nameEn: data.nameEn.present ? data.nameEn.value : this.nameEn,
       position: data.position.present ? data.position.value : this.position,
     );
   }
@@ -1343,14 +1378,16 @@ class PortalApplicationCategory extends DataClass
           ..write('id: $id, ')
           ..write('user: $user, ')
           ..write('distinguishedName: $distinguishedName, ')
-          ..write('name: $name, ')
+          ..write('nameZh: $nameZh, ')
+          ..write('nameEn: $nameEn, ')
           ..write('position: $position')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(id, user, distinguishedName, name, position);
+  int get hashCode =>
+      Object.hash(id, user, distinguishedName, nameZh, nameEn, position);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1358,7 +1395,8 @@ class PortalApplicationCategory extends DataClass
           other.id == this.id &&
           other.user == this.user &&
           other.distinguishedName == this.distinguishedName &&
-          other.name == this.name &&
+          other.nameZh == this.nameZh &&
+          other.nameEn == this.nameEn &&
           other.position == this.position);
 }
 
@@ -1367,37 +1405,42 @@ class PortalApplicationCategoriesCompanion
   final Value<int> id;
   final Value<int> user;
   final Value<String> distinguishedName;
-  final Value<String> name;
+  final Value<String> nameZh;
+  final Value<String?> nameEn;
   final Value<int> position;
   const PortalApplicationCategoriesCompanion({
     this.id = const Value.absent(),
     this.user = const Value.absent(),
     this.distinguishedName = const Value.absent(),
-    this.name = const Value.absent(),
+    this.nameZh = const Value.absent(),
+    this.nameEn = const Value.absent(),
     this.position = const Value.absent(),
   });
   PortalApplicationCategoriesCompanion.insert({
     this.id = const Value.absent(),
     required int user,
     required String distinguishedName,
-    required String name,
+    required String nameZh,
+    this.nameEn = const Value.absent(),
     required int position,
   }) : user = Value(user),
        distinguishedName = Value(distinguishedName),
-       name = Value(name),
+       nameZh = Value(nameZh),
        position = Value(position);
   static Insertable<PortalApplicationCategory> custom({
     Expression<int>? id,
     Expression<int>? user,
     Expression<String>? distinguishedName,
-    Expression<String>? name,
+    Expression<String>? nameZh,
+    Expression<String>? nameEn,
     Expression<int>? position,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (user != null) 'user': user,
       if (distinguishedName != null) 'distinguished_name': distinguishedName,
-      if (name != null) 'name': name,
+      if (nameZh != null) 'name_zh': nameZh,
+      if (nameEn != null) 'name_en': nameEn,
       if (position != null) 'position': position,
     });
   }
@@ -1406,14 +1449,16 @@ class PortalApplicationCategoriesCompanion
     Value<int>? id,
     Value<int>? user,
     Value<String>? distinguishedName,
-    Value<String>? name,
+    Value<String>? nameZh,
+    Value<String?>? nameEn,
     Value<int>? position,
   }) {
     return PortalApplicationCategoriesCompanion(
       id: id ?? this.id,
       user: user ?? this.user,
       distinguishedName: distinguishedName ?? this.distinguishedName,
-      name: name ?? this.name,
+      nameZh: nameZh ?? this.nameZh,
+      nameEn: nameEn ?? this.nameEn,
       position: position ?? this.position,
     );
   }
@@ -1430,8 +1475,11 @@ class PortalApplicationCategoriesCompanion
     if (distinguishedName.present) {
       map['distinguished_name'] = Variable<String>(distinguishedName.value);
     }
-    if (name.present) {
-      map['name'] = Variable<String>(name.value);
+    if (nameZh.present) {
+      map['name_zh'] = Variable<String>(nameZh.value);
+    }
+    if (nameEn.present) {
+      map['name_en'] = Variable<String>(nameEn.value);
     }
     if (position.present) {
       map['position'] = Variable<int>(position.value);
@@ -1445,7 +1493,8 @@ class PortalApplicationCategoriesCompanion
           ..write('id: $id, ')
           ..write('user: $user, ')
           ..write('distinguishedName: $distinguishedName, ')
-          ..write('name: $name, ')
+          ..write('nameZh: $nameZh, ')
+          ..write('nameEn: $nameEn, ')
           ..write('position: $position')
           ..write(')'))
         .toString();
@@ -1494,14 +1543,23 @@ class $PortalApplicationsTable extends PortalApplications
     type: DriftSqlType.string,
     requiredDuringInsert: true,
   );
-  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  static const VerificationMeta _nameZhMeta = const VerificationMeta('nameZh');
   @override
-  late final GeneratedColumn<String> name = GeneratedColumn<String>(
-    'name',
+  late final GeneratedColumn<String> nameZh = GeneratedColumn<String>(
+    'name_zh',
     aliasedName,
     false,
     type: DriftSqlType.string,
     requiredDuringInsert: true,
+  );
+  static const VerificationMeta _nameEnMeta = const VerificationMeta('nameEn');
+  @override
+  late final GeneratedColumn<String> nameEn = GeneratedColumn<String>(
+    'name_en',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
   );
   static const VerificationMeta _iconUrlMeta = const VerificationMeta(
     'iconUrl',
@@ -1530,7 +1588,8 @@ class $PortalApplicationsTable extends PortalApplications
     id,
     category,
     code,
-    name,
+    nameZh,
+    nameEn,
     iconUrl,
     position,
   ];
@@ -1565,13 +1624,19 @@ class $PortalApplicationsTable extends PortalApplications
     } else if (isInserting) {
       context.missing(_codeMeta);
     }
-    if (data.containsKey('name')) {
+    if (data.containsKey('name_zh')) {
       context.handle(
-        _nameMeta,
-        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+        _nameZhMeta,
+        nameZh.isAcceptableOrUnknown(data['name_zh']!, _nameZhMeta),
       );
     } else if (isInserting) {
-      context.missing(_nameMeta);
+      context.missing(_nameZhMeta);
+    }
+    if (data.containsKey('name_en')) {
+      context.handle(
+        _nameEnMeta,
+        nameEn.isAcceptableOrUnknown(data['name_en']!, _nameEnMeta),
+      );
     }
     if (data.containsKey('icon_url')) {
       context.handle(
@@ -1612,10 +1677,14 @@ class $PortalApplicationsTable extends PortalApplications
         DriftSqlType.string,
         data['${effectivePrefix}code'],
       )!,
-      name: attachedDatabase.typeMapping.read(
+      nameZh: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
-        data['${effectivePrefix}name'],
+        data['${effectivePrefix}name_zh'],
       )!,
+      nameEn: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name_en'],
+      ),
       iconUrl: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}icon_url'],
@@ -1644,8 +1713,11 @@ class PortalApplication extends DataClass
   /// Portal SSO target identifier (`apOu`).
   final String code;
 
-  /// Application display name supplied by the portal.
-  final String name;
+  /// Chinese application display name supplied by the portal.
+  final String nameZh;
+
+  /// English application display name supplied by the portal.
+  final String? nameEn;
 
   /// Absolute URL of the portal-provided application icon.
   final String? iconUrl;
@@ -1656,7 +1728,8 @@ class PortalApplication extends DataClass
     required this.id,
     required this.category,
     required this.code,
-    required this.name,
+    required this.nameZh,
+    this.nameEn,
     this.iconUrl,
     required this.position,
   });
@@ -1666,7 +1739,10 @@ class PortalApplication extends DataClass
     map['id'] = Variable<int>(id);
     map['category'] = Variable<int>(category);
     map['code'] = Variable<String>(code);
-    map['name'] = Variable<String>(name);
+    map['name_zh'] = Variable<String>(nameZh);
+    if (!nullToAbsent || nameEn != null) {
+      map['name_en'] = Variable<String>(nameEn);
+    }
     if (!nullToAbsent || iconUrl != null) {
       map['icon_url'] = Variable<String>(iconUrl);
     }
@@ -1679,7 +1755,10 @@ class PortalApplication extends DataClass
       id: Value(id),
       category: Value(category),
       code: Value(code),
-      name: Value(name),
+      nameZh: Value(nameZh),
+      nameEn: nameEn == null && nullToAbsent
+          ? const Value.absent()
+          : Value(nameEn),
       iconUrl: iconUrl == null && nullToAbsent
           ? const Value.absent()
           : Value(iconUrl),
@@ -1696,7 +1775,8 @@ class PortalApplication extends DataClass
       id: serializer.fromJson<int>(json['id']),
       category: serializer.fromJson<int>(json['category']),
       code: serializer.fromJson<String>(json['code']),
-      name: serializer.fromJson<String>(json['name']),
+      nameZh: serializer.fromJson<String>(json['nameZh']),
+      nameEn: serializer.fromJson<String?>(json['nameEn']),
       iconUrl: serializer.fromJson<String?>(json['iconUrl']),
       position: serializer.fromJson<int>(json['position']),
     );
@@ -1708,7 +1788,8 @@ class PortalApplication extends DataClass
       'id': serializer.toJson<int>(id),
       'category': serializer.toJson<int>(category),
       'code': serializer.toJson<String>(code),
-      'name': serializer.toJson<String>(name),
+      'nameZh': serializer.toJson<String>(nameZh),
+      'nameEn': serializer.toJson<String?>(nameEn),
       'iconUrl': serializer.toJson<String?>(iconUrl),
       'position': serializer.toJson<int>(position),
     };
@@ -1718,14 +1799,16 @@ class PortalApplication extends DataClass
     int? id,
     int? category,
     String? code,
-    String? name,
+    String? nameZh,
+    Value<String?> nameEn = const Value.absent(),
     Value<String?> iconUrl = const Value.absent(),
     int? position,
   }) => PortalApplication(
     id: id ?? this.id,
     category: category ?? this.category,
     code: code ?? this.code,
-    name: name ?? this.name,
+    nameZh: nameZh ?? this.nameZh,
+    nameEn: nameEn.present ? nameEn.value : this.nameEn,
     iconUrl: iconUrl.present ? iconUrl.value : this.iconUrl,
     position: position ?? this.position,
   );
@@ -1734,7 +1817,8 @@ class PortalApplication extends DataClass
       id: data.id.present ? data.id.value : this.id,
       category: data.category.present ? data.category.value : this.category,
       code: data.code.present ? data.code.value : this.code,
-      name: data.name.present ? data.name.value : this.name,
+      nameZh: data.nameZh.present ? data.nameZh.value : this.nameZh,
+      nameEn: data.nameEn.present ? data.nameEn.value : this.nameEn,
       iconUrl: data.iconUrl.present ? data.iconUrl.value : this.iconUrl,
       position: data.position.present ? data.position.value : this.position,
     );
@@ -1746,7 +1830,8 @@ class PortalApplication extends DataClass
           ..write('id: $id, ')
           ..write('category: $category, ')
           ..write('code: $code, ')
-          ..write('name: $name, ')
+          ..write('nameZh: $nameZh, ')
+          ..write('nameEn: $nameEn, ')
           ..write('iconUrl: $iconUrl, ')
           ..write('position: $position')
           ..write(')'))
@@ -1754,7 +1839,8 @@ class PortalApplication extends DataClass
   }
 
   @override
-  int get hashCode => Object.hash(id, category, code, name, iconUrl, position);
+  int get hashCode =>
+      Object.hash(id, category, code, nameZh, nameEn, iconUrl, position);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1762,7 +1848,8 @@ class PortalApplication extends DataClass
           other.id == this.id &&
           other.category == this.category &&
           other.code == this.code &&
-          other.name == this.name &&
+          other.nameZh == this.nameZh &&
+          other.nameEn == this.nameEn &&
           other.iconUrl == this.iconUrl &&
           other.position == this.position);
 }
@@ -1771,14 +1858,16 @@ class PortalApplicationsCompanion extends UpdateCompanion<PortalApplication> {
   final Value<int> id;
   final Value<int> category;
   final Value<String> code;
-  final Value<String> name;
+  final Value<String> nameZh;
+  final Value<String?> nameEn;
   final Value<String?> iconUrl;
   final Value<int> position;
   const PortalApplicationsCompanion({
     this.id = const Value.absent(),
     this.category = const Value.absent(),
     this.code = const Value.absent(),
-    this.name = const Value.absent(),
+    this.nameZh = const Value.absent(),
+    this.nameEn = const Value.absent(),
     this.iconUrl = const Value.absent(),
     this.position = const Value.absent(),
   });
@@ -1786,18 +1875,20 @@ class PortalApplicationsCompanion extends UpdateCompanion<PortalApplication> {
     this.id = const Value.absent(),
     required int category,
     required String code,
-    required String name,
+    required String nameZh,
+    this.nameEn = const Value.absent(),
     this.iconUrl = const Value.absent(),
     required int position,
   }) : category = Value(category),
        code = Value(code),
-       name = Value(name),
+       nameZh = Value(nameZh),
        position = Value(position);
   static Insertable<PortalApplication> custom({
     Expression<int>? id,
     Expression<int>? category,
     Expression<String>? code,
-    Expression<String>? name,
+    Expression<String>? nameZh,
+    Expression<String>? nameEn,
     Expression<String>? iconUrl,
     Expression<int>? position,
   }) {
@@ -1805,7 +1896,8 @@ class PortalApplicationsCompanion extends UpdateCompanion<PortalApplication> {
       if (id != null) 'id': id,
       if (category != null) 'category': category,
       if (code != null) 'code': code,
-      if (name != null) 'name': name,
+      if (nameZh != null) 'name_zh': nameZh,
+      if (nameEn != null) 'name_en': nameEn,
       if (iconUrl != null) 'icon_url': iconUrl,
       if (position != null) 'position': position,
     });
@@ -1815,7 +1907,8 @@ class PortalApplicationsCompanion extends UpdateCompanion<PortalApplication> {
     Value<int>? id,
     Value<int>? category,
     Value<String>? code,
-    Value<String>? name,
+    Value<String>? nameZh,
+    Value<String?>? nameEn,
     Value<String?>? iconUrl,
     Value<int>? position,
   }) {
@@ -1823,7 +1916,8 @@ class PortalApplicationsCompanion extends UpdateCompanion<PortalApplication> {
       id: id ?? this.id,
       category: category ?? this.category,
       code: code ?? this.code,
-      name: name ?? this.name,
+      nameZh: nameZh ?? this.nameZh,
+      nameEn: nameEn ?? this.nameEn,
       iconUrl: iconUrl ?? this.iconUrl,
       position: position ?? this.position,
     );
@@ -1841,8 +1935,11 @@ class PortalApplicationsCompanion extends UpdateCompanion<PortalApplication> {
     if (code.present) {
       map['code'] = Variable<String>(code.value);
     }
-    if (name.present) {
-      map['name'] = Variable<String>(name.value);
+    if (nameZh.present) {
+      map['name_zh'] = Variable<String>(nameZh.value);
+    }
+    if (nameEn.present) {
+      map['name_en'] = Variable<String>(nameEn.value);
     }
     if (iconUrl.present) {
       map['icon_url'] = Variable<String>(iconUrl.value);
@@ -1859,7 +1956,8 @@ class PortalApplicationsCompanion extends UpdateCompanion<PortalApplication> {
           ..write('id: $id, ')
           ..write('category: $category, ')
           ..write('code: $code, ')
-          ..write('name: $name, ')
+          ..write('nameZh: $nameZh, ')
+          ..write('nameEn: $nameEn, ')
           ..write('iconUrl: $iconUrl, ')
           ..write('position: $position')
           ..write(')'))
@@ -14540,7 +14638,8 @@ typedef $$PortalApplicationCategoriesTableCreateCompanionBuilder =
       Value<int> id,
       required int user,
       required String distinguishedName,
-      required String name,
+      required String nameZh,
+      Value<String?> nameEn,
       required int position,
     });
 typedef $$PortalApplicationCategoriesTableUpdateCompanionBuilder =
@@ -14548,7 +14647,8 @@ typedef $$PortalApplicationCategoriesTableUpdateCompanionBuilder =
       Value<int> id,
       Value<int> user,
       Value<String> distinguishedName,
-      Value<String> name,
+      Value<String> nameZh,
+      Value<String?> nameEn,
       Value<int> position,
     });
 
@@ -14624,8 +14724,13 @@ class $$PortalApplicationCategoriesTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
-  ColumnFilters<String> get name => $composableBuilder(
-    column: $table.name,
+  ColumnFilters<String> get nameZh => $composableBuilder(
+    column: $table.nameZh,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get nameEn => $composableBuilder(
+    column: $table.nameEn,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -14702,8 +14807,13 @@ class $$PortalApplicationCategoriesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
-  ColumnOrderings<String> get name => $composableBuilder(
-    column: $table.name,
+  ColumnOrderings<String> get nameZh => $composableBuilder(
+    column: $table.nameZh,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get nameEn => $composableBuilder(
+    column: $table.nameEn,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -14753,8 +14863,11 @@ class $$PortalApplicationCategoriesTableAnnotationComposer
     builder: (column) => column,
   );
 
-  GeneratedColumn<String> get name =>
-      $composableBuilder(column: $table.name, builder: (column) => column);
+  GeneratedColumn<String> get nameZh =>
+      $composableBuilder(column: $table.nameZh, builder: (column) => column);
+
+  GeneratedColumn<String> get nameEn =>
+      $composableBuilder(column: $table.nameEn, builder: (column) => column);
 
   GeneratedColumn<int> get position =>
       $composableBuilder(column: $table.position, builder: (column) => column);
@@ -14854,13 +14967,15 @@ class $$PortalApplicationCategoriesTableTableManager
                 Value<int> id = const Value.absent(),
                 Value<int> user = const Value.absent(),
                 Value<String> distinguishedName = const Value.absent(),
-                Value<String> name = const Value.absent(),
+                Value<String> nameZh = const Value.absent(),
+                Value<String?> nameEn = const Value.absent(),
                 Value<int> position = const Value.absent(),
               }) => PortalApplicationCategoriesCompanion(
                 id: id,
                 user: user,
                 distinguishedName: distinguishedName,
-                name: name,
+                nameZh: nameZh,
+                nameEn: nameEn,
                 position: position,
               ),
           createCompanionCallback:
@@ -14868,13 +14983,15 @@ class $$PortalApplicationCategoriesTableTableManager
                 Value<int> id = const Value.absent(),
                 required int user,
                 required String distinguishedName,
-                required String name,
+                required String nameZh,
+                Value<String?> nameEn = const Value.absent(),
                 required int position,
               }) => PortalApplicationCategoriesCompanion.insert(
                 id: id,
                 user: user,
                 distinguishedName: distinguishedName,
-                name: name,
+                nameZh: nameZh,
+                nameEn: nameEn,
                 position: position,
               ),
           withReferenceMapper: (p0) => p0
@@ -14974,7 +15091,8 @@ typedef $$PortalApplicationsTableCreateCompanionBuilder =
       Value<int> id,
       required int category,
       required String code,
-      required String name,
+      required String nameZh,
+      Value<String?> nameEn,
       Value<String?> iconUrl,
       required int position,
     });
@@ -14983,7 +15101,8 @@ typedef $$PortalApplicationsTableUpdateCompanionBuilder =
       Value<int> id,
       Value<int> category,
       Value<String> code,
-      Value<String> name,
+      Value<String> nameZh,
+      Value<String?> nameEn,
       Value<String?> iconUrl,
       Value<int> position,
     });
@@ -15040,8 +15159,13 @@ class $$PortalApplicationsTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
-  ColumnFilters<String> get name => $composableBuilder(
-    column: $table.name,
+  ColumnFilters<String> get nameZh => $composableBuilder(
+    column: $table.nameZh,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get nameEn => $composableBuilder(
+    column: $table.nameEn,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -15099,8 +15223,13 @@ class $$PortalApplicationsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
-  ColumnOrderings<String> get name => $composableBuilder(
-    column: $table.name,
+  ColumnOrderings<String> get nameZh => $composableBuilder(
+    column: $table.nameZh,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get nameEn => $composableBuilder(
+    column: $table.nameEn,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -15154,8 +15283,11 @@ class $$PortalApplicationsTableAnnotationComposer
   GeneratedColumn<String> get code =>
       $composableBuilder(column: $table.code, builder: (column) => column);
 
-  GeneratedColumn<String> get name =>
-      $composableBuilder(column: $table.name, builder: (column) => column);
+  GeneratedColumn<String> get nameZh =>
+      $composableBuilder(column: $table.nameZh, builder: (column) => column);
+
+  GeneratedColumn<String> get nameEn =>
+      $composableBuilder(column: $table.nameEn, builder: (column) => column);
 
   GeneratedColumn<String> get iconUrl =>
       $composableBuilder(column: $table.iconUrl, builder: (column) => column);
@@ -15224,14 +15356,16 @@ class $$PortalApplicationsTableTableManager
                 Value<int> id = const Value.absent(),
                 Value<int> category = const Value.absent(),
                 Value<String> code = const Value.absent(),
-                Value<String> name = const Value.absent(),
+                Value<String> nameZh = const Value.absent(),
+                Value<String?> nameEn = const Value.absent(),
                 Value<String?> iconUrl = const Value.absent(),
                 Value<int> position = const Value.absent(),
               }) => PortalApplicationsCompanion(
                 id: id,
                 category: category,
                 code: code,
-                name: name,
+                nameZh: nameZh,
+                nameEn: nameEn,
                 iconUrl: iconUrl,
                 position: position,
               ),
@@ -15240,14 +15374,16 @@ class $$PortalApplicationsTableTableManager
                 Value<int> id = const Value.absent(),
                 required int category,
                 required String code,
-                required String name,
+                required String nameZh,
+                Value<String?> nameEn = const Value.absent(),
                 Value<String?> iconUrl = const Value.absent(),
                 required int position,
               }) => PortalApplicationsCompanion.insert(
                 id: id,
                 category: category,
                 code: code,
-                name: name,
+                nameZh: nameZh,
+                nameEn: nameEn,
                 iconUrl: iconUrl,
                 position: position,
               ),

--- a/lib/database/schema.dart
+++ b/lib/database/schema.dart
@@ -101,6 +101,77 @@ class Users extends Table with AutoIncrementId, Fetchable {
 
   /// When the academic calendar was last fetched from the portal.
   late final calendarFetchedAt = dateTime().nullable()();
+
+  /// When the portal application catalog was last fetched.
+  late final applicationCatalogFetchedAt = dateTime().nullable()();
+}
+
+/// A top-level application category available to one portal user.
+///
+/// Data source: PortalService.getApplicationCatalog()
+class PortalApplicationCategories extends Table with AutoIncrementId {
+  /// User whose portal account exposed this category.
+  late final user = integer().references(Users, #id, onDelete: .cascade)();
+
+  /// LDAP distinguished name used by the portal to fetch this category.
+  late final distinguishedName = text()();
+
+  /// Category display name supplied by the portal.
+  late final name = text()();
+
+  /// Display order supplied by the portal.
+  late final position = integer()();
+
+  @override
+  List<Set<Column>> get uniqueKeys => [
+    {user, distinguishedName},
+  ];
+}
+
+/// A browser-openable application in a portal category.
+///
+/// Nested portal folders are flattened by PortalService into their top-level
+/// category before these rows are cached.
+class PortalApplications extends Table with AutoIncrementId {
+  /// Category containing this application.
+  late final category = integer().references(
+    PortalApplicationCategories,
+    #id,
+    onDelete: .cascade,
+  )();
+
+  /// Portal SSO target identifier (`apOu`).
+  late final code = text()();
+
+  /// Application display name supplied by the portal.
+  late final name = text()();
+
+  /// Absolute URL of the portal-provided application icon.
+  late final iconUrl = text().nullable()();
+
+  /// Display order within the category.
+  late final position = integer()();
+
+  @override
+  List<Set<Column>> get uniqueKeys => [
+    {category, code},
+  ];
+}
+
+/// A user's app-local portal application favorite.
+///
+/// Favorites deliberately reference an application code instead of a cached
+/// [PortalApplications] row. This preserves the preference when a refresh
+/// moves an application to another category or temporarily removes it.
+class PortalApplicationFavorites extends Table {
+  /// User who selected this favorite.
+  late final user = integer().references(Users, #id, onDelete: .cascade)();
+
+  /// Portal SSO target identifier (`apOu`).
+  late final applicationCode = text()();
+
+  @override
+  Set<Column> get primaryKey => {user, applicationCode};
 }
 
 /// Student seen in an I-School Plus course roster.

--- a/lib/database/schema.dart
+++ b/lib/database/schema.dart
@@ -116,8 +116,11 @@ class PortalApplicationCategories extends Table with AutoIncrementId {
   /// LDAP distinguished name used by the portal to fetch this category.
   late final distinguishedName = text()();
 
-  /// Category display name supplied by the portal.
-  late final name = text()();
+  /// Chinese category display name supplied by the portal.
+  late final nameZh = text()();
+
+  /// English category display name supplied by the portal.
+  late final nameEn = text().nullable()();
 
   /// Display order supplied by the portal.
   late final position = integer()();
@@ -143,8 +146,11 @@ class PortalApplications extends Table with AutoIncrementId {
   /// Portal SSO target identifier (`apOu`).
   late final code = text()();
 
-  /// Application display name supplied by the portal.
-  late final name = text()();
+  /// Chinese application display name supplied by the portal.
+  late final nameZh = text()();
+
+  /// English application display name supplied by the portal.
+  late final nameEn = text().nullable()();
 
   /// Absolute URL of the portal-provided application icon.
   late final iconUrl = text().nullable()();

--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -54,6 +54,13 @@ nav:
   calendar: Calendar
   profile: Me
   vote: Vote Login
+portal:
+  sourceNotice: This feature is still under development and may change significantly.
+  openPortal: Open Campus Portal
+  empty: No information systems are currently available.
+  favorites: My Favorites
+  addFavorite: Add to favorites
+  removeFavorite: Remove from favorites
 home:
   projectTattoo:
     title: About Project Tattoo

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 382 (191 per locale)
+/// Strings: 394 (197 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -44,6 +44,7 @@ class TranslationsEnUs extends Translations with BaseTranslations<AppLocale, Tra
 	@override late final _Translations$intro$en_US intro = _Translations$intro$en_US._(_root);
 	@override late final _Translations$login$en_US login = _Translations$login$en_US._(_root);
 	@override late final _Translations$nav$en_US nav = _Translations$nav$en_US._(_root);
+	@override late final _Translations$portal$en_US portal = _Translations$portal$en_US._(_root);
 	@override late final _Translations$home$en_US home = _Translations$home$en_US._(_root);
 	@override late final _Translations$score$en_US score = _Translations$score$en_US._(_root);
 	@override late final _Translations$calendar$en_US calendar = _Translations$calendar$en_US._(_root);
@@ -142,6 +143,21 @@ class _Translations$nav$en_US extends Translations$nav$zh_TW {
 	@override String get calendar => 'Calendar';
 	@override String get profile => 'Me';
 	@override String get vote => 'Vote Login';
+}
+
+// Path: portal
+class _Translations$portal$en_US extends Translations$portal$zh_TW {
+	_Translations$portal$en_US._(TranslationsEnUs root) : this._root = root, super.internal(root);
+
+	final TranslationsEnUs _root; // ignore: unused_field
+
+	// Translations
+	@override String get sourceNotice => 'This feature is still under development and may change significantly.';
+	@override String get openPortal => 'Open Campus Portal';
+	@override String get empty => 'No information systems are currently available.';
+	@override String get favorites => 'My Favorites';
+	@override String get addFavorite => 'Add to favorites';
+	@override String get removeFavorite => 'Remove from favorites';
 }
 
 // Path: home
@@ -666,6 +682,12 @@ extension on TranslationsEnUs {
 			'nav.calendar' => 'Calendar',
 			'nav.profile' => 'Me',
 			'nav.vote' => 'Vote Login',
+			'portal.sourceNotice' => 'This feature is still under development and may change significantly.',
+			'portal.openPortal' => 'Open Campus Portal',
+			'portal.empty' => 'No information systems are currently available.',
+			'portal.favorites' => 'My Favorites',
+			'portal.addFavorite' => 'Add to favorites',
+			'portal.removeFavorite' => 'Remove from favorites',
 			'home.projectTattoo.title' => 'About Project Tattoo',
 			'home.projectTattoo.description' => 'Learn more or invite your friends to join the testing program.',
 			'home.projectTattoo.url' => 'https://ntut.app',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -45,6 +45,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	late final Translations$intro$zh_TW intro = Translations$intro$zh_TW.internal(_root);
 	late final Translations$login$zh_TW login = Translations$login$zh_TW.internal(_root);
 	late final Translations$nav$zh_TW nav = Translations$nav$zh_TW.internal(_root);
+	late final Translations$portal$zh_TW portal = Translations$portal$zh_TW.internal(_root);
 	late final Translations$home$zh_TW home = Translations$home$zh_TW.internal(_root);
 	late final Translations$score$zh_TW score = Translations$score$zh_TW.internal(_root);
 	late final Translations$calendar$zh_TW calendar = Translations$calendar$zh_TW.internal(_root);
@@ -209,6 +210,33 @@ class Translations$nav$zh_TW {
 
 	/// zh-TW: '投票登入'
 	String get vote => '投票登入';
+}
+
+// Path: portal
+class Translations$portal$zh_TW {
+	Translations$portal$zh_TW.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// zh-TW: '此功能仍在開發中，可能會有較大的改動。'
+	String get sourceNotice => '此功能仍在開發中，可能會有較大的改動。';
+
+	/// zh-TW: '開啟校園入口網站'
+	String get openPortal => '開啟校園入口網站';
+
+	/// zh-TW: '目前沒有可用的資訊系統'
+	String get empty => '目前沒有可用的資訊系統';
+
+	/// zh-TW: '我的最愛'
+	String get favorites => '我的最愛';
+
+	/// zh-TW: '加入最愛'
+	String get addFavorite => '加入最愛';
+
+	/// zh-TW: '取消最愛'
+	String get removeFavorite => '取消最愛';
 }
 
 // Path: home
@@ -1009,6 +1037,12 @@ extension on Translations {
 			'nav.calendar' => '行事曆',
 			'nav.profile' => '我',
 			'nav.vote' => '投票登入',
+			'portal.sourceNotice' => '此功能仍在開發中，可能會有較大的改動。',
+			'portal.openPortal' => '開啟校園入口網站',
+			'portal.empty' => '目前沒有可用的資訊系統',
+			'portal.favorites' => '我的最愛',
+			'portal.addFavorite' => '加入最愛',
+			'portal.removeFavorite' => '取消最愛',
 			'home.projectTattoo.title' => '關於Project Tattoo',
 			'home.projectTattoo.description' => '查看更多資訊或邀請你的朋友加入測試計畫。',
 			'home.projectTattoo.url' => 'https://ntut.app',

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -54,6 +54,13 @@ nav:
   calendar: 行事曆
   profile: 我
   vote: 投票登入
+portal:
+  sourceNotice: 此功能仍在開發中，可能會有較大的改動。
+  openPortal: 開啟校園入口網站
+  empty: 目前沒有可用的資訊系統
+  favorites: 我的最愛
+  addFavorite: 加入最愛
+  removeFavorite: 取消最愛
 home:
   projectTattoo:
     title: 關於Project Tattoo

--- a/lib/repositories/portal_repository.dart
+++ b/lib/repositories/portal_repository.dart
@@ -1,0 +1,292 @@
+import 'dart:async';
+
+import 'package:drift/drift.dart';
+import 'package:riverpod/riverpod.dart';
+import 'package:tattoo/database/database.dart';
+import 'package:tattoo/repositories/auth_repository.dart';
+import 'package:tattoo/services/portal/portal_service.dart';
+
+/// A cached portal application together with its app-local favorite state.
+typedef PortalApplicationData = ({
+  PortalApplication application,
+  bool isFavorite,
+});
+
+/// A cached portal category and its applications in portal display order.
+typedef PortalApplicationCategoryData = ({
+  PortalApplicationCategory category,
+  List<PortalApplicationData> applications,
+});
+
+/// Provides the session-scoped [PortalRepository] instance.
+final portalRepositoryProvider = Provider<PortalRepository>((ref) {
+  ref.watch(sessionProvider);
+  return PortalRepository(
+    portalService: ref.watch(portalServiceProvider),
+    database: ref.watch(databaseProvider),
+    authRepository: ref.watch(authRepositoryProvider),
+  );
+});
+
+/// Manages the NTUT Portal application catalog and app-local favorites.
+class PortalRepository {
+  final PortalService _portalService;
+  final AppDatabase _database;
+  final AuthRepository _authRepository;
+  Completer<void>? _refreshInFlight;
+
+  PortalRepository({
+    required this._portalService,
+    required this._database,
+    required this._authRepository,
+  });
+
+  /// Watches the current user's cached application catalog.
+  ///
+  /// Cached data and favorite changes are emitted through the same Drift
+  /// stream. Missing data is fetched before the first empty value is yielded;
+  /// stale data is yielded immediately and refreshed in the background.
+  /// Network errors are absorbed so cached data remains available.
+  Stream<List<PortalApplicationCategoryData>> watchApplicationCatalog() async* {
+    const ttl = Duration(days: 1);
+
+    final user = await _database.select(_database.users).getSingleOrNull();
+    if (user == null) {
+      yield const [];
+      return;
+    }
+
+    final categories = _database.portalApplicationCategories;
+    final applications = _database.portalApplications;
+    final favorites = _database.portalApplicationFavorites;
+    final query =
+        _database.select(categories).join([
+            leftOuterJoin(
+              applications,
+              applications.category.equalsExp(categories.id),
+            ),
+            leftOuterJoin(
+              favorites,
+              favorites.user.equalsExp(categories.user) &
+                  favorites.applicationCode.equalsExp(applications.code),
+            ),
+          ])
+          ..where(categories.user.equals(user.id))
+          ..orderBy([
+            OrderingTerm.asc(categories.position),
+            OrderingTerm.asc(applications.position),
+          ]);
+
+    await for (final rows in query.watch()) {
+      final data = _mapCatalogRows(rows);
+      final currentUser = await (_database.select(
+        _database.users,
+      )..where((row) => row.id.equals(user.id))).getSingleOrNull();
+      if (currentUser == null) {
+        yield const [];
+        return;
+      }
+
+      var refreshedMissingCache = false;
+      if (currentUser.applicationCatalogFetchedAt == null) {
+        refreshedMissingCache = true;
+        try {
+          await refreshApplicationCatalog();
+        } catch (_) {
+          // Absorb: yield empty or stale data below.
+        }
+      }
+
+      yield data;
+
+      if (refreshedMissingCache) continue;
+      final freshUser = await (_database.select(
+        _database.users,
+      )..where((row) => row.id.equals(user.id))).getSingleOrNull();
+      final age = switch (freshUser?.applicationCatalogFetchedAt) {
+        final fetchedAt? => DateTime.now().difference(fetchedAt),
+        null => ttl,
+      };
+      if (age >= ttl) {
+        try {
+          await refreshApplicationCatalog();
+        } catch (_) {
+          // Absorb: stale data is already visible through the stream.
+        }
+      }
+    }
+  }
+
+  /// Fetches the complete catalog and atomically synchronizes the local cache.
+  ///
+  /// Concurrent calls coalesce. The portal session is refreshed through
+  /// [AuthRepository] when needed; no service-specific SSO is required because
+  /// this data comes from the portal itself.
+  Future<void> refreshApplicationCatalog() {
+    if (_refreshInFlight case final existing?) return existing.future;
+
+    final completer = Completer<void>();
+    _refreshInFlight = completer;
+    unawaited(_completeRefresh(completer));
+    return completer.future;
+  }
+
+  Future<void> _completeRefresh(Completer<void> completer) async {
+    try {
+      await _refreshApplicationCatalog();
+      completer.complete();
+    } catch (error, stackTrace) {
+      completer.completeError(error, stackTrace);
+    } finally {
+      _refreshInFlight = null;
+    }
+  }
+
+  Future<void> _refreshApplicationCatalog() async {
+    final user = await _database.select(_database.users).getSingle();
+    final catalog = await _authRepository.withAuth(
+      _portalService.getApplicationCatalog,
+    );
+
+    await _database.transaction(() async {
+      final fetchedCategoryIds = <int>{};
+      for (final (categoryPosition, categoryDto) in catalog.indexed) {
+        final category = await _database
+            .into(_database.portalApplicationCategories)
+            .insertReturning(
+              PortalApplicationCategoriesCompanion.insert(
+                user: user.id,
+                distinguishedName: categoryDto.distinguishedName,
+                name: categoryDto.name,
+                position: categoryPosition,
+              ),
+              onConflict: DoUpdate(
+                (old) => PortalApplicationCategoriesCompanion(
+                  name: Value(categoryDto.name),
+                  position: Value(categoryPosition),
+                ),
+                target: [
+                  _database.portalApplicationCategories.user,
+                  _database.portalApplicationCategories.distinguishedName,
+                ],
+              ),
+            );
+        fetchedCategoryIds.add(category.id);
+
+        final fetchedApplicationIds = <int>{};
+        for (final (applicationPosition, applicationDto)
+            in categoryDto.applications.indexed) {
+          final application = await _database
+              .into(_database.portalApplications)
+              .insertReturning(
+                PortalApplicationsCompanion.insert(
+                  category: category.id,
+                  code: applicationDto.code,
+                  name: applicationDto.name,
+                  iconUrl: Value(applicationDto.iconUrl),
+                  position: applicationPosition,
+                ),
+                onConflict: DoUpdate(
+                  (old) => PortalApplicationsCompanion(
+                    name: Value(applicationDto.name),
+                    iconUrl: Value(applicationDto.iconUrl),
+                    position: Value(applicationPosition),
+                  ),
+                  target: [
+                    _database.portalApplications.category,
+                    _database.portalApplications.code,
+                  ],
+                ),
+              );
+          fetchedApplicationIds.add(application.id);
+        }
+
+        final staleApplications =
+            _database.delete(
+              _database.portalApplications,
+            )..where((row) {
+              final inCategory = row.category.equals(category.id);
+              return fetchedApplicationIds.isEmpty
+                  ? inCategory
+                  : inCategory & row.id.isNotIn(fetchedApplicationIds);
+            });
+        await staleApplications.go();
+      }
+
+      final staleCategories =
+          _database.delete(
+            _database.portalApplicationCategories,
+          )..where((row) {
+            final belongsToUser = row.user.equals(user.id);
+            return fetchedCategoryIds.isEmpty
+                ? belongsToUser
+                : belongsToUser & row.id.isNotIn(fetchedCategoryIds);
+          });
+      await staleCategories.go();
+
+      await (_database.update(
+        _database.users,
+      )..where((row) => row.id.equals(user.id))).write(
+        UsersCompanion(
+          applicationCatalogFetchedAt: Value(DateTime.now()),
+        ),
+      );
+    });
+  }
+
+  /// Sets one app-local favorite without changing NTUT Portal bookmarks.
+  Future<void> setApplicationFavorite({
+    required String applicationCode,
+    required bool isFavorite,
+  }) async {
+    if (applicationCode.isEmpty) {
+      throw ArgumentError.value(
+        applicationCode,
+        'applicationCode',
+        'Application code cannot be empty.',
+      );
+    }
+
+    final user = await _database.select(_database.users).getSingle();
+    if (isFavorite) {
+      await _database
+          .into(_database.portalApplicationFavorites)
+          .insert(
+            PortalApplicationFavoritesCompanion.insert(
+              user: user.id,
+              applicationCode: applicationCode,
+            ),
+            mode: InsertMode.insertOrIgnore,
+          );
+      return;
+    }
+
+    await (_database.delete(_database.portalApplicationFavorites)..where(
+          (row) =>
+              row.user.equals(user.id) &
+              row.applicationCode.equals(applicationCode),
+        ))
+        .go();
+  }
+
+  List<PortalApplicationCategoryData> _mapCatalogRows(
+    List<TypedResult> rows,
+  ) {
+    final grouped = <int, PortalApplicationCategoryData>{};
+    for (final row in rows) {
+      final category = row.readTable(_database.portalApplicationCategories);
+      final group = grouped.putIfAbsent(
+        category.id,
+        () => (category: category, applications: []),
+      );
+      final application = row.readTableOrNull(_database.portalApplications);
+      if (application == null) continue;
+      group.applications.add((
+        application: application,
+        isFavorite:
+            row.readTableOrNull(_database.portalApplicationFavorites) != null,
+      ));
+    }
+    return grouped.values.toList();
+  }
+}

--- a/lib/repositories/portal_repository.dart
+++ b/lib/repositories/portal_repository.dart
@@ -149,6 +149,31 @@ class PortalRepository {
     );
 
     await _database.transaction(() async {
+      final cachedEnglishNames =
+          await (_database
+                  .select(
+                    _database.portalApplications,
+                  )
+                  .join([
+                    innerJoin(
+                      _database.portalApplicationCategories,
+                      _database.portalApplicationCategories.id.equalsExp(
+                        _database.portalApplications.category,
+                      ),
+                    ),
+                  ])
+                ..where(
+                  _database.portalApplicationCategories.user.equals(user.id),
+                ))
+              .get();
+      final cachedApplicationNameEnByCode = <String, String>{};
+      for (final row in cachedEnglishNames) {
+        final application = row.readTable(_database.portalApplications);
+        if (application.nameEn case final name?) {
+          cachedApplicationNameEnByCode[application.code] = name;
+        }
+      }
+
       final fetchedCategoryIds = <int>{};
       for (final (categoryPosition, categoryDto) in catalog.indexed) {
         final category = await _database
@@ -157,12 +182,14 @@ class PortalRepository {
               PortalApplicationCategoriesCompanion.insert(
                 user: user.id,
                 distinguishedName: categoryDto.distinguishedName,
-                name: categoryDto.name,
+                nameZh: categoryDto.nameZh,
+                nameEn: Value(categoryDto.nameEn),
                 position: categoryPosition,
               ),
               onConflict: DoUpdate(
                 (old) => PortalApplicationCategoriesCompanion(
-                  name: Value(categoryDto.name),
+                  nameZh: Value(categoryDto.nameZh),
+                  nameEn: .absentIfNull(categoryDto.nameEn),
                   position: Value(categoryPosition),
                 ),
                 target: [
@@ -176,19 +203,24 @@ class PortalRepository {
         final fetchedApplicationIds = <int>{};
         for (final (applicationPosition, applicationDto)
             in categoryDto.applications.indexed) {
+          final nameEn =
+              applicationDto.nameEn ??
+              cachedApplicationNameEnByCode[applicationDto.code];
           final application = await _database
               .into(_database.portalApplications)
               .insertReturning(
                 PortalApplicationsCompanion.insert(
                   category: category.id,
                   code: applicationDto.code,
-                  name: applicationDto.name,
+                  nameZh: applicationDto.nameZh,
+                  nameEn: Value(nameEn),
                   iconUrl: Value(applicationDto.iconUrl),
                   position: applicationPosition,
                 ),
                 onConflict: DoUpdate(
                   (old) => PortalApplicationsCompanion(
-                    name: Value(applicationDto.name),
+                    nameZh: Value(applicationDto.nameZh),
+                    nameEn: .absentIfNull(nameEn),
                     iconUrl: Value(applicationDto.iconUrl),
                     position: Value(applicationPosition),
                   ),

--- a/lib/repositories/portal_repository.dart
+++ b/lib/repositories/portal_repository.dart
@@ -56,6 +56,15 @@ class PortalRepository {
       return;
     }
 
+    final attemptedInitialRefresh = user.applicationCatalogFetchedAt == null;
+    if (attemptedInitialRefresh) {
+      try {
+        await refreshApplicationCatalog();
+      } catch (_) {
+        // Absorb: the initial query snapshot below yields empty or stale data.
+      }
+    }
+
     final categories = _database.portalApplicationCategories;
     final applications = _database.portalApplications;
     final favorites = _database.portalApplicationFavorites;
@@ -87,19 +96,9 @@ class PortalRepository {
         return;
       }
 
-      var refreshedMissingCache = false;
-      if (currentUser.applicationCatalogFetchedAt == null) {
-        refreshedMissingCache = true;
-        try {
-          await refreshApplicationCatalog();
-        } catch (_) {
-          // Absorb: yield empty or stale data below.
-        }
-      }
-
       yield data;
 
-      if (refreshedMissingCache) continue;
+      if (attemptedInitialRefresh) continue;
       final freshUser = await (_database.select(
         _database.users,
       )..where((row) => row.id.equals(user.id))).getSingleOrNull();
@@ -279,7 +278,8 @@ class PortalRepository {
       );
     }
 
-    final user = await _database.select(_database.users).getSingle();
+    final user = await _database.select(_database.users).getSingleOrNull();
+    if (user == null) return;
     if (isFavorite) {
       await _database
           .into(_database.portalApplicationFavorites)

--- a/lib/repositories/portal_repository.dart
+++ b/lib/repositories/portal_repository.dart
@@ -56,8 +56,8 @@ class PortalRepository {
       return;
     }
 
-    final attemptedInitialRefresh = user.applicationCatalogFetchedAt == null;
-    if (attemptedInitialRefresh) {
+    var skipNextStalenessCheck = user.applicationCatalogFetchedAt == null;
+    if (skipNextStalenessCheck) {
       try {
         await refreshApplicationCatalog();
       } catch (_) {
@@ -98,7 +98,10 @@ class PortalRepository {
 
       yield data;
 
-      if (attemptedInitialRefresh) continue;
+      if (skipNextStalenessCheck) {
+        skipNextStalenessCheck = false;
+        continue;
+      }
       final freshUser = await (_database.select(
         _database.users,
       )..where((row) => row.id.equals(user.id))).getSingleOrNull();

--- a/lib/repositories/portal_repository.dart
+++ b/lib/repositories/portal_repository.dart
@@ -291,7 +291,7 @@ class PortalRepository {
               user: user.id,
               applicationCode: applicationCode,
             ),
-            mode: InsertMode.insertOrIgnore,
+            mode: .insertOrIgnore,
           );
       return;
     }

--- a/lib/screens/main/portal/portal_screen.dart
+++ b/lib/screens/main/portal/portal_screen.dart
@@ -5,118 +5,14 @@ import 'package:tattoo/components/notices.dart';
 import 'package:tattoo/components/section_header.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/auth_repository.dart';
+import 'package:tattoo/repositories/portal_repository.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 import 'package:tattoo/utils/launch_url.dart';
+import 'package:tattoo/utils/localized.dart';
 
-// TODO: Fetch portal services from backend instead of hardcoding.
-final _portalSections =
-    <
-      ({
-        String title,
-        List<({String title, String serviceCode})> services,
-      })
-    >[
-      (
-        title: '學務系統',
-        services: [
-          (
-            title: '學生查詢系統',
-            serviceCode: 'sa_003_oauth',
-          ),
-          (
-            title: '學生請假系統',
-            serviceCode: 'sa_010_oauth',
-          ),
-          (
-            title: '學雜費減免及弱勢助學申請系統',
-            serviceCode: 'NTUT_exemption_oauth',
-          ),
-          (
-            title: '就學貸款申請系統',
-            serviceCode: 'sa_SLAS_oauth',
-          ),
-          (
-            title: '諮商預約系統',
-            serviceCode: 'counseling_oauth',
-          ),
-        ],
-      ),
-      (
-        title: '教務系統',
-        services: [
-          (
-            title: '課程系統',
-            serviceCode: 'aa_0010-oauth',
-          ),
-          (
-            title: '期末網路教學評量系統',
-            serviceCode: 'aa_009_oauth',
-          ),
-          (
-            title: '期末網路預選系統',
-            serviceCode: 'aa_011_oauth',
-          ),
-          (
-            title: '暑修需求登錄',
-            serviceCode: 'aa_015_oauth',
-          ),
-          (
-            title: '期中網路撤選系統（學生）',
-            serviceCode: 'aa_Online+Course+Withdrawal+System_stu_oauth',
-          ),
-        ],
-      ),
-      (
-        title: '總務系統',
-        services: [
-          (
-            title: '建物與設備維修通報單錄案系統',
-            serviceCode: 'ga_008_oauth',
-          ),
-          (
-            title: '化學物質GHS管理系統',
-            serviceCode: 'ga_ghs_oauth',
-          ),
-          (
-            title: '線上繳費系統',
-            serviceCode: 'OnlinePayment_oauth',
-          ),
-        ],
-      ),
-      (
-        title: '資訊服務',
-        services: [
-          (
-            title: '網路投票系統',
-            serviceCode: 'per_001_oauth',
-          ),
-          (
-            title: '網路與資訊安全管理系統',
-            serviceCode: 'ipmac_oauth',
-          ),
-          (
-            title: '校園授權軟體',
-            serviceCode: 'inf001_oauth',
-          ),
-          (
-            title: '電子郵件/網路郵局WebMail',
-            serviceCode: 'zimbrasso_oauth',
-          ),
-          (
-            title: '臺北科大小郵差',
-            serviceCode: 'test_postman',
-          ),
-        ],
-      ),
-      (
-        title: '圖書館系統',
-        services: [
-          (
-            title: '圖書館系統',
-            serviceCode: 'lib_002_oauth',
-          ),
-        ],
-      ),
-    ];
+final _portalApplicationCatalogProvider = StreamProvider(
+  (ref) => ref.watch(portalRepositoryProvider).watchApplicationCatalog(),
+);
 
 class PortalScreen extends ConsumerWidget {
   const PortalScreen({super.key});
@@ -141,50 +37,189 @@ class PortalScreen extends ConsumerWidget {
     }
   }
 
+  Future<void> _setFavorite(
+    BuildContext context,
+    WidgetRef ref,
+    String applicationCode,
+    bool isFavorite,
+  ) async {
+    try {
+      await ref
+          .read(portalRepositoryProvider)
+          .setApplicationFavorite(
+            applicationCode: applicationCode,
+            isFavorite: isFavorite,
+          );
+    } catch (_) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(SnackBar(content: Text(t.errors.occurred)));
+    }
+  }
+
+  Future<void> _refresh(BuildContext context, WidgetRef ref) async {
+    try {
+      await ref.read(portalRepositoryProvider).refreshApplicationCatalog();
+    } catch (_) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(SnackBar(content: Text(t.errors.occurred)));
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(title: Text(t.nav.portal)),
       body: SafeArea(
-        child: CustomScrollView(
-          slivers: [
-            SliverPadding(
-              padding: const .all(16),
-              sliver: SliverToBoxAdapter(
-                child: Column(
-                  crossAxisAlignment: .center,
-                  spacing: 12,
-                  children: [
-                    ClearNotice(text: "此功能尚在實驗階段，未讀取可用功能，與實際系統可能有差異"),
-                    // TODO: auto-login to nportal
-                    _PortalCard(
-                      title: "打開校園入口網站",
-                      onTap: () => launchUrl(
-                        .parse('https://nportal.ntut.edu.tw'),
-                      ),
-                    ),
-                    for (final section in _portalSections)
-                      Column(
-                        crossAxisAlignment: .center,
-                        spacing: 4,
-                        children: [
-                          SectionHeader(title: section.title),
-                          for (final service in section.services)
-                            _PortalCard(
-                              title: service.title,
-                              onTap: () => _openNtutService(
-                                context,
-                                ref,
-                                service.serviceCode,
-                              ),
-                            ),
-                        ],
-                      ),
-                  ],
-                ),
+        child: ref
+            .watch(_portalApplicationCatalogProvider)
+            .when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (_, _) => Center(child: Text(t.errors.connectionFailed)),
+              data: (categories) => _PortalCatalog(
+                categories: categories,
+                onRefresh: () => _refresh(context, ref),
+                onOpen: (code) => _openNtutService(context, ref, code),
+                onFavoriteChanged: (code, favorite) =>
+                    _setFavorite(context, ref, code, favorite),
               ),
             ),
-          ],
+      ),
+    );
+  }
+}
+
+class _PortalCatalog extends StatelessWidget {
+  const _PortalCatalog({
+    required this.categories,
+    required this.onRefresh,
+    required this.onOpen,
+    required this.onFavoriteChanged,
+  });
+
+  final List<PortalApplicationCategoryData> categories;
+  final RefreshCallback onRefresh;
+  final ValueChanged<String> onOpen;
+  final Future<void> Function(String code, bool favorite) onFavoriteChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final visibleCategories = categories
+        .where((category) => category.applications.isNotEmpty)
+        .toList();
+    final favorites = visibleCategories
+        .expand((category) => category.applications)
+        .where((application) => application.isFavorite)
+        .toList();
+
+    return RefreshIndicator(
+      onRefresh: onRefresh,
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          SliverPadding(
+            padding: const .all(16),
+            sliver: SliverToBoxAdapter(
+              child: Column(
+                crossAxisAlignment: .center,
+                spacing: 12,
+                children: [
+                  ClearNotice(text: t.portal.sourceNotice.spaced),
+                  _PortalCard(
+                    title: t.portal.openPortal,
+                    onTap: () => launchUrl(
+                      .parse('https://nportal.ntut.edu.tw'),
+                    ),
+                  ),
+                  if (visibleCategories.isEmpty)
+                    ClearNotice(text: t.portal.empty),
+                  if (favorites.isNotEmpty) ...[
+                    SectionHeader(title: t.portal.favorites),
+                    for (final favorite in favorites)
+                      _ApplicationCard(
+                        application: favorite,
+                        onOpen: onOpen,
+                        onFavoriteChanged: onFavoriteChanged,
+                      ),
+                  ],
+                  for (final category in visibleCategories)
+                    Column(
+                      crossAxisAlignment: .center,
+                      spacing: 4,
+                      children: [
+                        SectionHeader(
+                          title: localized(
+                            category.category.nameZh,
+                            category.category.nameEn,
+                          ).spaced,
+                        ),
+                        for (final application in category.applications)
+                          _ApplicationCard(
+                            application: application,
+                            onOpen: onOpen,
+                            onFavoriteChanged: onFavoriteChanged,
+                          ),
+                      ],
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ApplicationCard extends StatelessWidget {
+  const _ApplicationCard({
+    required this.application,
+    required this.onOpen,
+    required this.onFavoriteChanged,
+  });
+
+  final PortalApplicationData application;
+  final ValueChanged<String> onOpen;
+  final Future<void> Function(String code, bool favorite) onFavoriteChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final data = application.application;
+    return Card(
+      clipBehavior: .antiAlias,
+      child: InkWell(
+        onTap: () => onOpen(data.code),
+        child: Padding(
+          padding: const .only(left: 16, top: 4, bottom: 4),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  localized(data.nameZh, data.nameEn).spaced,
+                  maxLines: 2,
+                  overflow: .ellipsis,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ),
+              IconButton(
+                tooltip: application.isFavorite
+                    ? t.portal.removeFavorite
+                    : t.portal.addFavorite,
+                onPressed: () async {
+                  await onFavoriteChanged(
+                    data.code,
+                    !application.isFavorite,
+                  );
+                },
+                icon: Icon(
+                  application.isFavorite ? Icons.star : Icons.star_border,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/services/portal/mock_portal_service.dart
+++ b/lib/services/portal/mock_portal_service.dart
@@ -154,32 +154,38 @@ class MockPortalService implements PortalService {
         [
           (
             distinguishedName: 'OU=aa,OU=aproot',
-            name: '教務系統',
+            nameZh: '教務系統',
+            nameEn: 'System of Academic Affairs',
             applications: [
               (
                 code: PortalServiceCode.courseService.code,
-                name: '課程系統',
+                nameZh: '課程系統',
+                nameEn: 'Curriculum System',
                 iconUrl: null,
               ),
               (
                 code: PortalServiceCode.iSchoolPlusService.code,
-                name: '北科i學園PLUS（校外連線請用VPN）',
+                nameZh: '北科i學園PLUS（校外連線請用VPN）',
+                nameEn: 'ischool_plus（Please use VPN for off-campus）',
                 iconUrl: null,
               ),
             ],
           ),
           (
             distinguishedName: 'OU=sa,OU=aproot',
-            name: '學務系統',
+            nameZh: '學務系統',
+            nameEn: 'Student Affairs System',
             applications: [
               (
                 code: PortalServiceCode.studentQueryService.code,
-                name: '學生查詢專區',
+                nameZh: '學生查詢專區',
+                nameEn: 'Student Inquiry System',
                 iconUrl: null,
               ),
               (
                 code: 'sa_010_oauth',
-                name: '學生請假系統',
+                nameZh: '學生請假系統',
+                nameEn: 'Student Leave System',
                 iconUrl: null,
               ),
             ],

--- a/lib/services/portal/mock_portal_service.dart
+++ b/lib/services/portal/mock_portal_service.dart
@@ -10,6 +10,7 @@ class MockPortalService implements PortalService {
   String? uploadAvatarResult;
   Uri? ssoUrlResult;
   List<CalendarEventDto>? calendarResult;
+  List<PortalApplicationCategoryDto>? applicationCatalogResult;
 
   @override
   Future<UserDto> login(String username, String password) async {
@@ -143,6 +144,45 @@ class MockPortalService implements PortalService {
             content: null,
             ownerName: '學校行事曆',
             creatorName: '教務處',
+          ),
+        ];
+  }
+
+  @override
+  Future<List<PortalApplicationCategoryDto>> getApplicationCatalog() async {
+    return applicationCatalogResult ??
+        [
+          (
+            distinguishedName: 'OU=aa,OU=aproot',
+            name: '教務系統',
+            applications: [
+              (
+                code: PortalServiceCode.courseService.code,
+                name: '課程系統',
+                iconUrl: null,
+              ),
+              (
+                code: PortalServiceCode.iSchoolPlusService.code,
+                name: '北科i學園PLUS（校外連線請用VPN）',
+                iconUrl: null,
+              ),
+            ],
+          ),
+          (
+            distinguishedName: 'OU=sa,OU=aproot',
+            name: '學務系統',
+            applications: [
+              (
+                code: PortalServiceCode.studentQueryService.code,
+                name: '學生查詢專區',
+                iconUrl: null,
+              ),
+              (
+                code: 'sa_010_oauth',
+                name: '學生請假系統',
+                iconUrl: null,
+              ),
+            ],
           ),
         ];
   }

--- a/lib/services/portal/ntut_portal_service.dart
+++ b/lib/services/portal/ntut_portal_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -10,12 +11,27 @@ import 'package:tattoo/models/login_exception.dart';
 import 'package:tattoo/services/portal/portal_service.dart';
 import 'package:tattoo/utils/http.dart';
 
+typedef _PortalApplicationPageDto = ({
+  String code,
+  String name,
+  String? iconUrl,
+});
+
+typedef _PortalApplicationCategoryPageDto = ({
+  String distinguishedName,
+  String name,
+  List<_PortalApplicationPageDto> applications,
+});
+
 class NtutPortalService implements PortalService {
+  static const _chineseLocale = 'zh_TW';
+  static const _englishLocale = 'en';
   static final _folderCallPattern = RegExp(
     r"apPopupSubEip5\('([^']+)','apMap','([^']*)'\)",
   );
 
   late final Dio _portalDio;
+  Future<void> _catalogLocaleOperation = Future.value();
 
   NtutPortalService() {
     // Emulate the NTUT iOS app's HTTP client
@@ -280,7 +296,44 @@ class NtutPortalService implements PortalService {
   }
 
   @override
-  Future<List<PortalApplicationCategoryDto>> getApplicationCatalog() async {
+  Future<List<PortalApplicationCategoryDto>> getApplicationCatalog() {
+    return _withCatalogLocaleLock(() async {
+      await _setPortalLocale(_chineseLocale);
+      final chinese = await _getApplicationCatalogForCurrentLocale();
+
+      List<_PortalApplicationCategoryPageDto> english = const [];
+      Object? operationError;
+      try {
+        await _setPortalLocale(_englishLocale);
+        english = await _getApplicationCatalogForCurrentLocale();
+      } on SessionExpiredException catch (error) {
+        operationError = error;
+        rethrow;
+      } catch (_) {
+        // Match CourseService's bilingual behavior: English enriches the
+        // canonical Chinese response, but its instability must not make the
+        // complete catalog unavailable.
+      } finally {
+        // The portal locale is server-side session state. Always restore the
+        // app's established Chinese source state, including failure paths.
+        try {
+          await _setPortalLocale(_chineseLocale);
+        } catch (restoreError, restoreStackTrace) {
+          // Preserve the root failure when both the crawl and cleanup fail.
+          // If the crawl succeeded, fail the refresh so the repository does
+          // not mark an uncertain portal session state as freshly cached.
+          if (operationError == null) {
+            Error.throwWithStackTrace(restoreError, restoreStackTrace);
+          }
+        }
+      }
+
+      return _mergeApplicationCatalog(chinese, english);
+    });
+  }
+
+  Future<List<_PortalApplicationCategoryPageDto>>
+  _getApplicationCatalogForCurrentLocale() async {
     final response = await _getApplicationPage(queryParameters: {'init': ''});
     final document = _parseApplicationPage(response.data!);
     final categories = _parseApplicationCategories(document);
@@ -290,7 +343,7 @@ class NtutPortalService implements PortalService {
       );
     }
 
-    final result = <PortalApplicationCategoryDto>[];
+    final result = <_PortalApplicationCategoryPageDto>[];
     for (final category in categories) {
       final applications = await _getCategoryApplications(
         category.distinguishedName,
@@ -303,6 +356,44 @@ class NtutPortalService implements PortalService {
       ));
     }
     return result;
+  }
+
+  Future<void> _setPortalLocale(String locale) async {
+    final response = await _portalDio.post<String>(
+      'localeModify.do',
+      data: {'localeId': locale},
+      options: Options(
+        contentType: Headers.formUrlEncodedContentType,
+        responseType: .plain,
+        headers: const {'X-Requested-With': 'XMLHttpRequest'},
+      ),
+    );
+    final body = response.data?.trim() ?? '';
+    _throwIfPortalSessionExpired(body);
+    if (body != locale) {
+      throw FormatException(
+        'NTUT Portal did not confirm locale $locale.',
+      );
+    }
+
+    final reload = await _portalDio.get<String>(
+      'localeReload.do',
+      queryParameters: {'locale': body},
+      options: Options(responseType: .plain),
+    );
+    _throwIfPortalSessionExpired(reload.data ?? '');
+  }
+
+  Future<T> _withCatalogLocaleLock<T>(Future<T> Function() operation) async {
+    final previous = _catalogLocaleOperation;
+    final release = Completer<void>();
+    _catalogLocaleOperation = release.future;
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release.complete();
+    }
   }
 
   Future<Response<String>> _getApplicationPage({
@@ -319,15 +410,17 @@ class NtutPortalService implements PortalService {
   }
 
   Document _parseApplicationPage(String html) {
+    _throwIfPortalSessionExpired(html);
     final document = parse(html);
-    final text = document.body?.text ?? '';
-    if (document.querySelector('title')?.text.trim() == '請重新登入' ||
-        text.contains('請重新登入') ||
-        text.contains('您目前已和伺服器中斷連線') ||
-        text.contains('You have been disconnected from the server')) {
+    return document;
+  }
+
+  void _throwIfPortalSessionExpired(String body) {
+    if (body.contains('請重新登入') ||
+        body.contains('您目前已和伺服器中斷連線') ||
+        body.contains('You have been disconnected from the server')) {
       throw const SessionExpiredException('NTUT Portal session expired');
     }
-    return document;
   }
 
   List<({String distinguishedName, String name})> _parseApplicationCategories(
@@ -343,7 +436,7 @@ class NtutPortalService implements PortalService {
     return categories;
   }
 
-  Future<List<PortalApplicationDto>> _getCategoryApplications(
+  Future<List<_PortalApplicationPageDto>> _getCategoryApplications(
     String distinguishedName, {
     required Set<String> visitedFolders,
   }) async {
@@ -356,7 +449,7 @@ class NtutPortalService implements PortalService {
       },
     );
     final document = _parseApplicationPage(response.data!);
-    final applications = <PortalApplicationDto>[];
+    final applications = <_PortalApplicationPageDto>[];
     final seenCodes = <String>{};
 
     for (final item in document.querySelectorAll('.apt-icon')) {
@@ -383,7 +476,10 @@ class NtutPortalService implements PortalService {
     return applications;
   }
 
-  PortalApplicationDto? _parseApplication(Element item, Uri responseUri) {
+  _PortalApplicationPageDto? _parseApplication(
+    Element item,
+    Uri responseUri,
+  ) {
     Element? link;
     for (final candidate in item.querySelectorAll('a[href]')) {
       final href = candidate.attributes['href'];
@@ -419,6 +515,49 @@ class NtutPortalService implements PortalService {
       iconUrl: iconPath == null || iconPath.isEmpty
           ? null
           : responseUri.resolve(iconPath).toString(),
+    );
+  }
+
+  List<PortalApplicationCategoryDto> _mergeApplicationCatalog(
+    List<_PortalApplicationCategoryPageDto> chinese,
+    List<_PortalApplicationCategoryPageDto> english,
+  ) {
+    final englishByDn = {
+      for (final category in english) category.distinguishedName: category,
+    };
+    final englishApplicationsByCode = {
+      for (final category in english)
+        for (final application in category.applications)
+          application.code: application,
+    };
+    return [
+      for (final category in chinese)
+        _mergeApplicationCategory(
+          chinese: category,
+          english: englishByDn[category.distinguishedName],
+          englishApplicationsByCode: englishApplicationsByCode,
+        ),
+    ];
+  }
+
+  PortalApplicationCategoryDto _mergeApplicationCategory({
+    required _PortalApplicationCategoryPageDto chinese,
+    _PortalApplicationCategoryPageDto? english,
+    required Map<String, _PortalApplicationPageDto> englishApplicationsByCode,
+  }) {
+    return (
+      distinguishedName: chinese.distinguishedName,
+      nameZh: chinese.name,
+      nameEn: english?.name,
+      applications: [
+        for (final application in chinese.applications)
+          (
+            code: application.code,
+            nameZh: application.name,
+            nameEn: englishApplicationsByCode[application.code]?.name,
+            iconUrl: application.iconUrl,
+          ),
+      ],
     );
   }
 

--- a/lib/services/portal/ntut_portal_service.dart
+++ b/lib/services/portal/ntut_portal_service.dart
@@ -561,8 +561,9 @@ class NtutPortalService implements PortalService {
       final href = candidate.attributes['href'];
       if (href == null) continue;
       final uri = Uri.tryParse(href);
+      final endpoint = uri?.path.split('/').last;
       if (uri == null ||
-          (uri.path != 'ssoIndex.do' && uri.path != 'ssoFromOu.do') ||
+          (endpoint != 'ssoIndex.do' && endpoint != 'ssoFromOu.do') ||
           !uri.queryParameters.containsKey('apOu')) {
         continue;
       }

--- a/lib/services/portal/ntut_portal_service.dart
+++ b/lib/services/portal/ntut_portal_service.dart
@@ -430,8 +430,15 @@ class NtutPortalService implements PortalService {
     final seen = <String>{};
     for (final anchor in document.querySelectorAll('a.dropdown-item[href]')) {
       final folder = _parseFolderCall(anchor.attributes['href']);
-      if (folder == null || !seen.add(folder.distinguishedName)) continue;
-      categories.add(folder);
+      if (folder == null ||
+          folder.name.trim().isEmpty ||
+          !seen.add(folder.distinguishedName)) {
+        continue;
+      }
+      categories.add((
+        distinguishedName: folder.distinguishedName,
+        name: folder.name.trim(),
+      ));
     }
     return categories;
   }

--- a/lib/services/portal/ntut_portal_service.dart
+++ b/lib/services/portal/ntut_portal_service.dart
@@ -26,12 +26,18 @@ typedef _PortalApplicationCategoryPageDto = ({
 class NtutPortalService implements PortalService {
   static const _chineseLocale = 'zh_TW';
   static const _englishLocale = 'en';
+  // The mobile home endpoint is a JSON feed and exposes no locale marker.
+  // This category has a stable DN and is translated in both portal locales.
+  static const _academicCategoryDnPrefix = 'OU=aa,';
+  static const _chineseAcademicCategoryName = '教務系統';
+  static const _englishAcademicCategoryName = 'System of Academic Affairs';
   static final _folderCallPattern = RegExp(
     r"apPopupSubEip5\('([^']+)','apMap','([^']*)'\)",
   );
 
   late final Dio _portalDio;
-  Future<void> _catalogLocaleOperation = Future.value();
+  Future<void> _portalLocaleOperation = Future.value();
+  bool _portalLocaleStateUncertain = false;
 
   NtutPortalService() {
     // Emulate the NTUT iOS app's HTTP client
@@ -73,6 +79,7 @@ class NtutPortalService implements PortalService {
     }
 
     final String? passwordExpiredRemind = body['passwordExpiredRemind'];
+    _portalLocaleStateUncertain = false;
 
     // Normalize empty strings to null for consistency
     String? normalizeEmpty(String? value) =>
@@ -154,56 +161,60 @@ class NtutPortalService implements PortalService {
   }
 
   @override
-  Future<void> sso(String serviceCode) async {
-    final (actionUrl, formData) = await _fetchSsoForm(serviceCode);
+  Future<void> sso(String serviceCode) {
+    return _withPortalLocaleLock(() async {
+      final (actionUrl, formData) = await _fetchSsoForm(serviceCode);
 
-    // Prepend the invalid cookie filter interceptor for i-School Plus SSO
-    if (serviceCode == PortalServiceCode.iSchoolPlusService.code) {
-      _portalDio.interceptors.insert(0, InvalidCookieFilter());
-      _portalDio.transformer = PlainTextTransformer();
-    }
+      // Prepend the invalid cookie filter interceptor for i-School Plus SSO
+      if (serviceCode == PortalServiceCode.iSchoolPlusService.code) {
+        _portalDio.interceptors.insert(0, InvalidCookieFilter());
+        _portalDio.transformer = PlainTextTransformer();
+      }
 
-    // Submit the SSO form and follow redirects
-    // Sets the necessary cookies for the target service
-    await _portalDio.post(
-      actionUrl,
-      data: formData,
-      options: Options(contentType: Headers.formUrlEncodedContentType),
-    );
+      // Submit the SSO form and follow redirects
+      // Sets the necessary cookies for the target service
+      await _portalDio.post(
+        actionUrl,
+        data: formData,
+        options: Options(contentType: Headers.formUrlEncodedContentType),
+      );
+    });
   }
 
   @override
-  Future<Uri> getSsoUrl(String serviceCode) async {
-    final (actionUrl, formData) = await _fetchSsoForm(serviceCode);
+  Future<Uri> getSsoUrl(String serviceCode) {
+    return _withPortalLocaleLock(() async {
+      final (actionUrl, formData) = await _fetchSsoForm(serviceCode);
 
-    // Clone and strip RedirectInterceptor so we can capture the 302 Location
-    // instead of following it.
-    final dioWithoutRedirects = _portalDio.clone()
-      ..interceptors.removeWhere(
-        (interceptor) => interceptor is RedirectInterceptor,
+      // Clone and strip RedirectInterceptor so we can capture the 302 Location
+      // instead of following it.
+      final dioWithoutRedirects = _portalDio.clone()
+        ..interceptors.removeWhere(
+          (interceptor) => interceptor is RedirectInterceptor,
+        );
+
+      final response = await dioWithoutRedirects.post(
+        actionUrl,
+        data: formData,
+        options: Options(
+          contentType: Headers.formUrlEncodedContentType,
+          followRedirects: false,
+          validateStatus: (status) => status != null && status < 400,
+        ),
       );
 
-    final response = await dioWithoutRedirects.post(
-      actionUrl,
-      data: formData,
-      options: Options(
-        contentType: Headers.formUrlEncodedContentType,
-        followRedirects: false,
-        validateStatus: (status) => status != null && status < 400,
-      ),
-    );
+      final location = response.headers.value('location');
+      if (location == null) {
+        throw Exception('SSO redirect not received. Are you logged in?');
+      }
 
-    final location = response.headers.value('location');
-    if (location == null) {
-      throw Exception('SSO redirect not received. Are you logged in?');
-    }
-
-    // The portal may return http:// URLs; upgrade to https://
-    var uri = Uri.parse(location);
-    if (uri.scheme == 'http') {
-      uri = uri.replace(scheme: 'https');
-    }
-    return uri;
+      // The portal may return http:// URLs; upgrade to https://
+      var uri = Uri.parse(location);
+      if (uri.scheme == 'http') {
+        uri = uri.replace(scheme: 'https');
+      }
+      return uri;
+    });
   }
 
   /// Fetches and parses the SSO form for a given apOu code.
@@ -297,45 +308,98 @@ class NtutPortalService implements PortalService {
 
   @override
   Future<List<PortalApplicationCategoryDto>> getApplicationCatalog() {
-    return _withCatalogLocaleLock(() async {
-      await _setPortalLocale(_chineseLocale);
-      final chinese = await _getApplicationCatalogForCurrentLocale();
-
-      List<_PortalApplicationCategoryPageDto> english = const [];
+    return _withPortalLocaleLock(() async {
+      final initialResponse = await _getApplicationPage(
+        queryParameters: {'init': ''},
+      );
+      final initialDocument = _parseApplicationPage(initialResponse.data!);
+      final originalLocale = _parsePortalLocale(initialDocument);
+      var localeMutationAttempted = false;
       Object? operationError;
       try {
-        await _setPortalLocale(_englishLocale);
-        english = await _getApplicationCatalogForCurrentLocale();
-      } on SessionExpiredException catch (error) {
+        List<_PortalApplicationCategoryPageDto> english = const [];
+        late final List<_PortalApplicationCategoryPageDto> chinese;
+        if (originalLocale == _englishLocale) {
+          try {
+            english = await _getApplicationCatalogForCurrentLocale(
+              categoryDocument: initialDocument,
+            );
+          } on SessionExpiredException {
+            rethrow;
+          } catch (_) {
+            // English is optional; continue with the canonical Chinese crawl.
+          }
+          localeMutationAttempted = true;
+          await _setPortalLocale(_chineseLocale);
+          chinese = await _getApplicationCatalogForCurrentLocale();
+        } else {
+          chinese = await _getApplicationCatalogForCurrentLocale(
+            categoryDocument: initialDocument,
+          );
+          localeMutationAttempted = true;
+          await _setPortalLocale(_englishLocale);
+          try {
+            english = await _getApplicationCatalogForCurrentLocale();
+          } on SessionExpiredException {
+            rethrow;
+          } catch (_) {
+            // Match CourseService's bilingual behavior: English enriches the
+            // canonical Chinese response, but its instability must not make
+            // the complete catalog unavailable.
+          }
+        }
+
+        return _mergeApplicationCatalog(chinese, english);
+      } catch (error) {
         operationError = error;
         rethrow;
-      } catch (_) {
-        // Match CourseService's bilingual behavior: English enriches the
-        // canonical Chinese response, but its instability must not make the
-        // complete catalog unavailable.
       } finally {
-        // The portal locale is server-side session state. Always restore the
-        // app's established Chinese source state, including failure paths.
-        try {
-          await _setPortalLocale(_chineseLocale);
-        } catch (restoreError, restoreStackTrace) {
-          // Preserve the root failure when both the crawl and cleanup fail.
-          // If the crawl succeeded, fail the refresh so the repository does
-          // not mark an uncertain portal session state as freshly cached.
-          if (operationError == null) {
-            Error.throwWithStackTrace(restoreError, restoreStackTrace);
+        if (localeMutationAttempted) {
+          try {
+            await _setPortalLocale(originalLocale);
+          } catch (restoreError, restoreStackTrace) {
+            _portalLocaleStateUncertain = true;
+            // Preserve the root failure when both the crawl and cleanup fail.
+            // If the crawl succeeded, fail the refresh so the repository does
+            // not mark an uncertain portal session state as freshly cached.
+            if (operationError == null) {
+              Error.throwWithStackTrace(restoreError, restoreStackTrace);
+            }
           }
         }
       }
-
-      return _mergeApplicationCatalog(chinese, english);
     });
   }
 
+  String _parsePortalLocale(Document document) {
+    for (final category in _parseApplicationCategories(document)) {
+      if (!category.distinguishedName.startsWith(_academicCategoryDnPrefix)) {
+        continue;
+      }
+      return switch (category.name) {
+        _chineseAcademicCategoryName => _chineseLocale,
+        _englishAcademicCategoryName => _englishLocale,
+        _ => throw FormatException(
+          'Unknown NTUT Portal academic category name: ${category.name}',
+        ),
+      };
+    }
+    throw const FormatException(
+      'NTUT Portal academic category was not found.',
+    );
+  }
+
   Future<List<_PortalApplicationCategoryPageDto>>
-  _getApplicationCatalogForCurrentLocale() async {
-    final response = await _getApplicationPage(queryParameters: {'init': ''});
-    final document = _parseApplicationPage(response.data!);
+  _getApplicationCatalogForCurrentLocale({Document? categoryDocument}) async {
+    final Document document;
+    if (categoryDocument case final cached?) {
+      document = cached;
+    } else {
+      final response = await _getApplicationPage(
+        queryParameters: {'init': ''},
+      );
+      document = _parseApplicationPage(response.data!);
+    }
     final categories = _parseApplicationCategories(document);
     if (categories.isEmpty) {
       throw const FormatException(
@@ -384,12 +448,17 @@ class NtutPortalService implements PortalService {
     _throwIfPortalSessionExpired(reload.data ?? '');
   }
 
-  Future<T> _withCatalogLocaleLock<T>(Future<T> Function() operation) async {
-    final previous = _catalogLocaleOperation;
+  Future<T> _withPortalLocaleLock<T>(Future<T> Function() operation) async {
+    final previous = _portalLocaleOperation;
     final release = Completer<void>();
-    _catalogLocaleOperation = release.future;
+    _portalLocaleOperation = release.future;
     await previous;
     try {
+      if (_portalLocaleStateUncertain) {
+        throw const SessionExpiredException(
+          'NTUT Portal locale state could not be restored',
+        );
+      }
       return await operation();
     } finally {
       release.complete();

--- a/lib/services/portal/ntut_portal_service.dart
+++ b/lib/services/portal/ntut_portal_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:dio_redirect_interceptor/dio_redirect_interceptor.dart';
+import 'package:html/dom.dart';
 import 'package:html/parser.dart';
 import 'package:http_parser/http_parser.dart';
 import 'package:intl/intl.dart';
@@ -10,6 +11,10 @@ import 'package:tattoo/services/portal/portal_service.dart';
 import 'package:tattoo/utils/http.dart';
 
 class NtutPortalService implements PortalService {
+  static final _folderCallPattern = RegExp(
+    r"apPopupSubEip5\('([^']+)','apMap','([^']*)'\)",
+  );
+
   late final Dio _portalDio;
 
   NtutPortalService() {
@@ -272,5 +277,160 @@ class NtutPortalService implements PortalService {
           ),
         )
         .toList();
+  }
+
+  @override
+  Future<List<PortalApplicationCategoryDto>> getApplicationCatalog() async {
+    final response = await _getApplicationPage(queryParameters: {'init': ''});
+    final document = _parseApplicationPage(response.data!);
+    final categories = _parseApplicationCategories(document);
+    if (categories.isEmpty) {
+      throw const FormatException(
+        'No application categories found in NTUT Portal response.',
+      );
+    }
+
+    final result = <PortalApplicationCategoryDto>[];
+    for (final category in categories) {
+      final applications = await _getCategoryApplications(
+        category.distinguishedName,
+        visitedFolders: <String>{},
+      );
+      result.add((
+        distinguishedName: category.distinguishedName,
+        name: category.name,
+        applications: applications,
+      ));
+    }
+    return result;
+  }
+
+  Future<Response<String>> _getApplicationPage({
+    required Map<String, dynamic> queryParameters,
+  }) {
+    return _portalDio.get<String>(
+      'apPopupFull.do',
+      queryParameters: queryParameters,
+      options: Options(
+        responseType: .plain,
+        headers: const {'X-Requested-With': 'XMLHttpRequest'},
+      ),
+    );
+  }
+
+  Document _parseApplicationPage(String html) {
+    final document = parse(html);
+    final text = document.body?.text ?? '';
+    if (document.querySelector('title')?.text.trim() == '請重新登入' ||
+        text.contains('請重新登入') ||
+        text.contains('您目前已和伺服器中斷連線') ||
+        text.contains('You have been disconnected from the server')) {
+      throw const SessionExpiredException('NTUT Portal session expired');
+    }
+    return document;
+  }
+
+  List<({String distinguishedName, String name})> _parseApplicationCategories(
+    Document document,
+  ) {
+    final categories = <({String distinguishedName, String name})>[];
+    final seen = <String>{};
+    for (final anchor in document.querySelectorAll('a.dropdown-item[href]')) {
+      final folder = _parseFolderCall(anchor.attributes['href']);
+      if (folder == null || !seen.add(folder.distinguishedName)) continue;
+      categories.add(folder);
+    }
+    return categories;
+  }
+
+  Future<List<PortalApplicationDto>> _getCategoryApplications(
+    String distinguishedName, {
+    required Set<String> visitedFolders,
+  }) async {
+    if (!visitedFolders.add(distinguishedName)) return const [];
+
+    final response = await _getApplicationPage(
+      queryParameters: {
+        'apView': 'apMap',
+        'apDn': distinguishedName,
+      },
+    );
+    final document = _parseApplicationPage(response.data!);
+    final applications = <PortalApplicationDto>[];
+    final seenCodes = <String>{};
+
+    for (final item in document.querySelectorAll('.apt-icon')) {
+      final application = _parseApplication(
+        item,
+        response.requestOptions.uri,
+      );
+      if (application != null) {
+        if (seenCodes.add(application.code)) applications.add(application);
+        continue;
+      }
+
+      final folder = _parseFolderCall(item.attributes['onclick']);
+      if (folder == null) continue;
+      final nested = await _getCategoryApplications(
+        folder.distinguishedName,
+        visitedFolders: visitedFolders,
+      );
+      for (final application in nested) {
+        if (seenCodes.add(application.code)) applications.add(application);
+      }
+    }
+
+    return applications;
+  }
+
+  PortalApplicationDto? _parseApplication(Element item, Uri responseUri) {
+    Element? link;
+    for (final candidate in item.querySelectorAll('a[href]')) {
+      final href = candidate.attributes['href'];
+      if (href == null) continue;
+      final uri = Uri.tryParse(href);
+      if (uri == null ||
+          (uri.path != 'ssoIndex.do' && uri.path != 'ssoFromOu.do') ||
+          !uri.queryParameters.containsKey('apOu')) {
+        continue;
+      }
+      link = candidate;
+      break;
+    }
+    if (link == null) return null;
+
+    final href = Uri.parse(link.attributes['href']!);
+    final code = href.queryParameters['apOu'];
+    if (code == null || code.isEmpty) return null;
+
+    final name =
+        item
+            .querySelector('[data-bs-original-title]')
+            ?.attributes['data-bs-original-title']
+            ?.trim() ??
+        item.querySelector('[title]')?.attributes['title']?.trim() ??
+        link.text.trim();
+    if (name.isEmpty) return null;
+
+    final iconPath = item.querySelector('img[src]')?.attributes['src'];
+    return (
+      code: code,
+      name: name,
+      iconUrl: iconPath == null || iconPath.isEmpty
+          ? null
+          : responseUri.resolve(iconPath).toString(),
+    );
+  }
+
+  ({String distinguishedName, String name})? _parseFolderCall(
+    String? script,
+  ) {
+    if (script == null) return null;
+    final match = _folderCallPattern.firstMatch(script);
+    if (match == null) return null;
+    return (
+      distinguishedName: match.group(1)!,
+      name: match.group(2)!,
+    );
   }
 }

--- a/lib/services/portal/portal_service.dart
+++ b/lib/services/portal/portal_service.dart
@@ -62,6 +62,33 @@ typedef CalendarEventDto = ({
   String? creatorName,
 });
 
+/// Represents an application exposed by the NTUT Portal application catalog.
+typedef PortalApplicationDto = ({
+  /// Portal SSO target identifier (`apOu`).
+  String code,
+
+  /// Display name supplied by the portal.
+  String name,
+
+  /// Absolute URL of the icon supplied by the portal, when present.
+  String? iconUrl,
+});
+
+/// Represents one top-level NTUT Portal application category.
+///
+/// Nested portal folders are flattened into their top-level category so UI
+/// consumers receive only categories and browser-openable applications.
+typedef PortalApplicationCategoryDto = ({
+  /// LDAP distinguished name used to fetch the category from the portal.
+  String distinguishedName,
+
+  /// Display name supplied by the portal.
+  String name,
+
+  /// Applications in portal display order.
+  List<PortalApplicationDto> applications,
+});
+
 // dart format off
 /// Identification codes for NTUT services used in SSO authentication.
 ///
@@ -178,4 +205,14 @@ abstract interface class PortalService {
     DateTime startDate,
     DateTime endDate,
   );
+
+  /// Fetches every application category and browser-openable application
+  /// available to the current portal account.
+  ///
+  /// Portal folders are traversed recursively. The portal's own bookmark
+  /// state is intentionally not read or changed; favorites in Tattoo are
+  /// app-local data managed by the repository.
+  ///
+  /// Requires an active portal session (call [login] first).
+  Future<List<PortalApplicationCategoryDto>> getApplicationCatalog();
 }

--- a/lib/services/portal/portal_service.dart
+++ b/lib/services/portal/portal_service.dart
@@ -67,8 +67,11 @@ typedef PortalApplicationDto = ({
   /// Portal SSO target identifier (`apOu`).
   String code,
 
-  /// Display name supplied by the portal.
-  String name,
+  /// Chinese display name supplied by the portal.
+  String nameZh,
+
+  /// English display name supplied by the portal, when present.
+  String? nameEn,
 
   /// Absolute URL of the icon supplied by the portal, when present.
   String? iconUrl,
@@ -82,8 +85,11 @@ typedef PortalApplicationCategoryDto = ({
   /// LDAP distinguished name used to fetch the category from the portal.
   String distinguishedName,
 
-  /// Display name supplied by the portal.
-  String name,
+  /// Chinese display name supplied by the portal.
+  String nameZh,
+
+  /// English display name supplied by the portal, when present.
+  String? nameEn,
 
   /// Applications in portal display order.
   List<PortalApplicationDto> applications,
@@ -207,11 +213,15 @@ abstract interface class PortalService {
   );
 
   /// Fetches every application category and browser-openable application
-  /// available to the current portal account.
+  /// available to the current portal account in Chinese and English.
   ///
-  /// Portal folders are traversed recursively. The portal's own bookmark
-  /// state is intentionally not read or changed; favorites in Tattoo are
-  /// app-local data managed by the repository.
+  /// The portal stores language in the server session, so implementations
+  /// switch and fetch the two languages sequentially, merge by stable portal
+  /// identifiers, and restore Chinese before returning. English is optional:
+  /// when that fetch is unavailable, Chinese data is still returned. Portal
+  /// folders are traversed recursively. The portal's own bookmark state is
+  /// intentionally not read or changed; favorites in Tattoo are app-local
+  /// data managed by the repository.
   ///
   /// Requires an active portal session (call [login] first).
   Future<List<PortalApplicationCategoryDto>> getApplicationCatalog();

--- a/lib/services/portal/portal_service.dart
+++ b/lib/services/portal/portal_service.dart
@@ -217,10 +217,12 @@ abstract interface class PortalService {
   ///
   /// The portal stores language in the server session, so implementations
   /// switch and fetch the two languages sequentially, merge by stable portal
-  /// identifiers, and restore Chinese before returning. English is optional:
-  /// when that fetch is unavailable, Chinese data is still returned. Portal
-  /// folders are traversed recursively. The portal's own bookmark state is
-  /// intentionally not read or changed; favorites in Tattoo are app-local
+  /// identifiers, and restore the user's original portal language before
+  /// returning. SSO operations are serialized with these temporary switches
+  /// so browser handoff keeps its established language behavior. English is
+  /// optional: when that fetch is unavailable, Chinese data is still returned.
+  /// Portal folders are traversed recursively. The portal's own bookmark state
+  /// is intentionally not read or changed; favorites in Tattoo are app-local
   /// data managed by the repository.
   ///
   /// Requires an active portal session (call [login] first).

--- a/test/repositories/portal_repository_test.dart
+++ b/test/repositories/portal_repository_test.dart
@@ -62,10 +62,9 @@ void main() {
         ],
       );
 
-      final catalog = await repository
-          .watchApplicationCatalog()
-          .firstWhere((categories) => categories.isNotEmpty)
-          .timeout(const Duration(seconds: 5));
+      final catalog = await repository.watchApplicationCatalog().first.timeout(
+        const Duration(seconds: 5),
+      );
 
       expect(portalService.catalogCalls, 1);
       expect(catalog.single.category.nameZh, '教務系統');
@@ -241,6 +240,44 @@ void main() {
         'Curriculum System',
       );
     });
+
+    test('favorite update is a no-op after the user is removed', () async {
+      await database.delete(database.users).go();
+
+      await expectLater(
+        repository.setApplicationFavorite(
+          applicationCode: 'aa_0010-oauth',
+          isFavorite: true,
+        ),
+        completes,
+      );
+      expect(
+        await database.select(database.portalApplicationFavorites).get(),
+        isEmpty,
+      );
+    });
+
+    test(
+      'failed cold stream refresh emits empty only after one attempt',
+      () async {
+        portalService.catalogHandler = () => Future.error(
+          DioException(
+            requestOptions: RequestOptions(path: 'apPopupFull.do'),
+            type: DioExceptionType.connectionError,
+          ),
+        );
+
+        final catalog = await repository
+            .watchApplicationCatalog()
+            .first
+            .timeout(
+              const Duration(seconds: 5),
+            );
+
+        expect(catalog, isEmpty);
+        expect(portalService.catalogCalls, 1);
+      },
+    );
 
     test('concurrent refresh calls share one portal request', () async {
       final gate = Completer<List<PortalApplicationCategoryDto>>();

--- a/test/repositories/portal_repository_test.dart
+++ b/test/repositories/portal_repository_test.dart
@@ -281,11 +281,15 @@ void main() {
 
     test('concurrent refresh calls share one portal request', () async {
       final gate = Completer<List<PortalApplicationCategoryDto>>();
-      portalService.catalogHandler = () => gate.future;
+      final callStarted = Completer<void>();
+      portalService.catalogHandler = () {
+        if (!callStarted.isCompleted) callStarted.complete();
+        return gate.future;
+      };
 
       final first = repository.refreshApplicationCatalog();
-      await Future<void>.delayed(Duration.zero);
       final second = repository.refreshApplicationCatalog();
+      await callStarted.future.timeout(const Duration(seconds: 5));
       expect(portalService.catalogCalls, 1);
 
       gate.complete(

--- a/test/repositories/portal_repository_test.dart
+++ b/test/repositories/portal_repository_test.dart
@@ -1,0 +1,250 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tattoo/database/database.dart';
+import 'package:tattoo/repositories/auth_repository.dart';
+import 'package:tattoo/repositories/portal_repository.dart';
+import 'package:tattoo/services/portal/mock_portal_service.dart';
+import 'package:tattoo/services/portal/portal_service.dart';
+import 'package:tattoo/services/student_query/mock_student_query_service.dart';
+
+void main() {
+  group('PortalRepository', () {
+    late AppDatabase database;
+    late _TestPortalService portalService;
+    late PortalRepository repository;
+
+    setUp(() async {
+      database = AppDatabase(NativeDatabase.memory());
+      portalService = _TestPortalService();
+      final authRepository = AuthRepository(
+        portalService: portalService,
+        studentQueryService: MockStudentQueryService(),
+        database: database,
+        secureStorage: const FlutterSecureStorage(),
+        isDemo: false,
+        onSessionCreated: () {},
+        onSessionDestroyed: ([exception]) {},
+      );
+      repository = PortalRepository(
+        portalService: portalService,
+        database: database,
+        authRepository: authRepository,
+      );
+      await database
+          .into(database.users)
+          .insert(
+            UsersCompanion.insert(
+              studentId: '111592347',
+              nameZh: '王大同',
+              avatarFilename: '',
+              email: 't111592347@ntut.edu.tw',
+            ),
+          );
+    });
+
+    tearDown(() => database.close());
+
+    test('cold stream fetches and emits the cached catalog', () async {
+      portalService.catalog = _catalog(
+        categoryDn: 'OU=aa,OU=aproot',
+        categoryName: '教務系統',
+        applications: [
+          (code: 'aa_0010-oauth', name: '課程系統', iconUrl: 'https://icon'),
+        ],
+      );
+
+      final catalog = await repository
+          .watchApplicationCatalog()
+          .firstWhere((categories) => categories.isNotEmpty)
+          .timeout(const Duration(seconds: 5));
+
+      expect(portalService.catalogCalls, 1);
+      expect(catalog.single.category.name, '教務系統');
+      expect(
+        catalog.single.applications.single.application.code,
+        'aa_0010-oauth',
+      );
+      expect(catalog.single.applications.single.isFavorite, isFalse);
+      final user = await database.select(database.users).getSingle();
+      expect(user.applicationCatalogFetchedAt, isNotNull);
+
+      final cached = await repository.watchApplicationCatalog().first;
+      expect(cached, isNotEmpty);
+      expect(portalService.catalogCalls, 1);
+    });
+
+    test(
+      'favorite re-emits and survives category moves and cache clears',
+      () async {
+        portalService.catalog = _catalog(
+          categoryDn: 'OU=aa,OU=aproot',
+          categoryName: '教務系統',
+          applications: [
+            (code: 'shared_oauth', name: '共用系統', iconUrl: null),
+          ],
+        );
+        await repository.refreshApplicationCatalog();
+
+        final favoriteEmission = repository
+            .watchApplicationCatalog()
+            .firstWhere(
+              (categories) =>
+                  categories.isNotEmpty &&
+                  categories.single.applications.single.isFavorite,
+            )
+            .timeout(const Duration(seconds: 5));
+        await repository.setApplicationFavorite(
+          applicationCode: 'shared_oauth',
+          isFavorite: true,
+        );
+        await favoriteEmission;
+
+        portalService.catalog = _catalog(
+          categoryDn: 'OU=inf,OU=aproot',
+          categoryName: '資訊服務',
+          applications: [
+            (code: 'shared_oauth', name: '共用系統新名稱', iconUrl: null),
+          ],
+        );
+        await repository.refreshApplicationCatalog();
+
+        final moved = await repository.watchApplicationCatalog().first;
+        expect(moved.single.category.name, '資訊服務');
+        expect(moved.single.applications.single.application.name, '共用系統新名稱');
+        expect(moved.single.applications.single.isFavorite, isTrue);
+
+        await database.deleteCachedData();
+        expect(
+          await database.select(database.portalApplicationCategories).get(),
+          isEmpty,
+        );
+        expect(
+          await database.select(database.portalApplicationFavorites).get(),
+          hasLength(1),
+        );
+        final user = await database.select(database.users).getSingle();
+        expect(user.applicationCatalogFetchedAt, isNull);
+      },
+    );
+
+    test('refresh removes stale rows and preserves empty categories', () async {
+      portalService.catalog = [
+        ..._catalog(
+          categoryDn: 'OU=aa,OU=aproot',
+          categoryName: '教務系統',
+          applications: [
+            (code: 'old_oauth', name: '舊系統', iconUrl: null),
+          ],
+        ),
+        ..._catalog(
+          categoryDn: 'OU=sa,OU=aproot',
+          categoryName: '學務系統',
+          applications: [
+            (code: 'removed_oauth', name: '移除系統', iconUrl: null),
+          ],
+        ),
+      ];
+      await repository.refreshApplicationCatalog();
+
+      portalService.catalog = _catalog(
+        categoryDn: 'OU=aa,OU=aproot',
+        categoryName: '教務資訊',
+        applications: const [],
+      );
+      await repository.refreshApplicationCatalog();
+
+      final catalog = await repository.watchApplicationCatalog().first;
+      expect(catalog, hasLength(1));
+      expect(catalog.single.category.name, '教務資訊');
+      expect(catalog.single.applications, isEmpty);
+      expect(await database.select(database.portalApplications).get(), isEmpty);
+    });
+
+    test('concurrent refresh calls share one portal request', () async {
+      final gate = Completer<List<PortalApplicationCategoryDto>>();
+      portalService.catalogHandler = () => gate.future;
+
+      final first = repository.refreshApplicationCatalog();
+      await Future<void>.delayed(Duration.zero);
+      final second = repository.refreshApplicationCatalog();
+      expect(portalService.catalogCalls, 1);
+
+      gate.complete(
+        _catalog(
+          categoryDn: 'OU=aa,OU=aproot',
+          categoryName: '教務系統',
+          applications: const [],
+        ),
+      );
+      await Future.wait([first, second]);
+
+      expect(portalService.catalogCalls, 1);
+    });
+
+    test('failed refresh keeps the previous cache and timestamp', () async {
+      portalService.catalog = _catalog(
+        categoryDn: 'OU=aa,OU=aproot',
+        categoryName: '教務系統',
+        applications: [
+          (code: 'cached_oauth', name: '快取系統', iconUrl: null),
+        ],
+      );
+      await repository.refreshApplicationCatalog();
+      final timestamp = (await database.select(database.users).getSingle())
+          .applicationCatalogFetchedAt;
+
+      portalService.catalogHandler = () => Future.error(
+        DioException(
+          requestOptions: RequestOptions(path: 'apPopupFull.do'),
+          type: DioExceptionType.connectionError,
+        ),
+      );
+
+      await expectLater(
+        repository.refreshApplicationCatalog(),
+        throwsA(isA<DioException>()),
+      );
+
+      final catalog = await repository.watchApplicationCatalog().first;
+      expect(
+        catalog.single.applications.single.application.code,
+        'cached_oauth',
+      );
+      expect(
+        (await database.select(database.users).getSingle())
+            .applicationCatalogFetchedAt,
+        timestamp,
+      );
+    });
+  });
+}
+
+List<PortalApplicationCategoryDto> _catalog({
+  required String categoryDn,
+  required String categoryName,
+  required List<PortalApplicationDto> applications,
+}) {
+  return [
+    (
+      distinguishedName: categoryDn,
+      name: categoryName,
+      applications: applications,
+    ),
+  ];
+}
+
+class _TestPortalService extends MockPortalService {
+  List<PortalApplicationCategoryDto> catalog = const [];
+  Future<List<PortalApplicationCategoryDto>> Function()? catalogHandler;
+  int catalogCalls = 0;
+
+  @override
+  Future<List<PortalApplicationCategoryDto>> getApplicationCatalog() async {
+    catalogCalls++;
+    return catalogHandler?.call() ?? catalog;
+  }
+}

--- a/test/repositories/portal_repository_test.dart
+++ b/test/repositories/portal_repository_test.dart
@@ -53,7 +53,12 @@ void main() {
         categoryDn: 'OU=aa,OU=aproot',
         categoryName: '教務系統',
         applications: [
-          (code: 'aa_0010-oauth', name: '課程系統', iconUrl: 'https://icon'),
+          (
+            code: 'aa_0010-oauth',
+            nameZh: '課程系統',
+            nameEn: 'Curriculum System',
+            iconUrl: 'https://icon',
+          ),
         ],
       );
 
@@ -63,7 +68,8 @@ void main() {
           .timeout(const Duration(seconds: 5));
 
       expect(portalService.catalogCalls, 1);
-      expect(catalog.single.category.name, '教務系統');
+      expect(catalog.single.category.nameZh, '教務系統');
+      expect(catalog.single.category.nameEn, 'System of Academic Affairs');
       expect(
         catalog.single.applications.single.application.code,
         'aa_0010-oauth',
@@ -84,7 +90,12 @@ void main() {
           categoryDn: 'OU=aa,OU=aproot',
           categoryName: '教務系統',
           applications: [
-            (code: 'shared_oauth', name: '共用系統', iconUrl: null),
+            (
+              code: 'shared_oauth',
+              nameZh: '共用系統',
+              nameEn: 'Shared System',
+              iconUrl: null,
+            ),
           ],
         );
         await repository.refreshApplicationCatalog();
@@ -107,14 +118,26 @@ void main() {
           categoryDn: 'OU=inf,OU=aproot',
           categoryName: '資訊服務',
           applications: [
-            (code: 'shared_oauth', name: '共用系統新名稱', iconUrl: null),
+            (
+              code: 'shared_oauth',
+              nameZh: '共用系統新名稱',
+              nameEn: null,
+              iconUrl: null,
+            ),
           ],
         );
         await repository.refreshApplicationCatalog();
 
         final moved = await repository.watchApplicationCatalog().first;
-        expect(moved.single.category.name, '資訊服務');
-        expect(moved.single.applications.single.application.name, '共用系統新名稱');
+        expect(moved.single.category.nameZh, '資訊服務');
+        expect(
+          moved.single.applications.single.application.nameZh,
+          '共用系統新名稱',
+        );
+        expect(
+          moved.single.applications.single.application.nameEn,
+          'Shared System',
+        );
         expect(moved.single.applications.single.isFavorite, isTrue);
 
         await database.deleteCachedData();
@@ -137,14 +160,24 @@ void main() {
           categoryDn: 'OU=aa,OU=aproot',
           categoryName: '教務系統',
           applications: [
-            (code: 'old_oauth', name: '舊系統', iconUrl: null),
+            (
+              code: 'old_oauth',
+              nameZh: '舊系統',
+              nameEn: 'Old System',
+              iconUrl: null,
+            ),
           ],
         ),
         ..._catalog(
           categoryDn: 'OU=sa,OU=aproot',
           categoryName: '學務系統',
           applications: [
-            (code: 'removed_oauth', name: '移除系統', iconUrl: null),
+            (
+              code: 'removed_oauth',
+              nameZh: '移除系統',
+              nameEn: 'Removed System',
+              iconUrl: null,
+            ),
           ],
         ),
       ];
@@ -159,9 +192,54 @@ void main() {
 
       final catalog = await repository.watchApplicationCatalog().first;
       expect(catalog, hasLength(1));
-      expect(catalog.single.category.name, '教務資訊');
+      expect(catalog.single.category.nameZh, '教務資訊');
       expect(catalog.single.applications, isEmpty);
       expect(await database.select(database.portalApplications).get(), isEmpty);
+    });
+
+    test('missing English enrichment keeps cached translations', () async {
+      portalService.catalog = _catalog(
+        categoryDn: 'OU=aa,OU=aproot',
+        categoryName: '教務系統',
+        applications: [
+          (
+            code: 'aa_0010-oauth',
+            nameZh: '課程系統',
+            nameEn: 'Curriculum System',
+            iconUrl: null,
+          ),
+        ],
+      );
+      await repository.refreshApplicationCatalog();
+
+      portalService.catalog = [
+        (
+          distinguishedName: 'OU=aa,OU=aproot',
+          nameZh: '教務資訊系統',
+          nameEn: null,
+          applications: [
+            (
+              code: 'aa_0010-oauth',
+              nameZh: '課程系統新版',
+              nameEn: null,
+              iconUrl: null,
+            ),
+          ],
+        ),
+      ];
+      await repository.refreshApplicationCatalog();
+
+      final catalog = await repository.watchApplicationCatalog().first;
+      expect(catalog.single.category.nameZh, '教務資訊系統');
+      expect(catalog.single.category.nameEn, 'System of Academic Affairs');
+      expect(
+        catalog.single.applications.single.application.nameZh,
+        '課程系統新版',
+      );
+      expect(
+        catalog.single.applications.single.application.nameEn,
+        'Curriculum System',
+      );
     });
 
     test('concurrent refresh calls share one portal request', () async {
@@ -190,7 +268,12 @@ void main() {
         categoryDn: 'OU=aa,OU=aproot',
         categoryName: '教務系統',
         applications: [
-          (code: 'cached_oauth', name: '快取系統', iconUrl: null),
+          (
+            code: 'cached_oauth',
+            nameZh: '快取系統',
+            nameEn: 'Cached System',
+            iconUrl: null,
+          ),
         ],
       );
       await repository.refreshApplicationCatalog();
@@ -231,7 +314,12 @@ List<PortalApplicationCategoryDto> _catalog({
   return [
     (
       distinguishedName: categoryDn,
-      name: categoryName,
+      nameZh: categoryName,
+      nameEn: switch (categoryName) {
+        '教務系統' => 'System of Academic Affairs',
+        '學務系統' => 'Student Affairs System',
+        _ => null,
+      },
       applications: applications,
     ),
   ];

--- a/test/repositories/portal_repository_test.dart
+++ b/test/repositories/portal_repository_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dio/dio.dart';
+import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -278,6 +279,61 @@ void main() {
         expect(portalService.catalogCalls, 1);
       },
     );
+
+    test('cold stream checks staleness after its initial snapshot', () async {
+      portalService.catalog = _catalog(
+        categoryDn: 'OU=aa,OU=aproot',
+        categoryName: '教務系統',
+        applications: [
+          (
+            code: 'aa_0010-oauth',
+            nameZh: '課程系統',
+            nameEn: 'Curriculum System',
+            iconUrl: null,
+          ),
+        ],
+      );
+      final catalog = StreamIterator(repository.watchApplicationCatalog());
+      addTearDown(catalog.cancel);
+
+      expect(await catalog.moveNext(), isTrue);
+      expect(portalService.catalogCalls, 1);
+
+      await database
+          .update(database.users)
+          .write(
+            UsersCompanion(
+              applicationCatalogFetchedAt: Value(
+                DateTime.now().subtract(const Duration(days: 2)),
+              ),
+            ),
+          );
+      final favoriteEmission = catalog.moveNext();
+      await repository.setApplicationFavorite(
+        applicationCode: 'aa_0010-oauth',
+        isFavorite: true,
+      );
+      expect(
+        await favoriteEmission.timeout(const Duration(seconds: 5)),
+        isTrue,
+      );
+
+      final refreshStarted = Completer<void>();
+      final refreshGate = Completer<List<PortalApplicationCategoryDto>>();
+      portalService.catalogHandler = () {
+        refreshStarted.complete();
+        return refreshGate.future;
+      };
+      final refreshedEmission = catalog.moveNext();
+
+      await refreshStarted.future.timeout(const Duration(seconds: 5));
+      expect(portalService.catalogCalls, 2);
+      refreshGate.complete(portalService.catalog);
+      expect(
+        await refreshedEmission.timeout(const Duration(seconds: 5)),
+        isTrue,
+      );
+    });
 
     test('concurrent refresh calls share one portal request', () async {
       final gate = Completer<List<PortalApplicationCategoryDto>>();

--- a/test/services/portal_service_test.dart
+++ b/test/services/portal_service_test.dart
@@ -325,6 +325,7 @@ void main() {
         for (final category in categories) {
           expect(category.distinguishedName, isNotEmpty);
           expect(category.nameZh, isNotEmpty);
+          expect(category.nameZh, category.nameZh.trim());
           for (final application in category.applications) {
             expect(application.code, isNotEmpty);
             expect(application.nameZh, isNotEmpty);

--- a/test/services/portal_service_test.dart
+++ b/test/services/portal_service_test.dart
@@ -332,6 +332,99 @@ void main() {
           }
         }
       });
+
+      test(
+        'should preserve English portal locale while SSO waits for refresh',
+        () async {
+          await portalService.login(
+            TestCredentials.username,
+            TestCredentials.password,
+          );
+
+          final probeDio = createDio()
+            ..options.baseUrl = 'https://app.ntut.edu.tw/'
+            ..options.headers = {
+              'User-Agent': 'Direk ios App',
+              'Connection': 'close',
+            };
+
+          Future<void> setLocale(String locale) async {
+            await probeDio.post<String>(
+              'localeModify.do',
+              data: {'localeId': locale},
+              options: Options(
+                contentType: Headers.formUrlEncodedContentType,
+                responseType: .plain,
+                headers: const {'X-Requested-With': 'XMLHttpRequest'},
+              ),
+            );
+            await probeDio.get<String>(
+              'localeReload.do',
+              queryParameters: {'locale': locale},
+              options: Options(responseType: .plain),
+            );
+          }
+
+          Future<String> getCategoryPage() async {
+            final response = await probeDio.get<String>(
+              'apPopupFull.do',
+              queryParameters: {'init': ''},
+              options: Options(
+                responseType: .plain,
+                headers: const {'X-Requested-With': 'XMLHttpRequest'},
+              ),
+            );
+            return response.data!;
+          }
+
+          final originalCategoryPage = await getCategoryPage();
+          final originalLocale = switch ((
+            originalCategoryPage.contains('System of Academic Affairs'),
+            originalCategoryPage.contains('教務系統'),
+          )) {
+            (true, _) => 'en',
+            (_, true) => 'zh_TW',
+            _ => fail('Could not determine the original portal locale.'),
+          };
+          try {
+            await setLocale('en');
+            expect(
+              await getCategoryPage(),
+              contains('System of Academic Affairs'),
+            );
+            final baselineSsoUrl = await portalService.getSsoUrl(
+              PortalServiceCode.courseService.code,
+            );
+
+            final completions = <String>[];
+            final catalogFuture = portalService.getApplicationCatalog().then((
+              catalog,
+            ) {
+              completions.add('catalog');
+              return catalog;
+            });
+            await Future<void>.delayed(const Duration(milliseconds: 100));
+            final ssoUrlFuture = portalService
+                .getSsoUrl(PortalServiceCode.courseService.code)
+                .then((url) {
+                  completions.add('sso');
+                  return url;
+                });
+
+            expect(await catalogFuture, isNotEmpty);
+            final ssoUrl = await ssoUrlFuture;
+            expect(completions, ['catalog', 'sso']);
+            expect(ssoUrl.origin, baselineSsoUrl.origin);
+            expect(ssoUrl.path, baselineSsoUrl.path);
+            expect(
+              await getCategoryPage(),
+              contains('System of Academic Affairs'),
+            );
+          } finally {
+            await setLocale(originalLocale);
+          }
+        },
+      );
     });
   });
 }

--- a/test/services/portal_service_test.dart
+++ b/test/services/portal_service_test.dart
@@ -291,24 +291,12 @@ void main() {
             .expand((category) => category.applications)
             .toList();
         expect(
-          applications,
-          contains(
-            isA<PortalApplicationDto>().having(
-              (application) => application.code,
-              'code',
-              PortalServiceCode.courseService.code,
-            ),
-          ),
+          applications.map((application) => application.code),
+          contains(PortalServiceCode.courseService.code),
         );
         expect(
-          applications,
-          contains(
-            isA<PortalApplicationDto>().having(
-              (application) => application.code,
-              'nested English course system code',
-              'en_v_1_oauth',
-            ),
-          ),
+          applications.map((application) => application.code),
+          contains('en_v_1_oauth'),
         );
         final courseSystem = applications.firstWhere(
           (application) =>

--- a/test/services/portal_service_test.dart
+++ b/test/services/portal_service_test.dart
@@ -315,12 +315,19 @@ void main() {
               application.code == PortalServiceCode.courseService.code,
         );
         expect(courseSystem.iconUrl, startsWith('https://app.ntut.edu.tw/'));
+        expect(courseSystem.nameZh, isNotEmpty);
+        expect(courseSystem.nameEn, isNotEmpty);
+        expect(
+          applications.where((application) => application.nameEn != null),
+          isNotEmpty,
+          reason: 'English catalog should enrich the Chinese catalog',
+        );
         for (final category in categories) {
           expect(category.distinguishedName, isNotEmpty);
-          expect(category.name, isNotEmpty);
+          expect(category.nameZh, isNotEmpty);
           for (final application in category.applications) {
             expect(application.code, isNotEmpty);
-            expect(application.name, isNotEmpty);
+            expect(application.nameZh, isNotEmpty);
           }
         }
       });

--- a/test/services/portal_service_test.dart
+++ b/test/services/portal_service_test.dart
@@ -275,5 +275,55 @@ void main() {
         },
       );
     });
+
+    group('getApplicationCatalog', () {
+      test('should return categorized browser-openable applications', () async {
+        await portalService.login(
+          TestCredentials.username,
+          TestCredentials.password,
+        );
+        await respectfulDelay();
+
+        final categories = await portalService.getApplicationCatalog();
+
+        expect(categories, isNotEmpty);
+        final applications = categories
+            .expand((category) => category.applications)
+            .toList();
+        expect(
+          applications,
+          contains(
+            isA<PortalApplicationDto>().having(
+              (application) => application.code,
+              'code',
+              PortalServiceCode.courseService.code,
+            ),
+          ),
+        );
+        expect(
+          applications,
+          contains(
+            isA<PortalApplicationDto>().having(
+              (application) => application.code,
+              'nested English course system code',
+              'en_v_1_oauth',
+            ),
+          ),
+        );
+        final courseSystem = applications.firstWhere(
+          (application) =>
+              application.code == PortalServiceCode.courseService.code,
+        );
+        expect(courseSystem.iconUrl, startsWith('https://app.ntut.edu.tw/'));
+        for (final category in categories) {
+          expect(category.distinguishedName, isNotEmpty);
+          expect(category.name, isNotEmpty);
+          for (final application in category.applications) {
+            expect(application.code, isNotEmpty);
+            expect(application.name, isNotEmpty);
+          }
+        }
+      });
+    });
   });
 }

--- a/tool/html_snapshot/presets.dart
+++ b/tool/html_snapshot/presets.dart
@@ -77,6 +77,28 @@ enum SnapshotService {
 
 final _presetList = <SnapshotPreset>[
   SnapshotPreset(
+    name: 'portal.application_categories',
+    service: .portal,
+    description: 'NTUT Portal application category page.',
+    includeInAll: true,
+    buildRequest: _simple(.portal, 'apPopupFull.do', query: {'init': ''}),
+  ),
+  SnapshotPreset(
+    name: 'portal.academic_applications',
+    service: .portal,
+    description: 'NTUT Portal academic application list.',
+    includeInAll: true,
+    buildRequest: _simple(
+      .portal,
+      'apPopupFull.do',
+      query: {
+        'apView': 'apMap',
+        'apDn':
+            'OU=aa,OU=aproot,OU=ldaproot,OU=ldapConfig,DC=campus,DC=cnc,DC=ntut,DC=edu,DC=tw',
+      },
+    ),
+  ),
+  SnapshotPreset(
     name: 'student_query.profile',
     service: .studentQuery,
     description: 'Student Query profile page.',


### PR DESCRIPTION
# 新增動態雙語入口網站應用系統目錄

## 主要變更

- 從校園入口網站動態取得目前帳號可使用的所有應用系統。
- 遞迴解析分類與子分類，並保留既有的瀏覽器 SSO 跳轉方式。
- 支援中英文名稱，並在英文資料暫時取得失敗時保留中文與既有英文快取。
- 因動態取得後數量較多，所以新增了暫時的最愛措施
- 新增了一個暫時的 UI 介面，更詳細的 UI 功能將在後續 PR 提供

## 流程

入口網站的語言是伺服器端 Session 狀態，因此 Service 會依序：

1. 切換中文並取得完整目錄。
2. 切換英文並取得翻譯。
3. 以分類 DN 與應用系統 `apOu` 合併資料。
4. 將入口網站語言還原為中文。

中文資料作為目錄結構與排序的主要來源，英文只用來補充名稱。Repository 再將雙語結果寫入資料庫，UI 可直接監聽快取並依 App 語系顯示。

## Follow-Ups

* 目前的 UI 為暫時功能，更完整的介面另開 PR 處理
  * 或許需要包含摺疊或者跳轉等功能
* 需討論最愛功能是否與入口網站同步，或是利用 Shared Preference 來儲存
* 目前已有擷取應用程式清單快照，將在本 PR 合併後推送到 HTML 快照分支
* 後端對不同的登入行為可能回傳略有不同的應用程式列表，需要再討論如何整合