### PR TITLE
feat: implement change password feature

### DIFF
--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -240,3 +240,20 @@ regedit:
     localOverride: User Override
     remoteOverride: Forced (Remote)
   invalidInput: Invalid input
+
+changePassword:
+  title: Change Password
+  titleExpired: Change Expired Password
+  expiredNotice: Your password has expired. Please set a new password to continue.
+  currentPassword: Current Password
+  newPassword: New Password
+  confirmPassword: Confirm New Password
+  submit: Change Password
+  success: Password changed successfully
+  errors:
+    emptyFields: Please fill in all fields
+    mismatch: New passwords do not match
+    failed: "Password change failed: ${error}"
+    invalidLength: Password length must be between 8 and 14 characters
+    invalidComplexity: Password must contain uppercase, lowercase, numbers, and symbols
+    sameAsUsername: Password cannot be the same as your student ID

--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -257,3 +257,10 @@ changePassword:
     invalidLength: Password length must be between 8 and 14 characters
     invalidComplexity: Password must contain uppercase, lowercase, numbers, and symbols
     sameAsUsername: Password cannot be the same as your student ID
+    server:
+      authFailed: Current password is incorrect
+      minAge: Password cannot be changed more than once per day
+      historyRepeat: Password cannot be the same as any of the last 3 passwords used
+      sameAsUsername: Password cannot be the same as your student ID
+      length: Password length must be between 8 and 14 characters
+      complexity: Password must contain uppercase, lowercase, numbers, and symbols

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 398 (199 per locale)
+/// Strings: 426 (213 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 426 (213 per locale)
+/// Strings: 438 (219 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -55,6 +55,7 @@ class TranslationsEnUs extends Translations with BaseTranslations<AppLocale, Tra
 	@override late final _Translations$enrollmentStatus$en_US enrollmentStatus = _Translations$enrollmentStatus$en_US._(_root);
 	@override late final _Translations$about$en_US about = _Translations$about$en_US._(_root);
 	@override late final _Translations$regedit$en_US regedit = _Translations$regedit$en_US._(_root);
+	@override late final _Translations$changePassword$en_US changePassword = _Translations$changePassword$en_US._(_root);
 }
 
 // Path: general
@@ -333,6 +334,24 @@ class _Translations$regedit$en_US extends Translations$regedit$zh_TW {
 	@override String get invalidInput => 'Invalid input';
 }
 
+// Path: changePassword
+class _Translations$changePassword$en_US extends Translations$changePassword$zh_TW {
+	_Translations$changePassword$en_US._(TranslationsEnUs root) : this._root = root, super.internal(root);
+
+	final TranslationsEnUs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Change Password';
+	@override String get titleExpired => 'Change Expired Password';
+	@override String get expiredNotice => 'Your password has expired. Please set a new password to continue.';
+	@override String get currentPassword => 'Current Password';
+	@override String get newPassword => 'New Password';
+	@override String get confirmPassword => 'Confirm New Password';
+	@override String get submit => 'Change Password';
+	@override String get success => 'Password changed successfully';
+	@override late final _Translations$changePassword$errors$en_US errors = _Translations$changePassword$errors$en_US._(_root);
+}
+
 // Path: intro.features
 class _Translations$intro$features$en_US extends Translations$intro$features$zh_TW {
 	_Translations$intro$features$en_US._(TranslationsEnUs root) : this._root = root, super.internal(root);
@@ -581,6 +600,21 @@ class _Translations$regedit$status$en_US extends Translations$regedit$status$zh_
 	@override String get remote => 'Remote Config';
 	@override String get localOverride => 'User Override';
 	@override String get remoteOverride => 'Forced (Remote)';
+}
+
+// Path: changePassword.errors
+class _Translations$changePassword$errors$en_US extends Translations$changePassword$errors$zh_TW {
+	_Translations$changePassword$errors$en_US._(TranslationsEnUs root) : this._root = root, super.internal(root);
+
+	final TranslationsEnUs _root; // ignore: unused_field
+
+	// Translations
+	@override String get emptyFields => 'Please fill in all fields';
+	@override String get mismatch => 'New passwords do not match';
+	@override String failed({required Object error}) => 'Password change failed: ${error}';
+	@override String get invalidLength => 'Password length must be between 8 and 14 characters';
+	@override String get invalidComplexity => 'Password must contain uppercase, lowercase, numbers, and symbols';
+	@override String get sameAsUsername => 'Password cannot be the same as your student ID';
 }
 
 // Path: intro.features.courseTable
@@ -834,6 +868,20 @@ extension on TranslationsEnUs {
 			'regedit.status.localOverride' => 'User Override',
 			'regedit.status.remoteOverride' => 'Forced (Remote)',
 			'regedit.invalidInput' => 'Invalid input',
+			'changePassword.title' => 'Change Password',
+			'changePassword.titleExpired' => 'Change Expired Password',
+			'changePassword.expiredNotice' => 'Your password has expired. Please set a new password to continue.',
+			'changePassword.currentPassword' => 'Current Password',
+			'changePassword.newPassword' => 'New Password',
+			'changePassword.confirmPassword' => 'Confirm New Password',
+			'changePassword.submit' => 'Change Password',
+			'changePassword.success' => 'Password changed successfully',
+			'changePassword.errors.emptyFields' => 'Please fill in all fields',
+			'changePassword.errors.mismatch' => 'New passwords do not match',
+			'changePassword.errors.failed' => ({required Object error}) => 'Password change failed: ${error}',
+			'changePassword.errors.invalidLength' => 'Password length must be between 8 and 14 characters',
+			'changePassword.errors.invalidComplexity' => 'Password must contain uppercase, lowercase, numbers, and symbols',
+			'changePassword.errors.sameAsUsername' => 'Password cannot be the same as your student ID',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -615,6 +615,7 @@ class _Translations$changePassword$errors$en_US extends Translations$changePassw
 	@override String get invalidLength => 'Password length must be between 8 and 14 characters';
 	@override String get invalidComplexity => 'Password must contain uppercase, lowercase, numbers, and symbols';
 	@override String get sameAsUsername => 'Password cannot be the same as your student ID';
+	@override late final _Translations$changePassword$errors$server$en_US server = _Translations$changePassword$errors$server$en_US._(_root);
 }
 
 // Path: intro.features.courseTable
@@ -662,6 +663,21 @@ class _Translations$profile$dangerZone$items$en_US extends Translations$profile$
 	@override String get preferences => 'Preferences';
 	@override String get credentials => 'Credentials';
 	@override String get userData => 'User data';
+}
+
+// Path: changePassword.errors.server
+class _Translations$changePassword$errors$server$en_US extends Translations$changePassword$errors$server$zh_TW {
+	_Translations$changePassword$errors$server$en_US._(TranslationsEnUs root) : this._root = root, super.internal(root);
+
+	final TranslationsEnUs _root; // ignore: unused_field
+
+	// Translations
+	@override String get authFailed => 'Current password is incorrect';
+	@override String get minAge => 'Password cannot be changed more than once per day';
+	@override String get historyRepeat => 'Password cannot be the same as any of the last 3 passwords used';
+	@override String get sameAsUsername => 'Password cannot be the same as your student ID';
+	@override String get length => 'Password length must be between 8 and 14 characters';
+	@override String get complexity => 'Password must contain uppercase, lowercase, numbers, and symbols';
 }
 
 /// The flat map containing all translations for locale <en-US>.
