### PR TITLE
fix: correct course offering and syllabus identifiers

### DIFF
--- a/lib/database/actions.dart
+++ b/lib/database/actions.dart
@@ -206,8 +206,8 @@ extension DatabaseActions on AppDatabase {
 
   /// Returns the ID of an existing course offering, or creates/updates one.
   ///
-  /// Upserts by `(semester, number)`. Null-number entries always insert
-  /// (SQLite treats NULLs as distinct) — caller must delete stale ones first.
+  /// Upserts by number. Null-number entries always insert (SQLite treats NULLs
+  /// as distinct) — caller must delete stale ones first.
   Future<int> upsertCourseOffering({
     String? courseCode,
     required int semesterId,
@@ -247,7 +247,7 @@ extension DatabaseActions on AppDatabase {
           language: Value(language),
           remarks: Value(remarks),
         ),
-        target: [courseOfferings.semester, courseOfferings.number],
+        target: [courseOfferings.number],
       ),
     )).id;
   }

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -4964,6 +4964,7 @@ class $CourseOfferingsTable extends CourseOfferings
     true,
     type: DriftSqlType.string,
     requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
   );
   static const VerificationMeta _nameZhMeta = const VerificationMeta('nameZh');
   @override
@@ -5201,10 +5202,6 @@ class $CourseOfferingsTable extends CourseOfferings
 
   @override
   Set<GeneratedColumn> get $primaryKey => {id};
-  @override
-  List<Set<GeneratedColumn>> get uniqueKeys => [
-    {semester, number},
-  ];
   @override
   CourseOffering map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';

