### PR TITLE
feat: handle uncaught errors gracefully with preference gate

### DIFF
--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -12,6 +12,8 @@ general:
   cancel: Cancel
 errors:
   occurred: An error occurred
+  unexpected: An unexpected error occurred
+  networkError: Network error occurred
   flutterError: A Flutter error occurred
   asyncError: An async error occurred
   sessionExpired: Session expired. Please sign in again.

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 394 (197 per locale)
+/// Strings: 398 (199 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -85,6 +85,8 @@ class _Translations$errors$en_US extends Translations$errors$zh_TW {
 
 	// Translations
 	@override String get occurred => 'An error occurred';
+	@override String get unexpected => 'An unexpected error occurred';
+	@override String get networkError => 'Network error occurred';
 	@override String get flutterError => 'A Flutter error occurred';
 	@override String get asyncError => 'An async error occurred';
 	@override String get sessionExpired => 'Session expired. Please sign in again.';
@@ -648,6 +650,8 @@ extension on TranslationsEnUs {
 			'general.ok' => 'OK',
 			'general.cancel' => 'Cancel',
 			'errors.occurred' => 'An error occurred',
+			'errors.unexpected' => 'An unexpected error occurred',
+			'errors.networkError' => 'Network error occurred',
 			'errors.flutterError' => 'A Flutter error occurred',
 			'errors.asyncError' => 'An async error occurred',
 			'errors.sessionExpired' => 'Session expired. Please sign in again.',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -111,6 +111,12 @@ class Translations$errors$zh_TW {
 	/// zh-TW: '發生錯誤'
 	String get occurred => '發生錯誤';
 
+	/// zh-TW: '發生未預期的錯誤'
+	String get unexpected => '發生未預期的錯誤';
+
+	/// zh-TW: '網路連線出現錯誤'
+	String get networkError => '網路連線出現錯誤';
+
 	/// zh-TW: '發生Flutter錯誤'
 	String get flutterError => '發生Flutter錯誤';
 
@@ -1003,6 +1009,8 @@ extension on Translations {
 			'general.ok' => '確定',
 			'general.cancel' => '取消',
 			'errors.occurred' => '發生錯誤',
+			'errors.unexpected' => '發生未預期的錯誤',
+			'errors.networkError' => '網路連線出現錯誤',
 			'errors.flutterError' => '發生Flutter錯誤',
 			'errors.asyncError' => '發生非同步錯誤',
 			'errors.sessionExpired' => '登入狀態已過期，請重新登入',

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -12,6 +12,8 @@ general:
   cancel: 取消
 errors:
   occurred: 發生錯誤
+  unexpected: 發生未預期的錯誤
+  networkError: 網路連線出現錯誤
   flutterError: 發生Flutter錯誤
   asyncError: 發生非同步錯誤
   sessionExpired: 登入狀態已過期，請重新登入

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -95,34 +95,42 @@ Future<void> main() async {
     );
   }
 
+  void showErrorSnackBar(Object error) {
+    final message = isNetworkError(error)
+        ? t.errors.networkError
+        : t.errors.unexpected;
+
+    rootScaffoldMessengerKey.currentState
+      ?..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(message),
+        ),
+      );
+  }
+
+  Future<bool> shouldShowErrorDialog() async {
+    try {
+      return await container
+          .read(preferencesRepositoryProvider)
+          .get(PrefKey.showErrorDialog);
+    } catch (e) {
+      log('Failed to resolve error display preference: $e');
+      return PrefKey.showErrorDialog.defaultValue;
+    }
+  }
+
   Future<void> handleUncaughtError(
     Object error, {
     ErrorType type = .unknown,
     StackTrace? stackTrace,
   }) async {
-    bool shouldShowDialog;
-    try {
-      shouldShowDialog = await container
-          .read(preferencesRepositoryProvider)
-          .get(PrefKey.showErrorDialog);
-    } catch (_) {
-      shouldShowDialog = kDebugMode;
-    }
+    final showDialog = await shouldShowErrorDialog();
 
-    if (shouldShowDialog) {
+    if (showDialog) {
       showErrorDialog(error, type: type, stackTrace: stackTrace);
     } else {
-      final message = isNetworkError(error)
-          ? t.errors.networkError
-          : t.errors.unexpected;
-
-      rootScaffoldMessengerKey.currentState
-        ?..hideCurrentSnackBar()
-        ..showSnackBar(
-          SnackBar(
-            content: Text(message),
-          ),
-        );
+      showErrorSnackBar(error);
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -113,7 +113,7 @@ Future<void> main() async {
     try {
       return await container
           .read(preferencesRepositoryProvider)
-          .get(PrefKey.showErrorDialog);
+          .get(.showErrorDialog);
     } catch (e) {
       log('Failed to resolve error display preference: $e');
       return PrefKey.showErrorDialog.defaultValue;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:tattoo/router/app_router.dart';
 import 'package:tattoo/services/demo_mode.dart';
 import 'package:tattoo/services/firebase_service.dart';
 import 'package:tattoo/utils/auto_spacing.dart';
+import 'package:tattoo/utils/network_error.dart';
 
 enum ErrorType {
   flutter,
@@ -46,6 +47,8 @@ Future<void> main() async {
       log(e.toString(), name: 'Firebase Initialization');
     }
   }
+
+  final container = ProviderContainer();
 
   void showErrorDialog(
     Object error, {
@@ -77,8 +80,7 @@ Future<void> main() async {
               await Clipboard.setData(ClipboardData(text: copyText));
               if (!dialogContext.mounted) return;
               Navigator.of(dialogContext).pop();
-              if (!rootContext.mounted) return;
-              ScaffoldMessenger.maybeOf(rootContext)?.showSnackBar(
+              rootScaffoldMessengerKey.currentState?.showSnackBar(
                 SnackBar(content: Text(t.general.copied)),
               );
             },
@@ -93,12 +95,43 @@ Future<void> main() async {
     );
   }
 
+  Future<void> handleUncaughtError(
+    Object error, {
+    ErrorType type = .unknown,
+    StackTrace? stackTrace,
+  }) async {
+    bool shouldShowDialog;
+    try {
+      shouldShowDialog = await container
+          .read(preferencesRepositoryProvider)
+          .get(PrefKey.showErrorDialog);
+    } catch (_) {
+      shouldShowDialog = kDebugMode;
+    }
+
+    if (shouldShowDialog) {
+      showErrorDialog(error, type: type, stackTrace: stackTrace);
+    } else {
+      final message = isNetworkError(error)
+          ? t.errors.networkError
+          : t.errors.unexpected;
+
+      rootScaffoldMessengerKey.currentState
+        ?..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(
+            content: Text(message),
+          ),
+        );
+    }
+  }
+
   // Pass all uncaught "fatal" errors from the framework to Crashlytics
   FlutterError.onError = (details) {
     firebaseService.crashlytics?.recordFlutterFatalError(details);
     FlutterError.dumpErrorToConsole(details);
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      showErrorDialog(
+      handleUncaughtError(
         details.exception,
         type: .flutter,
         stackTrace: details.stack,
@@ -109,16 +142,14 @@ Future<void> main() async {
   // Pass all uncaught asynchronous errors that aren't handled by the Flutter framework to Crashlytics
   PlatformDispatcher.instance.onError = (error, stack) {
     firebaseService.crashlytics?.recordError(error, stack, fatal: true);
-    showErrorDialog(error, type: .async, stackTrace: stack);
     log('Uncaught asynchronous error: $error', stackTrace: stack);
+    handleUncaughtError(error, type: .async, stackTrace: stack);
     return true;
   };
 
   firebaseService.analytics?.logAppOpen();
 
   await LocaleSettings.useDeviceLocale();
-
-  final container = ProviderContainer();
 
   // Initialize Remote Config and preference defaults
   await container.read(preferencesRepositoryProvider).init();
@@ -159,6 +190,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       title: t.general.appTitle,
+      scaffoldMessengerKey: rootScaffoldMessengerKey,
       locale: TranslationProvider.of(context).flutterLocale,
       supportedLocales: AppLocaleUtils.supportedLocales,
       localizationsDelegates: GlobalMaterialLocalizations.delegates,

--- a/lib/repositories/preferences_repository.dart
+++ b/lib/repositories/preferences_repository.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:developer';
 import 'package:dio/dio.dart';
 import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tattoo/database/database.dart';
@@ -30,7 +31,13 @@ enum PrefKey<T> {
   showDangerZone<bool>(.boolean, false),
 
   /// Whether the Weblate button is shown on the about page.
-  showWeblateButton<bool>(.boolean, false);
+  showWeblateButton<bool>(.boolean, false),
+
+  /// Whether to show the detailed error dialog on uncaught exceptions.
+  ///
+  /// Defaults to `kDebugMode` (true in debug, false in release). Can be
+  /// overridden via the regedit screen or Remote Config for on-device debugging.
+  showErrorDialog<bool>(.boolean, kDebugMode);
 
   const PrefKey(this.type, this.defaultValue);
   final PrefType type;

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -19,6 +19,7 @@ import 'package:tattoo/services/firebase_service.dart';
 import 'package:tattoo/shells/animated_shell_container.dart';
 
 final rootNavigatorKey = GlobalKey<NavigatorState>();
+final rootScaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
 
 abstract class AppRoutes {
   static const home = '/';

--- a/lib/utils/network_error.dart
+++ b/lib/utils/network_error.dart
@@ -1,0 +1,9 @@
+import 'package:dio/dio.dart';
+import 'package:tattoo/utils/network_error_stub.dart'
+    if (dart.library.io) 'package:tattoo/utils/network_error_io.dart';
+
+/// Determines whether an error is a network-related failure.
+bool isNetworkError(Object error) {
+  if (error is DioException) return true;
+  return isNativeNetworkError(error);
+}

--- a/lib/utils/network_error_io.dart
+++ b/lib/utils/network_error_io.dart
@@ -1,0 +1,9 @@
+import 'dart:io';
+
+/// Platform implementation for platforms with dart:io support.
+bool isNativeNetworkError(Object error) {
+  return error is SocketException ||
+      error is HttpException ||
+      error is HandshakeException ||
+      error is TlsException;
+}

--- a/lib/utils/network_error_stub.dart
+++ b/lib/utils/network_error_stub.dart
@@ -1,0 +1,2 @@
+/// Fallback for platforms where dart:io is unavailable (e.g. Flutter web).
+bool isNativeNetworkError(Object error) => false;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1158,7 +1158,7 @@ packages:
     source: hosted
     version: "2.4.1"
   shared_preferences_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: shared_preferences_platform_interface
       sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dev_dependencies:
   pointycastle: ^4.0.0
   slang_mcp: ^0.2.0
   args: ^2.7.0
+  shared_preferences_platform_interface: ^2.4.2
 
 flutter:
   uses-material-design: true

--- a/test/repositories/preferences_repository_test.dart
+++ b/test/repositories/preferences_repository_test.dart
@@ -19,16 +19,16 @@ void main() {
           InMemorySharedPreferencesAsync.empty();
       final store = TypedPreferenceStore(SharedPreferencesAsync());
 
-      expect(await store.read(PrefKey.showErrorDialog), isNull);
+      expect(await store.read(.showErrorDialog), isNull);
 
-      await store.write(PrefKey.showErrorDialog, true);
-      expect(await store.read(PrefKey.showErrorDialog), isTrue);
+      await store.write(.showErrorDialog, true);
+      expect(await store.read(.showErrorDialog), isTrue);
 
-      await store.write(PrefKey.showErrorDialog, false);
-      expect(await store.read(PrefKey.showErrorDialog), isFalse);
+      await store.write(.showErrorDialog, false);
+      expect(await store.read(.showErrorDialog), isFalse);
 
-      await store.remove(PrefKey.showErrorDialog);
-      expect(await store.read(PrefKey.showErrorDialog), isNull);
+      await store.remove(.showErrorDialog);
+      expect(await store.read(.showErrorDialog), isNull);
     });
   });
 }

--- a/test/repositories/preferences_repository_test.dart
+++ b/test/repositories/preferences_repository_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:tattoo/repositories/preferences_repository.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PrefKey.showErrorDialog', () {
+    test('has expected type and default value', () {
+      expect(PrefKey.showErrorDialog.type, PrefType.boolean);
+      expect(PrefKey.showErrorDialog.defaultValue, kDebugMode);
+    });
+
+    test('can be written and read from TypedPreferenceStore', () async {
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
+      final store = TypedPreferenceStore(SharedPreferencesAsync());
+
+      expect(await store.read(PrefKey.showErrorDialog), isNull);
+
+      await store.write(PrefKey.showErrorDialog, true);
+      expect(await store.read(PrefKey.showErrorDialog), isTrue);
+
+      await store.write(PrefKey.showErrorDialog, false);
+      expect(await store.read(PrefKey.showErrorDialog), isFalse);
+
+      await store.remove(PrefKey.showErrorDialog);
+      expect(await store.read(PrefKey.showErrorDialog), isNull);
+    });
+  });
+}

--- a/test/repositories/preferences_repository_test.dart
+++ b/test/repositories/preferences_repository_test.dart
@@ -15,6 +15,11 @@ void main() {
     });
 
     test('can be written and read from TypedPreferenceStore', () async {
+      final originalInstance = SharedPreferencesAsyncPlatform.instance;
+      addTearDown(() {
+        SharedPreferencesAsyncPlatform.instance = originalInstance;
+      });
+
       SharedPreferencesAsyncPlatform.instance =
           InMemorySharedPreferencesAsync.empty();
       final store = TypedPreferenceStore(SharedPreferencesAsync());

--- a/test/utils/network_error_test.dart
+++ b/test/utils/network_error_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tattoo/utils/network_error.dart';
+import 'package:tattoo/utils/network_error_stub.dart' as stub;
+
+void main() {
+  group('isNetworkError', () {
+    test('identifies DioException as network error', () {
+      final dioError = DioException(
+        requestOptions: RequestOptions(path: 'https://example.com'),
+      );
+      expect(isNetworkError(dioError), isTrue);
+    });
+
+    test('identifies SocketException as network error', () {
+      expect(
+        isNetworkError(const SocketException('Failed host lookup')),
+        isTrue,
+      );
+    });
+
+    test('identifies HttpException as network error', () {
+      expect(isNetworkError(const HttpException('Connection closed')), isTrue);
+    });
+
+    test('identifies HandshakeException as network error', () {
+      expect(
+        isNetworkError(const HandshakeException('Handshake error')),
+        isTrue,
+      );
+    });
+
+    test('identifies TlsException as network error', () {
+      expect(isNetworkError(const TlsException('TLS error')), isTrue);
+    });
+
+    test('returns false for generic and unexpected errors', () {
+      expect(isNetworkError(Exception('something failed')), isFalse);
+      expect(isNetworkError(StateError('invalid state')), isFalse);
+      expect(isNetworkError(FormatException('invalid format')), isFalse);
+      expect(isNetworkError('error string'), isFalse);
+    });
+  });
+
+  group('network_error_stub', () {
+    test('isNativeNetworkError returns false on stub platform', () {
+      expect(stub.isNativeNetworkError(Exception('something failed')), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Previously, all uncaught Flutter and asynchronous errors displayed a modal `AlertDialog` containing technical exception details and stack traces.

This PR introduces graceful error handling:
- **Graceful SnackBar**: When verbose error dialogs are disabled (default in Release mode), uncaught errors show a floating `SnackBar` prompting either "網路連線出現錯誤" (`t.errors.networkError`) for network-related failures (`DioException`, `SocketException`, `HttpException`, `HandshakeException`, `TlsException`) or "發生未預期的錯誤" (`t.errors.unexpected`) for other runtime exceptions.
- **Preference Gate (`PrefKey.showErrorDialog`)**: Controlled via `PreferencesRepository` (defaulting to `kDebugMode`: `true` in debug, `false` in release). This allows enabling/disabling verbose error dialogs at runtime via the **Regedit** screen or remotely via Firebase Remote Config for easier bug reproduction in production.
- **Global `ScaffoldMessengerKey`**: Added `rootScaffoldMessengerKey` to ensure snackbar delivery without context dependency.
- **Reporting & Logging**: Firebase Crashlytics error reporting and console logging remain active regardless of the UI display preference.

## Changes

- Added `PrefKey.showErrorDialog` in `lib/repositories/preferences_repository.dart`
- Added `rootScaffoldMessengerKey` in `lib/router/app_router.dart` and attached to `MaterialApp.router` in `lib/main.dart`
- Created `isNetworkError` helper in `lib/utils/network_error.dart`
- Added i18n translation keys `unexpected` and `networkError` to `zh-TW.i18n.yaml` and `en-US.i18n.yaml`
- Added unit tests in `test/repositories/preferences_repository_test.dart` and `test/utils/network_error_test.dart`