@@ -882,6 +898,12 @@ extension on TranslationsEnUs {
 			'changePassword.errors.invalidLength' => 'Password length must be between 8 and 14 characters',
 			'changePassword.errors.invalidComplexity' => 'Password must contain uppercase, lowercase, numbers, and symbols',
 			'changePassword.errors.sameAsUsername' => 'Password cannot be the same as your student ID',
+			'changePassword.errors.server.authFailed' => 'Current password is incorrect',
+			'changePassword.errors.server.minAge' => 'Password cannot be changed more than once per day',
+			'changePassword.errors.server.historyRepeat' => 'Password cannot be the same as any of the last 3 passwords used',
+			'changePassword.errors.server.sameAsUsername' => 'Password cannot be the same as your student ID',
+			'changePassword.errors.server.length' => 'Password length must be between 8 and 14 characters',
+			'changePassword.errors.server.complexity' => 'Password must contain uppercase, lowercase, numbers, and symbols',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -981,6 +981,8 @@ class Translations$changePassword$errors$zh_TW {
 
 	/// zh-TW: '密碼不可與學號相同'
 	String get sameAsUsername => '密碼不可與學號相同';
+
+	late final Translations$changePassword$errors$server$zh_TW server = Translations$changePassword$errors$server$zh_TW.internal(_root);
 }
 
 // Path: intro.features.courseTable
@@ -1050,6 +1052,33 @@ class Translations$profile$dangerZone$items$zh_TW {
 
 	/// zh-TW: '使用者資料'
 	String get userData => '使用者資料';
+}
+
+// Path: changePassword.errors.server
+class Translations$changePassword$errors$server$zh_TW {
+	Translations$changePassword$errors$server$zh_TW.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// zh-TW: '目前密碼錯誤'
+	String get authFailed => '目前密碼錯誤';
+
+	/// zh-TW: '密碼於1天內不得再修改'
+	String get minAge => '密碼於1天內不得再修改';
+
+	/// zh-TW: '密碼不可與前3組重複'
+	String get historyRepeat => '密碼不可與前3組重複';
+
+	/// zh-TW: '密碼不可與學號相同'
+	String get sameAsUsername => '密碼不可與學號相同';
+
+	/// zh-TW: '密碼長度須介於8至14個字元之間'
+	String get length => '密碼長度須介於8至14個字元之間';
+
+	/// zh-TW: '密碼須包含英文大小寫字母、數字及符號'
+	String get complexity => '密碼須包含英文大小寫字母、數字及符號';
 }
 
 /// The flat map containing all translations for locale <zh-TW>.
@@ -1270,6 +1299,12 @@ extension on Translations {
 			'changePassword.errors.invalidLength' => '密碼長度須介於8至14個字元之間',
 			'changePassword.errors.invalidComplexity' => '密碼須包含英文大小寫字母、數字及符號',
 			'changePassword.errors.sameAsUsername' => '密碼不可與學號相同',
+			'changePassword.errors.server.authFailed' => '目前密碼錯誤',
+			'changePassword.errors.server.minAge' => '密碼於1天內不得再修改',
+			'changePassword.errors.server.historyRepeat' => '密碼不可與前3組重複',
+			'changePassword.errors.server.sameAsUsername' => '密碼不可與學號相同',
+			'changePassword.errors.server.length' => '密碼長度須介於8至14個字元之間',
+			'changePassword.errors.server.complexity' => '密碼須包含英文大小寫字母、數字及符號',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -56,6 +56,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	late final Translations$enrollmentStatus$zh_TW enrollmentStatus = Translations$enrollmentStatus$zh_TW.internal(_root);
 	late final Translations$about$zh_TW about = Translations$about$zh_TW.internal(_root);
 	late final Translations$regedit$zh_TW regedit = Translations$regedit$zh_TW.internal(_root);
+	late final Translations$changePassword$zh_TW changePassword = Translations$changePassword$zh_TW.internal(_root);
 }
 
 // Path: general
@@ -518,6 +519,41 @@ class Translations$regedit$zh_TW {
 	String get invalidInput => '輸入格式錯誤';
 }
 
+// Path: changePassword
+class Translations$changePassword$zh_TW {
+	Translations$changePassword$zh_TW.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// zh-TW: '變更密碼'
+	String get title => '變更密碼';
+
+	/// zh-TW: '變更過期密碼'
+	String get titleExpired => '變更過期密碼';
+
+	/// zh-TW: '您的密碼已過期，請設定新密碼以繼續使用。'
+	String get expiredNotice => '您的密碼已過期，請設定新密碼以繼續使用。';
+
+	/// zh-TW: '目前密碼'
+	String get currentPassword => '目前密碼';
+
+	/// zh-TW: '新密碼'
+	String get newPassword => '新密碼';
+
+	/// zh-TW: '確認新密碼'
+	String get confirmPassword => '確認新密碼';
+
+	/// zh-TW: '變更密碼'
+	String get submit => '變更密碼';
+
+	/// zh-TW: '密碼變更成功'
+	String get success => '密碼變更成功';
+
+	late final Translations$changePassword$errors$zh_TW errors = Translations$changePassword$errors$zh_TW.internal(_root);
+}
+
 // Path: intro.features
 class Translations$intro$features$zh_TW {
 	Translations$intro$features$zh_TW.internal(this._root);
@@ -920,6 +956,33 @@ class Translations$regedit$status$zh_TW {
 	String get remoteOverride => '強制覆寫（遠端）';
 }
 
+// Path: changePassword.errors
+class Translations$changePassword$errors$zh_TW {
+	Translations$changePassword$errors$zh_TW.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// zh-TW: '請填寫所有欄位'
+	String get emptyFields => '請填寫所有欄位';
+
+	/// zh-TW: '兩次輸入的密碼不一致'
+	String get mismatch => '兩次輸入的密碼不一致';
+
+	/// zh-TW: '變更密碼失敗：${error}'
+	String failed({required Object error}) => '變更密碼失敗：${error}';
+
+	/// zh-TW: '密碼長度須介於8至14個字元之間'
+	String get invalidLength => '密碼長度須介於8至14個字元之間';
+
+	/// zh-TW: '密碼須包含英文大小寫字母、數字及符號'
+	String get invalidComplexity => '密碼須包含英文大小寫字母、數字及符號';
+
+	/// zh-TW: '密碼不可與學號相同'
+	String get sameAsUsername => '密碼不可與學號相同';
+}
+
 // Path: intro.features.courseTable
 class Translations$intro$features$courseTable$zh_TW {
 	Translations$intro$features$courseTable$zh_TW.internal(this._root);
@@ -1193,6 +1256,20 @@ extension on Translations {
 			'regedit.status.localOverride' => '使用者覆寫',
 			'regedit.status.remoteOverride' => '強制覆寫（遠端）',
 			'regedit.invalidInput' => '輸入格式錯誤',
+			'changePassword.title' => '變更密碼',
+			'changePassword.titleExpired' => '變更過期密碼',
+			'changePassword.expiredNotice' => '您的密碼已過期，請設定新密碼以繼續使用。',
+			'changePassword.currentPassword' => '目前密碼',
+			'changePassword.newPassword' => '新密碼',
+			'changePassword.confirmPassword' => '確認新密碼',
+			'changePassword.submit' => '變更密碼',
+			'changePassword.success' => '密碼變更成功',
+			'changePassword.errors.emptyFields' => '請填寫所有欄位',
+			'changePassword.errors.mismatch' => '兩次輸入的密碼不一致',
+			'changePassword.errors.failed' => ({required Object error}) => '變更密碼失敗：${error}',
+			'changePassword.errors.invalidLength' => '密碼長度須介於8至14個字元之間',
+			'changePassword.errors.invalidComplexity' => '密碼須包含英文大小寫字母、數字及符號',
+			'changePassword.errors.sameAsUsername' => '密碼不可與學號相同',
 			_ => null,
 		};
 	}

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -240,3 +240,20 @@ regedit:
     localOverride: 使用者覆寫
     remoteOverride: 強制覆寫（遠端）
   invalidInput: 輸入格式錯誤
+
+changePassword:
+  title: 變更密碼
+  titleExpired: 變更過期密碼
+  expiredNotice: 您的密碼已過期，請設定新密碼以繼續使用。
+  currentPassword: 目前密碼
+  newPassword: 新密碼
+  confirmPassword: 確認新密碼
+  submit: 變更密碼
+  success: 密碼變更成功
+  errors:
+    emptyFields: 請填寫所有欄位
+    mismatch: 兩次輸入的密碼不一致
+    failed: 變更密碼失敗：${error}
+    invalidLength: 密碼長度須介於8至14個字元之間
+    invalidComplexity: 密碼須包含英文大小寫字母、數字及符號
+    sameAsUsername: 密碼不可與學號相同

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -257,3 +257,10 @@ changePassword:
     invalidLength: 密碼長度須介於8至14個字元之間
     invalidComplexity: 密碼須包含英文大小寫字母、數字及符號
     sameAsUsername: 密碼不可與學號相同
+    server:
+      authFailed: 目前密碼錯誤
+      minAge: 密碼於1天內不得再修改
+      historyRepeat: 密碼不可與前3組重複
+      sameAsUsername: 密碼不可與學號相同
+      length: 密碼長度須介於8至14個字元之間
+      complexity: 密碼須包含英文大小寫字母、數字及符號

--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -143,7 +143,7 @@ class AuthRepository {
 
     final UserDto userDto;
     if (isDemo) {
-      if (password == 'expired') {
+      if (isDemoPasswordExpired(username, password)) {
         throw const LoginException(LoginFailure.passwordExpired);
       }
       // Demo mode: skip real portal, use hardcoded data
@@ -538,7 +538,10 @@ class AuthRepository {
     }
 
     await withAuth(
-      () => _portalService.changePassword(currentPassword, newPassword),
+      () => _portalService.changePassword(
+        currentPassword: currentPassword,
+        newPassword: newPassword,
+      ),
     );
 
     // Update stored credentials so auto-login uses the new password
@@ -569,7 +572,14 @@ class AuthRepository {
     String username,
     String newPassword,
   ) async {
-    await _portalService.changeExpiredPassword(newPassword);
+    if (username.trim().isEmpty) {
+      throw ArgumentError.value(username, 'username', 'Username is required');
+    }
+
+    await _portalService.changePassword(
+      newPassword: newPassword,
+      isExpired: true,
+    );
 
     // Perform a full login with the new password to establish a valid session
     await login(username, newPassword);

--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -143,6 +143,9 @@ class AuthRepository {
 
     final UserDto userDto;
     if (isDemo) {
+      if (password == 'expired') {
+        throw const LoginException(LoginFailure.passwordExpired);
+      }
       // Demo mode: skip real portal, use hardcoded data
       userDto = (
         name: '王大同',

--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -556,6 +556,22 @@ class AuthRepository {
     } catch (_) {}
   }
 
+  /// Changes the user's expired NTUT Portal password.
+  ///
+  /// This must be called when the password has expired (e.g. login failed with
+  /// [LoginFailure.passwordExpired]). It uses the established session to
+  /// change the password, writes the new password to secure storage, and
+  /// performs a full login to establish a valid session.
+  Future<void> changeExpiredPassword(
+    String username,
+    String newPassword,
+  ) async {
+    await _portalService.changeExpiredPassword(newPassword);
+
+    // Perform a full login with the new password to establish a valid session
+    await login(username, newPassword);
+  }
+
   /// Watches the user's active registration (where enrollment status is "在學").
   ///
   /// Emits the most recent semester where the user is actively enrolled,

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -13,6 +13,7 @@ import 'package:tattoo/screens/main/profile/profile_screen.dart';
 import 'package:tattoo/screens/main/profile/regedit_screen.dart';
 import 'package:tattoo/screens/main/scanner/scanner_screen.dart';
 import 'package:tattoo/screens/main/score/score_screen.dart';
+import 'package:tattoo/screens/welcome/change_password_screen.dart';
 import 'package:tattoo/screens/welcome/intro_screen.dart';
 import 'package:tattoo/screens/welcome/login_screen.dart';
 import 'package:tattoo/services/firebase_service.dart';
@@ -34,6 +35,7 @@ abstract class AppRoutes {
   static const scanner = '/scanner';
   static const kioskLoginQr = '/kiosk-login-qr';
   static const regedit = '/regedit';
+  static const changePassword = '/change-password';
 }
 
 /// Bridges [sessionProvider] to a [Listenable] for [GoRouter.refreshListenable].
@@ -48,6 +50,7 @@ const _publicRoutes = {
   AppRoutes.intro,
   AppRoutes.login,
   AppRoutes.about,
+  AppRoutes.changePassword,
 };
 
 /// Creates a configured [GoRouter] starting at [initialLocation].
@@ -78,6 +81,18 @@ GoRouter createAppRouter({
     GoRoute(
       path: AppRoutes.login,
       builder: (context, state) => const LoginScreen(),
+    ),
+    GoRoute(
+      path: AppRoutes.changePassword,
+      builder: (context, state) {
+        final extra = state.extra as Map<String, dynamic>?;
+        final isExpired = extra?['isExpired'] as bool? ?? false;
+        final username = extra?['username'] as String?;
+        return ChangePasswordScreen(
+          isExpired: isExpired,
+          username: username,
+        );
+      },
     ),
     GoRoute(
       path: AppRoutes.about,

--- a/lib/screens/main/profile/profile_screen.dart
+++ b/lib/screens/main/profile/profile_screen.dart
@@ -95,7 +95,12 @@ class ProfileScreen extends ConsumerWidget {
       OptionEntryTile.icon(
         icon: Icons.password,
         title: t.profile.options.changePassword,
-        onTap: () => _showDemoTap(context),
+        onTap: () => context.push(
+          AppRoutes.changePassword,
+          extra: {
+            'isExpired': false,
+          },
+        ),
       ),
       OptionEntryTile.icon(
         icon: Icons.image,

--- a/lib/screens/welcome/change_password_providers.dart
+++ b/lib/screens/welcome/change_password_providers.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:riverpod/riverpod.dart';
+import 'package:tattoo/database/database.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/auth_repository.dart';
 import 'package:tattoo/screens/main/user_providers.dart';
@@ -70,8 +71,13 @@ class ChangePasswordNotifier extends Notifier<ChangePasswordState> {
       return t.changePassword.errors.invalidComplexity;
     }
 
-    if (studentId != null && password == studentId) {
-      return t.changePassword.errors.sameAsUsername;
+    if (studentId != null) {
+      final normalizedPassword = password.toLowerCase().trim();
+      final normalizedStudentId = studentId.toLowerCase().trim();
+      if (normalizedStudentId.isNotEmpty &&
+          normalizedPassword.contains(normalizedStudentId)) {
+        return t.changePassword.errors.sameAsUsername;
+      }
     }
 
     return null;
@@ -112,10 +118,24 @@ class ChangePasswordNotifier extends Notifier<ChangePasswordState> {
       return false;
     }
 
+    if (isExpired && (username == null || username.trim().isEmpty)) {
+      state = state.copyWith(
+        errorMessage: t.changePassword.errors.failed(
+          error: 'Student ID is missing',
+        ),
+        newHasError: true,
+      );
+      return false;
+    }
+
     // Determine the student ID for similarity validation
     String? studentId = username;
     if (!isExpired) {
-      final user = ref.read(userProfileProvider).value;
+      var user = ref.read(userProfileProvider).value;
+      if (user == null) {
+        final db = ref.read(databaseProvider);
+        user = await db.select(db.users).getSingleOrNull();
+      }
       studentId = user?.studentId;
     }
 
@@ -141,7 +161,7 @@ class ChangePasswordNotifier extends Notifier<ChangePasswordState> {
     try {
       final authRepo = ref.read(authRepositoryProvider);
       if (isExpired) {
-        await authRepo.changeExpiredPassword(username ?? '', newPassword);
+        await authRepo.changeExpiredPassword(username!, newPassword);
       } else {
         await authRepo.changePassword(currentPassword, newPassword);
       }

--- a/lib/screens/welcome/change_password_providers.dart
+++ b/lib/screens/welcome/change_password_providers.dart
@@ -1,0 +1,192 @@
+import 'dart:async';
+import 'package:riverpod/riverpod.dart';
+import 'package:tattoo/i18n/strings.g.dart';
+import 'package:tattoo/repositories/auth_repository.dart';
+import 'package:tattoo/screens/main/user_providers.dart';
+
+class ChangePasswordState {
+  final bool isLoading;
+  final String? errorMessage;
+  final bool currentHasError;
+  final bool newHasError;
+  final bool confirmHasError;
+
+  const ChangePasswordState({
+    this.isLoading = false,
+    this.errorMessage,
+    this.currentHasError = false,
+    this.newHasError = false,
+    this.confirmHasError = false,
+  });
+
+  ChangePasswordState copyWith({
+    bool? isLoading,
+    String? errorMessage,
+    bool? currentHasError,
+    bool? newHasError,
+    bool? confirmHasError,
+  }) {
+    return ChangePasswordState(
+      isLoading: isLoading ?? this.isLoading,
+      errorMessage: errorMessage,
+      currentHasError: currentHasError ?? this.currentHasError,
+      newHasError: newHasError ?? this.newHasError,
+      confirmHasError: confirmHasError ?? this.confirmHasError,
+    );
+  }
+}
+
+final changePasswordProvider =
+    NotifierProvider<ChangePasswordNotifier, ChangePasswordState>(
+      ChangePasswordNotifier.new,
+    );
+
+class ChangePasswordNotifier extends Notifier<ChangePasswordState> {
+  @override
+  ChangePasswordState build() {
+    return const ChangePasswordState();
+  }
+
+  void clearErrors() {
+    if (state.errorMessage != null ||
+        state.currentHasError ||
+        state.newHasError ||
+        state.confirmHasError) {
+      state = const ChangePasswordState();
+    }
+  }
+
+  String? _validatePasswordRules(String password, String? studentId) {
+    if (password.length < 8 || password.length > 14) {
+      return t.changePassword.errors.invalidLength;
+    }
+
+    final hasUpper = password.contains(RegExp(r'[A-Z]'));
+    final hasLower = password.contains(RegExp(r'[a-z]'));
+    final hasDigit = password.contains(RegExp(r'[0-9]'));
+    final hasSymbol = password.contains(RegExp(r'[^a-zA-Z0-9]'));
+
+    if (!hasUpper || !hasLower || !hasDigit || !hasSymbol) {
+      return t.changePassword.errors.invalidComplexity;
+    }
+
+    if (studentId != null && password == studentId) {
+      return t.changePassword.errors.sameAsUsername;
+    }
+
+    return null;
+  }
+
+  Future<bool> submit({
+    required String currentPassword,
+    required String newPassword,
+    required String confirmPassword,
+    required bool isExpired,
+    required String? username,
+  }) async {
+    // 1. Basic empty check
+    if (!isExpired && currentPassword.isEmpty) {
+      state = state.copyWith(
+        errorMessage: t.changePassword.errors.emptyFields,
+        currentHasError: true,
+      );
+      return false;
+    }
+
+    if (newPassword.isEmpty || confirmPassword.isEmpty) {
+      state = state.copyWith(
+        errorMessage: t.changePassword.errors.emptyFields,
+        newHasError: newPassword.isEmpty,
+        confirmHasError: confirmPassword.isEmpty,
+      );
+      return false;
+    }
+
+    // 2. Mismatch check
+    if (newPassword != confirmPassword) {
+      state = state.copyWith(
+        errorMessage: t.changePassword.errors.mismatch,
+        newHasError: true,
+        confirmHasError: true,
+      );
+      return false;
+    }
+
+    // Determine the student ID for similarity validation
+    String? studentId = username;
+    if (!isExpired) {
+      final user = ref.read(userProfileProvider).value;
+      studentId = user?.studentId;
+    }
+
+    // 3. Complexity & Similarity Validation
+    final validationError = _validatePasswordRules(newPassword, studentId);
+    if (validationError != null) {
+      state = state.copyWith(
+        errorMessage: validationError,
+        newHasError: true,
+        confirmHasError: true,
+      );
+      return false;
+    }
+
+    state = state.copyWith(
+      isLoading: true,
+      errorMessage: null,
+      currentHasError: false,
+      newHasError: false,
+      confirmHasError: false,
+    );
+
+    try {
+      final authRepo = ref.read(authRepositoryProvider);
+      if (isExpired) {
+        await authRepo.changeExpiredPassword(username ?? '', newPassword);
+      } else {
+        await authRepo.changePassword(currentPassword, newPassword);
+      }
+      return true;
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: t.changePassword.errors.failed(error: _errorMessageOf(e)),
+        currentHasError: !isExpired,
+        newHasError: true,
+        confirmHasError: true,
+      );
+      return false;
+    }
+  }
+
+  String _errorMessageOf(Object e) {
+    final str = e.toString();
+    final cleanMsg = str.startsWith('Exception: ')
+        ? str.substring('Exception: '.length)
+        : str;
+
+    if (cleanMsg.contains('身分驗證 失敗') ||
+        cleanMsg.contains('Identity verification Fail')) {
+      return t.changePassword.errors.server.authFailed;
+    }
+    if (cleanMsg.contains('密碼修改有誤。密碼於「1」天內不得再修改。請重新輸入。')) {
+      return t.changePassword.errors.server.minAge;
+    }
+    if (cleanMsg.contains('密碼修改有誤。密碼不得與前「3」次相同。請重新輸入。')) {
+      return t.changePassword.errors.server.historyRepeat;
+    }
+    if (cleanMsg.contains('帳號') && cleanMsg.contains('相同')) {
+      return t.changePassword.errors.server.sameAsUsername;
+    }
+    if (cleanMsg.contains('密碼長度') ||
+        (cleanMsg.contains('字元') && cleanMsg.contains('8'))) {
+      return t.changePassword.errors.server.length;
+    }
+    if (cleanMsg.contains('複雜性') ||
+        cleanMsg.contains('大小寫') ||
+        cleanMsg.contains('符號')) {
+      return t.changePassword.errors.server.complexity;
+    }
+
+    return cleanMsg;
+  }
+}

--- a/lib/screens/welcome/change_password_providers.dart
+++ b/lib/screens/welcome/change_password_providers.dart
@@ -165,6 +165,7 @@ class ChangePasswordNotifier extends Notifier<ChangePasswordState> {
       } else {
         await authRepo.changePassword(currentPassword, newPassword);
       }
+      state = state.copyWith(isLoading: false);
       return true;
     } catch (e) {
       state = state.copyWith(

--- a/lib/screens/welcome/change_password_screen.dart
+++ b/lib/screens/welcome/change_password_screen.dart
@@ -199,8 +199,8 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
                                       suffixIcon: IconButton(
                                         icon: Icon(
                                           _obscureCurrent
-                                              ? Icons.visibility
-                                              : Icons.visibility_off,
+                                              ? Icons.visibility_off
+                                              : Icons.visibility,
                                         ),
                                         onPressed: () {
                                           setState(() {
@@ -225,8 +225,8 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
                                     suffixIcon: IconButton(
                                       icon: Icon(
                                         _obscureNew
-                                            ? Icons.visibility
-                                            : Icons.visibility_off,
+                                            ? Icons.visibility_off
+                                            : Icons.visibility,
                                       ),
                                       onPressed: () {
                                         setState(() {
@@ -250,8 +250,8 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
                                     suffixIcon: IconButton(
                                       icon: Icon(
                                         _obscureConfirm
-                                            ? Icons.visibility
-                                            : Icons.visibility_off,
+                                            ? Icons.visibility_off
+                                            : Icons.visibility,
                                       ),
                                       onPressed: () {
                                         setState(() {

--- a/lib/screens/welcome/change_password_screen.dart
+++ b/lib/screens/welcome/change_password_screen.dart
@@ -191,7 +191,7 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
     } catch (e) {
       if (mounted) {
         _setError(
-          t.changePassword.errors.failed(error: e.toString()),
+          t.changePassword.errors.failed(error: _errorMessageOf(e)),
           current: !widget.isExpired,
           newPwd: true,
           confirm: true,
@@ -204,6 +204,14 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
         });
       }
     }
+  }
+
+  String _errorMessageOf(Object e) {
+    final str = e.toString();
+    if (str.startsWith('Exception: ')) {
+      return str.substring('Exception: '.length);
+    }
+    return str;
   }
 
   InputDecoration _inputDecoration(

--- a/lib/screens/welcome/change_password_screen.dart
+++ b/lib/screens/welcome/change_password_screen.dart
@@ -1,11 +1,9 @@
-import 'dart:developer';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:tattoo/i18n/strings.g.dart';
-import 'package:tattoo/repositories/auth_repository.dart';
 import 'package:tattoo/router/app_router.dart';
+import 'package:tattoo/screens/welcome/change_password_providers.dart';
 
 class ChangePasswordScreen extends ConsumerStatefulWidget {
   final bool isExpired;
@@ -35,12 +33,6 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
   bool _obscureNew = true;
   bool _obscureConfirm = true;
 
-  String? _errorMessage;
-  bool _currentHasError = false;
-  bool _newHasError = false;
-  bool _confirmHasError = false;
-  bool _isLoading = false;
-
   @override
   void dispose() {
     _currentPasswordController.dispose();
@@ -53,156 +45,34 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
   }
 
   void _clearErrors() {
-    if (_errorMessage != null ||
-        _currentHasError ||
-        _newHasError ||
-        _confirmHasError) {
-      setState(() {
-        _errorMessage = null;
-        _currentHasError = false;
-        _newHasError = false;
-        _confirmHasError = false;
-      });
-    }
+    ref.read(changePasswordProvider.notifier).clearErrors();
   }
-
-  void _setError(
-    String message, {
-    bool current = false,
-    bool newPwd = false,
-    bool confirm = false,
-  }) {
-    setState(() {
-      _errorMessage = message;
-      _currentHasError = current;
-      _newHasError = newPwd;
-      _confirmHasError = confirm;
-      _isLoading = false;
-    });
-  }
-
-  void _setLoading(bool loading) {
-    setState(() {
-      _isLoading = loading;
-      if (loading) {
-        _errorMessage = null;
-        _currentHasError = false;
-        _newHasError = false;
-        _confirmHasError = false;
-      }
-    });
-  }
-
-
 
   Future<void> _submit() async {
     final currentPassword = _currentPasswordController.text;
     final newPassword = _newPasswordController.text;
     final confirmPassword = _confirmPasswordController.text;
 
-    // 1. Basic empty check
-    if (!widget.isExpired && currentPassword.isEmpty) {
-      _setError(
-        t.changePassword.errors.emptyFields,
-        current: true,
-      );
-      return;
-    }
+    final success = await ref
+        .read(changePasswordProvider.notifier)
+        .submit(
+          currentPassword: currentPassword,
+          newPassword: newPassword,
+          confirmPassword: confirmPassword,
+          isExpired: widget.isExpired,
+          username: widget.username,
+        );
 
-    if (newPassword.isEmpty || confirmPassword.isEmpty) {
-      _setError(
-        t.changePassword.errors.emptyFields,
-        newPwd: newPassword.isEmpty,
-        confirm: confirmPassword.isEmpty,
-      );
-      return;
-    }
-
-    // 2. Mismatch check
-    if (newPassword != confirmPassword) {
-      _setError(
-        t.changePassword.errors.mismatch,
-        newPwd: true,
-        confirm: true,
-      );
-      return;
-    }
-
-
-
-    _setLoading(true);
-
-    try {
+    if (success && mounted) {
       if (widget.isExpired) {
-        final username = widget.username ?? '';
-        await ref
-            .read(authRepositoryProvider)
-            .changeExpiredPassword(username, newPassword);
-
-        if (mounted) {
-          context.go(AppRoutes.home);
-        }
+        context.go(AppRoutes.home);
       } else {
-        await ref
-            .read(authRepositoryProvider)
-            .changePassword(currentPassword, newPassword);
-
-        if (mounted) {
-          context.pop();
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(t.changePassword.success)),
-          );
-        }
-      }
-    } catch (e) {
-      if (mounted) {
-        _setError(
-          t.changePassword.errors.failed(error: _errorMessageOf(e)),
-          current: !widget.isExpired,
-          newPwd: true,
-          confirm: true,
+        context.pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(t.changePassword.success)),
         );
       }
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isLoading = false;
-        });
-      }
     }
-  }
-
-  String _errorMessageOf(Object e) {
-    final str = e.toString();
-    final cleanMsg = str.startsWith('Exception: ')
-        ? str.substring('Exception: '.length)
-        : str;
-    log(e.toString());
-
-    if (cleanMsg.contains('身分驗證 失敗') ||
-        cleanMsg.contains('Identity verification Fail')) {
-      return t.changePassword.errors.server.authFailed;
-    }
-    if (cleanMsg.contains('密碼修改有誤。密碼於「1」天內不得再修改。請重新輸入。')) {
-      return t.changePassword.errors.server.minAge;
-    }
-    if (cleanMsg.contains('密碼修改有誤。密碼不得與前「3」次相同。請重新輸入。')) {
-      return t.changePassword.errors.server.historyRepeat;
-    }
-    if (cleanMsg.contains('帳號') && cleanMsg.contains('相同')) {
-      return t.changePassword.errors.server.sameAsUsername;
-    }
-    if (cleanMsg.contains('密碼長度') ||
-        (cleanMsg.contains('字元') && cleanMsg.contains('8'))) {
-      return t.changePassword.errors.server.length;
-    }
-    if (cleanMsg.contains('複雜性') ||
-        cleanMsg.contains('大小寫') ||
-        cleanMsg.contains('符號')) {
-      return t.changePassword.errors.server.complexity;
-    }
-
-    return cleanMsg;
   }
 
   InputDecoration _inputDecoration(
@@ -246,6 +116,7 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
     final title = widget.isExpired
         ? t.changePassword.titleExpired
         : t.changePassword.title;
+    final state = ref.watch(changePasswordProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -316,7 +187,7 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
                                   TextField(
                                     controller: _currentPasswordController,
                                     focusNode: _currentPasswordFocusNode,
-                                    enabled: !_isLoading,
+                                    enabled: !state.isLoading,
                                     obscureText: _obscureCurrent,
                                     textInputAction: TextInputAction.next,
                                     onSubmitted: (_) =>
@@ -324,7 +195,7 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
                                     onChanged: (_) => _clearErrors(),
                                     decoration: _inputDecoration(
                                       t.changePassword.currentPassword,
-                                      hasError: _currentHasError,
+                                      hasError: state.currentHasError,
                                       suffixIcon: IconButton(
                                         icon: Icon(
                                           _obscureCurrent
@@ -342,7 +213,7 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
                                 TextField(
                                   controller: _newPasswordController,
                                   focusNode: _newPasswordFocusNode,
-                                  enabled: !_isLoading,
+                                  enabled: !state.isLoading,
                                   obscureText: _obscureNew,
                                   textInputAction: TextInputAction.next,
                                   onSubmitted: (_) =>
@@ -350,7 +221,7 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
                                   onChanged: (_) => _clearErrors(),
                                   decoration: _inputDecoration(
                                     t.changePassword.newPassword,
-                                    hasError: _newHasError,
+                                    hasError: state.newHasError,
                                     suffixIcon: IconButton(
                                       icon: Icon(
                                         _obscureNew
@@ -368,14 +239,14 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
                                 TextField(
                                   controller: _confirmPasswordController,
                                   focusNode: _confirmPasswordFocusNode,
-                                  enabled: !_isLoading,
+                                  enabled: !state.isLoading,
                                   obscureText: _obscureConfirm,
                                   textInputAction: TextInputAction.done,
                                   onSubmitted: (_) => _submit(),
                                   onChanged: (_) => _clearErrors(),
                                   decoration: _inputDecoration(
                                     t.changePassword.confirmPassword,
-                                    hasError: _confirmHasError,
+                                    hasError: state.confirmHasError,
                                     suffixIcon: IconButton(
                                       icon: Icon(
                                         _obscureConfirm
@@ -393,7 +264,7 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
                               ],
                             ),
 
-                            if (_errorMessage case final errorMessage?)
+                            if (state.errorMessage case final errorMessage?)
                               Padding(
                                 padding: const EdgeInsets.only(top: 24),
                                 child: Text(
@@ -418,10 +289,10 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
                                 backgroundColor: theme.colorScheme.primary,
                                 foregroundColor: Colors.white,
                               ),
-                              onPressed: _isLoading ? null : _submit,
+                              onPressed: state.isLoading ? null : _submit,
                               child: Padding(
                                 padding: const EdgeInsets.all(12.0),
-                                child: _isLoading
+                                child: state.isLoading
                                     ? const SizedBox(
                                         height: 20,
                                         width: 20,

--- a/lib/screens/welcome/change_password_screen.dart
+++ b/lib/screens/welcome/change_password_screen.dart
@@ -1,0 +1,450 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:tattoo/i18n/strings.g.dart';
+import 'package:tattoo/repositories/auth_repository.dart';
+import 'package:tattoo/router/app_router.dart';
+import 'package:tattoo/screens/main/user_providers.dart';
+
+class ChangePasswordScreen extends ConsumerStatefulWidget {
+  final bool isExpired;
+  final String? username;
+
+  const ChangePasswordScreen({
+    super.key,
+    required this.isExpired,
+    this.username,
+  });
+
+  @override
+  ConsumerState<ChangePasswordScreen> createState() =>
+      _ChangePasswordScreenState();
+}
+
+class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
+  final _currentPasswordController = TextEditingController();
+  final _newPasswordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+
+  final _currentPasswordFocusNode = FocusNode();
+  final _newPasswordFocusNode = FocusNode();
+  final _confirmPasswordFocusNode = FocusNode();
+
+  bool _obscureCurrent = true;
+  bool _obscureNew = true;
+  bool _obscureConfirm = true;
+
+  String? _errorMessage;
+  bool _currentHasError = false;
+  bool _newHasError = false;
+  bool _confirmHasError = false;
+  bool _isLoading = false;
+
+  @override
+  void dispose() {
+    _currentPasswordController.dispose();
+    _newPasswordController.dispose();
+    _confirmPasswordController.dispose();
+    _currentPasswordFocusNode.dispose();
+    _newPasswordFocusNode.dispose();
+    _confirmPasswordFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _clearErrors() {
+    if (_errorMessage != null ||
+        _currentHasError ||
+        _newHasError ||
+        _confirmHasError) {
+      setState(() {
+        _errorMessage = null;
+        _currentHasError = false;
+        _newHasError = false;
+        _confirmHasError = false;
+      });
+    }
+  }
+
+  void _setError(
+    String message, {
+    bool current = false,
+    bool newPwd = false,
+    bool confirm = false,
+  }) {
+    setState(() {
+      _errorMessage = message;
+      _currentHasError = current;
+      _newHasError = newPwd;
+      _confirmHasError = confirm;
+      _isLoading = false;
+    });
+  }
+
+  void _setLoading(bool loading) {
+    setState(() {
+      _isLoading = loading;
+      if (loading) {
+        _errorMessage = null;
+        _currentHasError = false;
+        _newHasError = false;
+        _confirmHasError = false;
+      }
+    });
+  }
+
+  String? _validatePasswordRules(String password, String? studentId) {
+    if (password.length < 8 || password.length > 14) {
+      return t.changePassword.errors.invalidLength;
+    }
+
+    final hasUpper = password.contains(RegExp(r'[A-Z]'));
+    final hasLower = password.contains(RegExp(r'[a-z]'));
+    final hasDigit = password.contains(RegExp(r'[0-9]'));
+    final hasSymbol = password.contains(RegExp(r'[^a-zA-Z0-9]'));
+
+    if (!hasUpper || !hasLower || !hasDigit || !hasSymbol) {
+      return t.changePassword.errors.invalidComplexity;
+    }
+
+    if (studentId != null && password == studentId) {
+      return t.changePassword.errors.sameAsUsername;
+    }
+
+    return null;
+  }
+
+  Future<void> _submit() async {
+    final currentPassword = _currentPasswordController.text;
+    final newPassword = _newPasswordController.text;
+    final confirmPassword = _confirmPasswordController.text;
+
+    // 1. Basic empty check
+    if (!widget.isExpired && currentPassword.isEmpty) {
+      _setError(
+        t.changePassword.errors.emptyFields,
+        current: true,
+      );
+      return;
+    }
+
+    if (newPassword.isEmpty || confirmPassword.isEmpty) {
+      _setError(
+        t.changePassword.errors.emptyFields,
+        newPwd: newPassword.isEmpty,
+        confirm: confirmPassword.isEmpty,
+      );
+      return;
+    }
+
+    // 2. Mismatch check
+    if (newPassword != confirmPassword) {
+      _setError(
+        t.changePassword.errors.mismatch,
+        newPwd: true,
+        confirm: true,
+      );
+      return;
+    }
+
+    // Determine the student ID for similarity validation
+    String? studentId = widget.username;
+    if (!widget.isExpired) {
+      final user = ref.read(userProfileProvider).value;
+      studentId = user?.studentId;
+    }
+
+    // 3. Complexity & Similarity Validation
+    final validationError = _validatePasswordRules(newPassword, studentId);
+    if (validationError != null) {
+      _setError(
+        validationError,
+        newPwd: true,
+        confirm: true,
+      );
+      return;
+    }
+
+    _setLoading(true);
+
+    try {
+      if (widget.isExpired) {
+        final username = widget.username ?? '';
+        await ref
+            .read(authRepositoryProvider)
+            .changeExpiredPassword(username, newPassword);
+
+        if (mounted) {
+          context.go(AppRoutes.home);
+        }
+      } else {
+        await ref
+            .read(authRepositoryProvider)
+            .changePassword(currentPassword, newPassword);
+
+        if (mounted) {
+          context.pop();
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(t.changePassword.success)),
+          );
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        _setError(
+          t.changePassword.errors.failed(error: e.toString()),
+          current: !widget.isExpired,
+          newPwd: true,
+          confirm: true,
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  InputDecoration _inputDecoration(
+    String hintText, {
+    bool hasError = false,
+    Widget? suffixIcon,
+  }) {
+    final theme = Theme.of(context);
+    final surfaceColor = theme.colorScheme.surfaceContainerHighest;
+    final errorColor = theme.colorScheme.error;
+    final primaryColor = theme.colorScheme.primary;
+
+    return InputDecoration(
+      hintText: hintText,
+      hintStyle: TextStyle(
+        color: theme.textTheme.bodyMedium?.color?.withAlpha(150),
+        fontWeight: FontWeight.w500,
+      ),
+      border: OutlineInputBorder(borderRadius: BorderRadius.circular(50)),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(50),
+        borderSide: BorderSide(color: hasError ? errorColor : surfaceColor),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(50),
+        borderSide: BorderSide(
+          color: hasError ? errorColor : primaryColor,
+          width: 2,
+        ),
+      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+      filled: true,
+      fillColor: surfaceColor,
+      suffixIcon: suffixIcon,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final title = widget.isExpired
+        ? t.changePassword.titleExpired
+        : t.changePassword.title;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title),
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        foregroundColor: theme.textTheme.bodyLarge?.color,
+      ),
+      body: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: () => FocusScope.of(context).unfocus(),
+              child: SingleChildScrollView(
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            if (widget.isExpired)
+                              Container(
+                                margin: const EdgeInsets.only(bottom: 24),
+                                padding: const EdgeInsets.all(16),
+                                decoration: BoxDecoration(
+                                  color: theme.colorScheme.errorContainer
+                                      .withAlpha(50),
+                                  borderRadius: BorderRadius.circular(16),
+                                  border: Border.all(
+                                    color: theme.colorScheme.error.withAlpha(
+                                      100,
+                                    ),
+                                  ),
+                                ),
+                                child: Row(
+                                  children: [
+                                    Icon(
+                                      Icons.warning_amber_rounded,
+                                      color: theme.colorScheme.error,
+                                    ),
+                                    const SizedBox(width: 12),
+                                    Expanded(
+                                      child: Text(
+                                        t.changePassword.expiredNotice,
+                                        style: TextStyle(
+                                          color: theme
+                                              .colorScheme
+                                              .onErrorContainer,
+                                          fontWeight: FontWeight.w500,
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+
+                            // Form fields
+                            Column(
+                              spacing: 16,
+                              children: [
+                                if (!widget.isExpired)
+                                  TextField(
+                                    controller: _currentPasswordController,
+                                    focusNode: _currentPasswordFocusNode,
+                                    enabled: !_isLoading,
+                                    obscureText: _obscureCurrent,
+                                    textInputAction: TextInputAction.next,
+                                    onSubmitted: (_) =>
+                                        _newPasswordFocusNode.requestFocus(),
+                                    onChanged: (_) => _clearErrors(),
+                                    decoration: _inputDecoration(
+                                      t.changePassword.currentPassword,
+                                      hasError: _currentHasError,
+                                      suffixIcon: IconButton(
+                                        icon: Icon(
+                                          _obscureCurrent
+                                              ? Icons.visibility
+                                              : Icons.visibility_off,
+                                        ),
+                                        onPressed: () {
+                                          setState(() {
+                                            _obscureCurrent = !_obscureCurrent;
+                                          });
+                                        },
+                                      ),
+                                    ),
+                                  ),
+                                TextField(
+                                  controller: _newPasswordController,
+                                  focusNode: _newPasswordFocusNode,
+                                  enabled: !_isLoading,
+                                  obscureText: _obscureNew,
+                                  textInputAction: TextInputAction.next,
+                                  onSubmitted: (_) =>
+                                      _confirmPasswordFocusNode.requestFocus(),
+                                  onChanged: (_) => _clearErrors(),
+                                  decoration: _inputDecoration(
+                                    t.changePassword.newPassword,
+                                    hasError: _newHasError,
+                                    suffixIcon: IconButton(
+                                      icon: Icon(
+                                        _obscureNew
+                                            ? Icons.visibility
+                                            : Icons.visibility_off,
+                                      ),
+                                      onPressed: () {
+                                        setState(() {
+                                          _obscureNew = !_obscureNew;
+                                        });
+                                      },
+                                    ),
+                                  ),
+                                ),
+                                TextField(
+                                  controller: _confirmPasswordController,
+                                  focusNode: _confirmPasswordFocusNode,
+                                  enabled: !_isLoading,
+                                  obscureText: _obscureConfirm,
+                                  textInputAction: TextInputAction.done,
+                                  onSubmitted: (_) => _submit(),
+                                  onChanged: (_) => _clearErrors(),
+                                  decoration: _inputDecoration(
+                                    t.changePassword.confirmPassword,
+                                    hasError: _confirmHasError,
+                                    suffixIcon: IconButton(
+                                      icon: Icon(
+                                        _obscureConfirm
+                                            ? Icons.visibility
+                                            : Icons.visibility_off,
+                                      ),
+                                      onPressed: () {
+                                        setState(() {
+                                          _obscureConfirm = !_obscureConfirm;
+                                        });
+                                      },
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+
+                            if (_errorMessage case final errorMessage?)
+                              Padding(
+                                padding: const EdgeInsets.only(top: 24),
+                                child: Text(
+                                  errorMessage,
+                                  textAlign: TextAlign.center,
+                                  style: TextStyle(
+                                    color: theme.colorScheme.error,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ),
+                          ],
+                        ),
+
+                        // Submit Button
+                        Padding(
+                          padding: const EdgeInsets.only(top: 24),
+                          child: SizedBox(
+                            width: double.infinity,
+                            child: ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: theme.colorScheme.primary,
+                                foregroundColor: Colors.white,
+                              ),
+                              onPressed: _isLoading ? null : _submit,
+                              child: Padding(
+                                padding: const EdgeInsets.all(12.0),
+                                child: _isLoading
+                                    ? const SizedBox(
+                                        height: 20,
+                                        width: 20,
+                                        child: CircularProgressIndicator(
+                                          strokeWidth: 2,
+                                          color: Colors.white,
+                                        ),
+                                      )
+                                    : Text(t.changePassword.submit),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/welcome/change_password_screen.dart
+++ b/lib/screens/welcome/change_password_screen.dart
@@ -13,7 +13,7 @@ class ChangePasswordScreen extends ConsumerStatefulWidget {
     super.key,
     required this.isExpired,
     this.username,
-  });
+  }) : assert(!isExpired || (username != null && username != ''));
 
   @override
   ConsumerState<ChangePasswordScreen> createState() =>

--- a/lib/screens/welcome/change_password_screen.dart
+++ b/lib/screens/welcome/change_password_screen.dart
@@ -1,10 +1,11 @@
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/auth_repository.dart';
 import 'package:tattoo/router/app_router.dart';
-import 'package:tattoo/screens/main/user_providers.dart';
 
 class ChangePasswordScreen extends ConsumerStatefulWidget {
   final bool isExpired;
@@ -92,26 +93,7 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
     });
   }
 
-  String? _validatePasswordRules(String password, String? studentId) {
-    if (password.length < 8 || password.length > 14) {
-      return t.changePassword.errors.invalidLength;
-    }
 
-    final hasUpper = password.contains(RegExp(r'[A-Z]'));
-    final hasLower = password.contains(RegExp(r'[a-z]'));
-    final hasDigit = password.contains(RegExp(r'[0-9]'));
-    final hasSymbol = password.contains(RegExp(r'[^a-zA-Z0-9]'));
-
-    if (!hasUpper || !hasLower || !hasDigit || !hasSymbol) {
-      return t.changePassword.errors.invalidComplexity;
-    }
-
-    if (studentId != null && password == studentId) {
-      return t.changePassword.errors.sameAsUsername;
-    }
-
-    return null;
-  }
 
   Future<void> _submit() async {
     final currentPassword = _currentPasswordController.text;
@@ -146,23 +128,7 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
       return;
     }
 
-    // Determine the student ID for similarity validation
-    String? studentId = widget.username;
-    if (!widget.isExpired) {
-      final user = ref.read(userProfileProvider).value;
-      studentId = user?.studentId;
-    }
 
-    // 3. Complexity & Similarity Validation
-    final validationError = _validatePasswordRules(newPassword, studentId);
-    if (validationError != null) {
-      _setError(
-        validationError,
-        newPwd: true,
-        confirm: true,
-      );
-      return;
-    }
 
     _setLoading(true);
 
@@ -211,15 +177,16 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
     final cleanMsg = str.startsWith('Exception: ')
         ? str.substring('Exception: '.length)
         : str;
+    log(e.toString());
 
-    if (cleanMsg.contains('身分驗證') &&
-        (cleanMsg.contains('失敗') || cleanMsg.contains('錯誤'))) {
+    if (cleanMsg.contains('身分驗證 失敗') ||
+        cleanMsg.contains('Identity verification Fail')) {
       return t.changePassword.errors.server.authFailed;
     }
-    if (cleanMsg.contains('不得再修改') || cleanMsg.contains('最短使用期限')) {
+    if (cleanMsg.contains('密碼修改有誤。密碼於「1」天內不得再修改。請重新輸入。')) {
       return t.changePassword.errors.server.minAge;
     }
-    if (cleanMsg.contains('前3組') || cleanMsg.contains('前三組')) {
+    if (cleanMsg.contains('密碼修改有誤。密碼不得與前「3」次相同。請重新輸入。')) {
       return t.changePassword.errors.server.historyRepeat;
     }
     if (cleanMsg.contains('帳號') && cleanMsg.contains('相同')) {

--- a/lib/screens/welcome/change_password_screen.dart
+++ b/lib/screens/welcome/change_password_screen.dart
@@ -208,10 +208,34 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
 
   String _errorMessageOf(Object e) {
     final str = e.toString();
-    if (str.startsWith('Exception: ')) {
-      return str.substring('Exception: '.length);
+    final cleanMsg = str.startsWith('Exception: ')
+        ? str.substring('Exception: '.length)
+        : str;
+
+    if (cleanMsg.contains('身分驗證') &&
+        (cleanMsg.contains('失敗') || cleanMsg.contains('錯誤'))) {
+      return t.changePassword.errors.server.authFailed;
     }
-    return str;
+    if (cleanMsg.contains('不得再修改') || cleanMsg.contains('最短使用期限')) {
+      return t.changePassword.errors.server.minAge;
+    }
+    if (cleanMsg.contains('前3組') || cleanMsg.contains('前三組')) {
+      return t.changePassword.errors.server.historyRepeat;
+    }
+    if (cleanMsg.contains('帳號') && cleanMsg.contains('相同')) {
+      return t.changePassword.errors.server.sameAsUsername;
+    }
+    if (cleanMsg.contains('密碼長度') ||
+        (cleanMsg.contains('字元') && cleanMsg.contains('8'))) {
+      return t.changePassword.errors.server.length;
+    }
+    if (cleanMsg.contains('複雜性') ||
+        cleanMsg.contains('大小寫') ||
+        cleanMsg.contains('符號')) {
+      return t.changePassword.errors.server.complexity;
+    }
+
+    return cleanMsg;
   }
 
   InputDecoration _inputDecoration(

--- a/lib/screens/welcome/login_screen.dart
+++ b/lib/screens/welcome/login_screen.dart
@@ -144,7 +144,15 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           case .accountLocked:
             _setError(t.login.errors.accountLocked);
           case .passwordExpired:
-            _setError(t.login.errors.passwordExpired);
+            if (mounted) {
+              context.push(
+                AppRoutes.changePassword,
+                extra: {
+                  'isExpired': true,
+                  'username': username,
+                },
+              );
+            }
           case .mobileVerificationRequired:
             _setError(t.login.errors.mobileVerificationRequired);
           case _:

--- a/lib/screens/welcome/login_screen.dart
+++ b/lib/screens/welcome/login_screen.dart
@@ -145,6 +145,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
             _setError(t.login.errors.accountLocked);
           case .passwordExpired:
             if (mounted) {
+              _setLoading(false);
               context.push(
                 AppRoutes.changePassword,
                 extra: {

--- a/lib/services/demo_mode.dart
+++ b/lib/services/demo_mode.dart
@@ -30,3 +30,7 @@ const String demoUsername = '111592347';
 /// account (see [demoUsername]).
 bool isDemoCredentials(String username, String password) =>
     username == demoUsername;
+
+/// Whether the demo credentials represent an expired password flow.
+bool isDemoPasswordExpired(String username, String password) =>
+    username == demoUsername && password == 'expired';

--- a/lib/services/portal/mock_portal_service.dart
+++ b/lib/services/portal/mock_portal_service.dart
@@ -24,13 +24,11 @@ class MockPortalService implements PortalService {
   }
 
   @override
-  Future<void> changePassword(
-    String currentPassword,
-    String newPassword,
-  ) async {}
-
-  @override
-  Future<void> changeExpiredPassword(String newPassword) async {}
+  Future<void> changePassword({
+    required String newPassword,
+    String? currentPassword,
+    bool isExpired = false,
+  }) async {}
 
   @override
   Future<Uint8List> getAvatar([String? filename]) async {

--- a/lib/services/portal/mock_portal_service.dart
+++ b/lib/services/portal/mock_portal_service.dart
@@ -30,6 +30,9 @@ class MockPortalService implements PortalService {
   ) async {}
 
   @override
+  Future<void> changeExpiredPassword(String newPassword) async {}
+
+  @override
   Future<Uint8List> getAvatar([String? filename]) async {
     return avatarResult ?? Uint8List(0);
   }

--- a/lib/services/portal/ntut_portal_service.dart
+++ b/lib/services/portal/ntut_portal_service.dart
@@ -127,22 +127,13 @@ class NtutPortalService implements PortalService {
         'pwdForceMdy': 'expired',
         'userPassword': newPassword,
         'confirmPassword': newPassword,
-        'localeId': _chineseLocale,
       },
-      options: Options(
-        contentType: Headers.formUrlEncodedContentType,
-        headers: const {'X-Requested-With': 'XMLHttpRequest'},
-      ),
     );
 
-    final dynamic body;
-    if (response.data is String) {
-      body = jsonDecode(response.data as String);
-    } else {
-      body = response.data;
-    }
+    final body = jsonDecode(response.data);
 
-    if (body['success'] != true && body['success'] != 'true') {
+    // API returns "success": "false" on failure (note the string "false")
+    if (body['success'] != true) {
       throw Exception(
         body['returnMsg'] ?? 'Password change failed. Please try again.',
       );

--- a/lib/services/portal/ntut_portal_service.dart
+++ b/lib/services/portal/ntut_portal_service.dart
@@ -96,38 +96,27 @@ class NtutPortalService implements PortalService {
   }
 
   @override
-  Future<void> changePassword(
-    String currentPassword,
-    String newPassword,
-  ) async {
+  Future<void> changePassword({
+    required String newPassword,
+    String? currentPassword,
+    bool isExpired = false,
+  }) async {
     final response = await _portalDio.post(
-      'passwordMdy.do',
-      queryParameters: {
-        "oldPassword": currentPassword,
-        "userPassword": newPassword,
-        "pwdForceMdy": "profile",
-      },
-    );
-
-    final body = jsonDecode(response.data);
-
-    // API returns "success": "false" on failure (note the string "false")
-    if (body['success'] != true) {
-      throw Exception(
-        body['returnMsg'] ?? 'Password change failed. Please try again.',
-      );
-    }
-  }
-
-  @override
-  Future<void> changeExpiredPassword(String newPassword) async {
-    final response = await _portalDio.post(
-      'passwordFirstMdy.do',
-      data: {
-        'pwdForceMdy': 'expired',
-        'userPassword': newPassword,
-        'confirmPassword': newPassword,
-      },
+      !isExpired ? 'passwordMdy.do' : 'passwordFirstMdy.do',
+      queryParameters: !isExpired
+          ? {
+              "oldPassword": currentPassword,
+              "userPassword": newPassword,
+              "pwdForceMdy": "profile",
+            }
+          : null,
+      data: isExpired
+          ? {
+              'pwdForceMdy': 'expired',
+              'userPassword': newPassword,
+              'confirmPassword': newPassword,
+            }
+          : null,
     );
 
     final body = jsonDecode(response.data);

--- a/lib/services/portal/ntut_portal_service.dart
+++ b/lib/services/portal/ntut_portal_service.dart
@@ -120,6 +120,36 @@ class NtutPortalService implements PortalService {
   }
 
   @override
+  Future<void> changeExpiredPassword(String newPassword) async {
+    final response = await _portalDio.post(
+      'passwordFirstMdy.do',
+      data: {
+        'pwdForceMdy': 'expired',
+        'userPassword': newPassword,
+        'confirmPassword': newPassword,
+        'localeId': _chineseLocale,
+      },
+      options: Options(
+        contentType: Headers.formUrlEncodedContentType,
+        headers: const {'X-Requested-With': 'XMLHttpRequest'},
+      ),
+    );
+
+    final dynamic body;
+    if (response.data is String) {
+      body = jsonDecode(response.data as String);
+    } else {
+      body = response.data;
+    }
+
+    if (body['success'] != true && body['success'] != 'true') {
+      throw Exception(
+        body['returnMsg'] ?? 'Password change failed. Please try again.',
+      );
+    }
+  }
+
+  @override
   Future<Uint8List> getAvatar([String? filename]) async {
     final response = await _portalDio.get(
       'photoView.do',

--- a/lib/services/portal/portal_service.dart
+++ b/lib/services/portal/portal_service.dart
@@ -154,6 +154,14 @@ abstract interface class PortalService {
   /// current password or the new password doesn't meet requirements).
   Future<void> changePassword(String currentPassword, String newPassword);
 
+  /// Changes the user's expired NTUT Portal password.
+  ///
+  /// This must be called immediately after a login attempt fails with
+  /// [LoginFailure.passwordExpired], which establishes the expired session.
+  ///
+  /// Throws an [Exception] if the password change fails.
+  Future<void> changeExpiredPassword(String newPassword);
+
   /// Downloads a user's avatar from NTUT Portal.
   ///
   /// If [filename] is omitted or empty, the server returns a dynamically

--- a/lib/services/portal/portal_service.dart
+++ b/lib/services/portal/portal_service.dart
@@ -146,21 +146,14 @@ abstract interface class PortalService {
   /// reason (wrong credentials, account locked, password expired, etc.).
   Future<UserDto> login(String username, String password);
 
-  /// Changes the user's NTUT Portal password.
-  ///
-  /// Requires an active session (call [login] first).
-  ///
-  /// Throws an [Exception] if the password change fails (e.g., incorrect
-  /// current password or the new password doesn't meet requirements).
-  Future<void> changePassword(String currentPassword, String newPassword);
-
-  /// Changes the user's expired NTUT Portal password.
-  ///
-  /// This must be called immediately after a login attempt fails with
-  /// [LoginFailure.passwordExpired], which establishes the expired session.
-  ///
-  /// Throws an [Exception] if the password change fails.
-  Future<void> changeExpiredPassword(String newPassword);
+  /// If [isExpired] is true, it changes an expired password (using the
+  /// expired/first-time login session). Otherwise, it performs a normal
+  /// password change (from settings) and requires [currentPassword].
+  Future<void> changePassword({
+    required String newPassword,
+    String? currentPassword,
+    bool isExpired = false,
+  });
 
   /// Downloads a user's avatar from NTUT Portal.
   ///

--- a/test/services/portal_service_test.dart
+++ b/test/services/portal_service_test.dart
@@ -130,7 +130,10 @@ void main() {
         );
 
         expect(
-          () => portalService.changePassword('wrong_password', 'new_password'),
+          () => portalService.changePassword(
+            currentPassword: 'wrong_password',
+            newPassword: 'new_password',
+          ),
           throwsException,
         );
       });
@@ -139,7 +142,10 @@ void main() {
         await cookieJar.deleteAll();
 
         expect(
-          () => portalService.changePassword('any', 'any'),
+          () => portalService.changePassword(
+            currentPassword: 'any',
+            newPassword: 'any',
+          ),
           throwsException,
         );
       });


### PR DESCRIPTION
This PR implements the change password feature in Tattoo, supporting:
1. Normal password change from settings (which submits to 'passwordMdy.do').
2. Forced password change when the login request returns 'passwordExpired' (which submits to 'passwordFirstMdy.do').

It also includes client-side password validations matching NTUT's guidelines (length of 8-14 chars, complexity of upper+lower+digits+symbols, and non-similarity to student ID).

討論:

1. 測試是否可以用同個請求（改密碼後登入）
2. 分離 ntut_portal_service 為兩個端點，但前端呼叫同個端點