--- a/lib/database/schema.dart
+++ b/lib/database/schema.dart
@@ -414,7 +414,7 @@ class CourseOfferings extends Table with AutoIncrementId, Fetchable {
   /// Course offering number (e.g., "313146", "352902").
   ///
   /// Null for special entries that have no assigned number.
-  late final number = text().nullable()();
+  late final number = text().nullable().unique()();
 
   /// Display name as it appears in this semester's timetable.
   ///
@@ -477,11 +477,6 @@ class CourseOfferings extends Table with AutoIncrementId, Fetchable {
 
   /// Number of withdrawn students (撤).
   late final withdrawn = integer().nullable()();
-
-  @override
-  List<Set<Column>> get uniqueKeys => [
-    {semester, number},
-  ];
 }
 
 // Junction tables and dependent tables

--- a/lib/repositories/course_repository.dart
+++ b/lib/repositories/course_repository.dart
@@ -768,7 +768,7 @@ class CourseRepository {
     final syllabus = await _authRepository.withAuth(
       () => _courseService.getSyllabus(
         courseNumber: offering.number!,
-        syllabusId: teacherId,
+        teacherId: teacherId,
       ),
       sso: [.courseService],
     );

--- a/lib/services/course/course_service.dart
+++ b/lib/services/course/course_service.dart
@@ -246,12 +246,12 @@ abstract interface class CourseService {
   /// hasn't submitted one yet (the page shows 尚未登錄).
   ///
   /// The [courseNumber] should be a course offering number (e.g., "346774"),
-  /// and [syllabusId] is the authoring teacher's code (one of the `teachers`
-  /// ids of a [ScheduleDto]).
+  /// and [teacherId] is the authoring teacher's ID (one of the `teachers` IDs
+  /// of a [ScheduleDto]).
   ///
   /// Throws an [Exception] if the syllabus tables are not found.
   Future<SyllabusDto?> getSyllabus({
     required String courseNumber,
-    required String syllabusId,
+    required String teacherId,
   });
 }

--- a/lib/services/course/mock_course_service.dart
+++ b/lib/services/course/mock_course_service.dart
@@ -1837,12 +1837,12 @@ class MockCourseService implements CourseService {
   @override
   Future<SyllabusDto?> getSyllabus({
     required String courseNumber,
-    required String syllabusId,
+    required String teacherId,
   }) async {
     if (syllabusResult != null) return syllabusResult;
     // Some teachers on a team-taught offering haven't submitted a syllabus yet
     // (the real page shows 尚未登錄); return null to exercise that path.
-    if (const {'11894', '11991'}.contains(syllabusId)) return null;
+    if (const {'11894', '11991'}.contains(teacherId)) return null;
     return (
       type: CourseType.universityCommonRequired,
       enrolled: 55,

--- a/lib/services/course/ntut_course_service.dart
+++ b/lib/services/course/ntut_course_service.dart
@@ -511,11 +511,11 @@ class NtutCourseService implements CourseService {
   @override
   Future<SyllabusDto?> getSyllabus({
     required String courseNumber,
-    required String syllabusId,
+    required String teacherId,
   }) async {
     final response = await _courseDio.get(
       'tw/ShowSyllabus.jsp',
-      queryParameters: {'snum': courseNumber, 'code': syllabusId},
+      queryParameters: {'snum': courseNumber, 'code': teacherId},
     );
 
     final document = parse(response.data);
@@ -607,10 +607,9 @@ class NtutCourseService implements CourseService {
     return text.isNotEmpty ? [text] : <String>[];
   }
 
-  /// Parses the available syllabus identifiers from the 查詢 column.
+  /// Parses an anchor's display name and `code` query parameter.
   ///
-  /// Each anchor links to a teacher's syllabus; its `code` query parameter is
-  /// the authoring teacher's id. Returns null when no syllabus is available.
+  /// Returns null fields when the corresponding anchor data is unavailable.
   ReferenceDto _parseAnchorRef(Element anchor) {
     final name = anchor.text.trim();
     final href = anchor.attributes['href'];

--- a/test/services/course_service_test.dart
+++ b/test/services/course_service_test.dart
@@ -368,7 +368,7 @@ void main() {
     });
 
     group('getSyllabus', () {
-      // A syllabus's code is its author's teacher code, so any teacher may have
+      // A syllabus belongs to its authoring teacher, so any teacher may have
       // one. Scans the course table for the first teacher who has submitted a
       // syllabus (others return null — the page shows 尚未登錄).
       Future<SyllabusDto> firstSyllabus() async {
@@ -381,12 +381,12 @@ void main() {
           final number = schedule.number;
           if (number == null || number.isEmpty) continue;
           for (final teacher in schedule.teachers ?? const []) {
-            final code = teacher.id;
-            if (code == null) continue;
+            final teacherId = teacher.id;
+            if (teacherId == null) continue;
             await respectfulDelay();
             final syllabus = await courseService.getSyllabus(
               courseNumber: number,
-              syllabusId: code,
+              teacherId: teacherId,
             );
             if (syllabus != null) return syllabus;
           }

--- a/tool/html_snapshot.dart
+++ b/tool/html_snapshot.dart
@@ -111,10 +111,12 @@ class CaptureCommand extends SnapshotCommand {
       ..addOption('year', help: 'Course ROC year, e.g. 114.')
       ..addOption('term', help: 'Course term, e.g. 1 or 2.')
       ..addOption('course-id', help: 'Course catalog ID for course.detail.')
-      ..addOption('teacher-id', help: 'Teacher ID for teacher presets.')
+      ..addOption(
+        'teacher-id',
+        help: 'Teacher ID for teacher and course.syllabus presets.',
+      )
       ..addOption('classroom-id', help: 'Classroom ID for course.classroom.')
       ..addOption('course-number', help: 'Course offering number.')
-      ..addOption('syllabus-id', help: 'Syllabus ID for course.syllabus.')
       ..addOption('course-internal-id', help: 'Internal iSchool+ course ID.');
   }
 

--- a/tool/html_snapshot/presets.dart
+++ b/tool/html_snapshot/presets.dart
@@ -213,8 +213,8 @@ final _presetList = <SnapshotPreset>[
     name: 'course.syllabus',
     service: .course,
     description:
-        'Course syllabus page. Required: --course-number --syllabus-id.',
-    allSkipReason: 'requires --course-number and --syllabus-id',
+        'Course syllabus page. Required: --course-number --teacher-id.',
+    allSkipReason: 'requires --course-number and --teacher-id',
     buildRequest: _syllabus,
   ),
   SnapshotPreset(
@@ -370,13 +370,13 @@ Future<SnapshotRequest> _syllabus(
   ArgResults args,
 ) async {
   final courseNumber = _requiredOption(args, 'course-number');
-  final syllabusId = _requiredOption(args, 'syllabus-id');
+  final teacherId = _requiredOption(args, 'teacher-id');
   return SnapshotRequest(
     service: .course,
     path: 'tw/ShowSyllabus.jsp',
-    query: {'snum': courseNumber, 'code': syllabusId},
+    query: {'snum': courseNumber, 'code': teacherId},
     extension: 'html',
-    fileParts: ['c$courseNumber', 's$syllabusId'],
+    fileParts: ['c$courseNumber', 't$teacherId'],
   );
 }
 


### PR DESCRIPTION
Closes #376

## Summary

- make non-null course offering numbers globally unique across semesters
- upsert course offerings by offering number instead of `(semester, number)`
- rename the syllabus author selector from `syllabusId` to `teacherId`
- update the HTML snapshot CLI to use `--teacher-id` for syllabus captures

## Details

`CourseOfferings.number` identifies a specific course offering globally. The offering still belongs to a semester through its required `semester` foreign key, but the semester is no longer part of the number's uniqueness constraint.

The syllabus endpoint uses two independent identifiers:

- `snum`: course offering number
- `code`: authoring teacher ID

The previous `syllabusId` terminology incorrectly described the teacher ID as a syllabus identifier. This PR renames the Dart API, repository callsites, mocks, integration test, and snapshot tooling while preserving the endpoint's wire parameters.

Nullable course offering numbers remain supported for special timetable entries. SQLite permits multiple `NULL` values under the single-column unique constraint.

## Verification

- `dart run build_runner build`
- `dart run tool/html_snapshot.dart capture --help`
- `dart run tool/html_snapshot.dart list`
- `flutter test --dart-define-from-file=test/test_config.json -r failures-only test/services/course_service_test.dart`
- `flutter analyze`

All 15 course service tests passed, and Flutter analysis reported no issues.