### PR TITLE
feat: add course offering lookup by number

### DIFF
--- a/lib/services/course/course_service.dart
+++ b/lib/services/course/course_service.dart
@@ -53,6 +53,18 @@ typedef ScheduleDto = ({
   String? remarks,
 });
 
+/// Data returned when looking up a course offering by number.
+///
+/// [schedule] contains the offering metadata and its teacher, class, classroom,
+/// and timeslot relations. Header-only values come from the syllabus endpoint.
+typedef CourseOfferingDto = ({
+  SemesterDto semester,
+  ScheduleDto schedule,
+  CourseType? courseType,
+  int? enrolled,
+  int? withdrawn,
+});
+
 /// Course information from the course catalog.
 typedef CourseDto = ({
   /// Course's unique identifier code.
@@ -198,6 +210,15 @@ abstract interface class CourseService {
     required String username,
     required SemesterDto semester,
   });
+
+  /// Fetches a course offering by its course number.
+  ///
+  /// Returns `null` only when the course system explicitly reports that the
+  /// number does not exist. Malformed or inconsistent responses throw so that
+  /// callers do not cache a server or parser failure as a missing offering.
+  ///
+  /// Throws an [ArgumentError] when [courseNumber] is blank.
+  Future<CourseOfferingDto?> getCourseOffering(String courseNumber);
 
   /// Fetches detailed information about a specific course from the catalog.
   ///

--- a/lib/services/course/mock_course_service.dart
+++ b/lib/services/course/mock_course_service.dart
@@ -1789,17 +1789,10 @@ class MockCourseService implements CourseService {
         semester: semester,
       )) {
         if (schedule.number != number) continue;
-        CourseType? courseType;
-        for (final candidate in CourseType.values) {
-          if (candidate.symbol == schedule.type) {
-            courseType = candidate;
-            break;
-          }
-        }
         return (
           semester: semester,
           schedule: schedule,
-          courseType: courseType,
+          courseType: null,
           enrolled: null,
           withdrawn: null,
         );

--- a/lib/services/course/mock_course_service.dart
+++ b/lib/services/course/mock_course_service.dart
@@ -6,6 +6,8 @@ import 'package:tattoo/services/course/course_service.dart';
 class MockCourseService implements CourseService {
   List<SemesterDto>? semesterListResult;
   List<ScheduleDto>? courseTableResult;
+  CourseOfferingDto? courseOfferingResult;
+
   CourseDto? courseResult;
   TeacherDto? teacherResult;
   SyllabusDto? syllabusResult;
@@ -1767,6 +1769,43 @@ class MockCourseService implements CourseService {
       ],
       _ => const [],
     };
+  }
+
+  @override
+  Future<CourseOfferingDto?> getCourseOffering(String courseNumber) async {
+    final number = courseNumber.trim();
+    if (number.isEmpty) {
+      throw ArgumentError.value(
+        courseNumber,
+        'courseNumber',
+        'must not be blank',
+      );
+    }
+    if (courseOfferingResult case final result?) return result;
+
+    for (final semester in await getCourseSemesterList()) {
+      for (final schedule in await getCourseTable(
+        username: '',
+        semester: semester,
+      )) {
+        if (schedule.number != number) continue;
+        CourseType? courseType;
+        for (final candidate in CourseType.values) {
+          if (candidate.symbol == schedule.type) {
+            courseType = candidate;
+            break;
+          }
+        }
+        return (
+          semester: semester,
+          schedule: schedule,
+          courseType: courseType,
+          enrolled: null,
+          withdrawn: null,
+        );
+      }
+    }
+    return null;
   }
 
   @override

--- a/lib/services/course/ntut_course_service.dart
+++ b/lib/services/course/ntut_course_service.dart
@@ -13,14 +13,19 @@ typedef _EnglishCourseNames = ({
   List<ReferenceDto> classes,
 });
 
-class NtutCourseService implements CourseService {
-  late final Dio _courseDio;
+typedef _OfferingHeader = ({
+  SemesterDto? semester,
+  String number,
+  String courseName,
+  CourseType? courseType,
+  int? enrolled,
+  int? withdrawn,
+});
 
-  NtutCourseService() {
-    _courseDio = createDio()
-      ..options.baseUrl = 'https://aps.ntut.edu.tw/course/'
-      ..interceptors.add(_SessionCheckInterceptor());
-  }
+class NtutCourseService implements CourseService {
+  late final Dio _courseDio = createDio()
+    ..options.baseUrl = 'https://aps.ntut.edu.tw/course/'
+    ..interceptors.add(_SessionCheckInterceptor());
 
   @override
   Future<List<SemesterDto>> getCourseSemesterList() async {
@@ -138,6 +143,301 @@ class NtutCourseService implements CourseService {
         remarks: dto.remarks,
       );
     }).toList();
+  }
+
+  @override
+  Future<CourseOfferingDto?> getCourseOffering(String courseNumber) async {
+    final number = courseNumber.trim();
+    if (number.isEmpty) {
+      throw ArgumentError.value(
+        courseNumber,
+        'courseNumber',
+        'must not be blank',
+      );
+    }
+
+    final headerResponse = await _courseDio.get(
+      'tw/ShowSyllabus.jsp',
+      queryParameters: {'snum': number},
+    );
+
+    final header = _parseOfferingHeader(
+      headerResponse.data,
+      requestedNumber: number,
+    );
+    if (header == null) return null;
+    final semester = header.semester;
+    if (semester == null || semester.year == null || semester.term == null) {
+      throw const FormatException(
+        'Course offering response has no valid semester.',
+      );
+    }
+
+    final queryResponse = await _courseDio.post(
+      'tw/QueryCourse.jsp',
+      data: {
+        'year': semester.year,
+        'sem': semester.term,
+        // The legacy form encodes "all divisions" as one SQL-style value.
+        'matric': "'0','1','4','5','6','7','8','9','A','C','D','E','F'",
+        'unit': '＊',
+        'cname': header.courseName,
+        'ccode': '',
+        'tname': '',
+        'stime': '0',
+      },
+      options: Options(contentType: Headers.formUrlEncodedContentType),
+    );
+
+    final schedule = _parseQueryCourseOffering(
+      queryResponse.data,
+      requestedNumber: number,
+    );
+    if (schedule == null) {
+      throw StateError(
+        'Course offering $number exists but was absent from query results.',
+      );
+    }
+
+    return (
+      semester: semester,
+      schedule: schedule,
+      courseType: header.courseType,
+      enrolled: header.enrolled,
+      withdrawn: header.withdrawn,
+    );
+  }
+
+  _OfferingHeader? _parseOfferingHeader(
+    String html, {
+    required String requestedNumber,
+  }) {
+    final document = parse(html);
+    List<Element>? rows;
+    for (final table in document.querySelectorAll('table')) {
+      final candidateRows = _directTableRows(table);
+      if (candidateRows.isEmpty) continue;
+      final labels = _directTableCells(
+        candidateRows.first,
+      ).map((cell) => cell.text.trim()).toList();
+      if (labels.contains('課號')) {
+        rows = candidateRows;
+        break;
+      }
+    }
+    if (rows == null) {
+      throw const FormatException('Course offering header table not found.');
+    }
+    if (rows.length < 2) {
+      if (document.body?.text.contains('查無課號') ?? false) return null;
+      throw const FormatException('Course offering header row not found.');
+    }
+
+    final labels = _directTableCells(
+      rows.first,
+    ).map((cell) => cell.text.trim()).toList();
+    final values = _directTableCells(rows[1]);
+    String? value(String label) {
+      final index = labels.indexOf(label);
+      return index >= 0 && index < values.length
+          ? _parseCellText(values[index])
+          : null;
+    }
+
+    final number = value('課號');
+    final name = value('課程名稱');
+    if (number == null || name == null) {
+      throw const FormatException(
+        'Course offering header has no number or course name.',
+      );
+    }
+    if (number != requestedNumber) {
+      throw FormatException(
+        'Course offering response number $number does not match '
+        '$requestedNumber.',
+      );
+    }
+
+    final semesterText = value('學年期');
+    final semesterMatch = semesterText == null
+        ? null
+        : RegExp(r'^(\d+)\s*-\s*([0-3])$').firstMatch(semesterText);
+    final typeSymbol = value('修');
+
+    return (
+      semester: semesterMatch == null
+          ? null
+          : (
+              year: int.parse(semesterMatch.group(1)!),
+              term: int.parse(semesterMatch.group(2)!),
+            ),
+      number: number,
+      courseName: name,
+      courseType: CourseType.values.firstWhereOrNull(
+        (type) => type.symbol == typeSymbol,
+      ),
+      enrolled: int.tryParse(value('人') ?? ''),
+      withdrawn: int.tryParse(value('撤') ?? ''),
+    );
+  }
+
+  ScheduleDto? _parseQueryCourseOffering(
+    String html, {
+    required String requestedNumber,
+  }) {
+    final document = parse(html);
+    const numberLabels = {'課號'};
+    Element? resultTable;
+    List<Element>? rows;
+    var headerIndex = -1;
+    for (final table in document.querySelectorAll('table')) {
+      final candidateRows = _directTableRows(table);
+      for (final (index, row) in candidateRows.indexed) {
+        final labels = _directTableCells(
+          row,
+        ).map((cell) => cell.text.trim()).toList();
+        if (labels.any(numberLabels.contains)) {
+          resultTable = table;
+          rows = candidateRows;
+          headerIndex = index;
+          break;
+        }
+      }
+      if (resultTable != null) break;
+    }
+    if (resultTable == null || rows == null || headerIndex < 0) {
+      throw const FormatException('Course query result table not found.');
+    }
+
+    final labels = _directTableCells(
+      rows[headerIndex],
+    ).map((cell) => cell.text.trim()).toList();
+    int column(Set<String> aliases) => labels.indexWhere(aliases.contains);
+    final numberColumn = column(numberLabels);
+    final matches = <Element>[];
+    for (final row in rows.skip(headerIndex + 1)) {
+      final cells = _directTableCells(row);
+      if (numberColumn >= 0 &&
+          numberColumn < cells.length &&
+          _parseCellText(cells[numberColumn]) == requestedNumber) {
+        matches.add(row);
+      }
+    }
+    if (matches.isEmpty) return null;
+    if (matches.length > 1) {
+      throw FormatException(
+        'Course query returned duplicate rows for $requestedNumber.',
+      );
+    }
+
+    final cells = _directTableCells(matches.single);
+
+    Element? cell(Set<String> aliases) {
+      final index = column(aliases);
+      return index >= 0 && index < cells.length ? cells[index] : null;
+    }
+
+    final courseCell = cell({'課程名稱'});
+    if (courseCell == null || _parseCellText(courseCell) == null) {
+      throw const FormatException('Course query row has no course name.');
+    }
+    final course = _parseCellRef(courseCell);
+    final teacherCell = cell({'教師'});
+    final classCell = cell({'班級'});
+    final teachers = teacherCell == null ? null : _parseQueryRefs(teacherCell);
+    final classes = classCell == null ? null : _parseQueryRefs(classCell);
+
+    final classroomCell = cell({'教室'});
+    final classroomRefs = classroomCell == null
+        ? const <ReferenceDto>[]
+        : (_parseQueryRefs(classroomCell) ?? const <ReferenceDto>[])
+              .map(_stripEClassroomMarker)
+              .toList();
+    final slots = <({DayOfWeek day, Period period})>[];
+    const dayLabels = {
+      DayOfWeek.sunday: {'日'},
+      DayOfWeek.monday: {'一'},
+      DayOfWeek.tuesday: {'二'},
+      DayOfWeek.wednesday: {'三'},
+      DayOfWeek.thursday: {'四'},
+      DayOfWeek.friday: {'五'},
+      DayOfWeek.saturday: {'六'},
+    };
+    for (final entry in dayLabels.entries) {
+      final dayCell = cell(entry.value);
+      if (dayCell == null) continue;
+      for (final match in RegExp(r'[1-9NABCD]').allMatches(dayCell.text)) {
+        final period = Period.values.firstWhereOrNull(
+          (candidate) => candidate.code == match.group(0),
+        );
+        if (period != null) slots.add((day: entry.key, period: period));
+      }
+    }
+    final schedule = slots.indexed
+        .map(
+          (entry) => (
+            day: entry.$2.day,
+            period: entry.$2.period,
+            classroom: switch (classroomRefs) {
+              [final classroom] => classroom,
+              _ when classroomRefs.length == slots.length =>
+                classroomRefs[entry.$1],
+              _ => null,
+            },
+          ),
+        )
+        .toList();
+
+    String? text(Set<String> aliases) {
+      final target = cell(aliases);
+      return target == null ? null : _parseCellText(target);
+    }
+
+    return (
+      number: requestedNumber,
+      course: (id: course.id, nameZh: course.name, nameEn: null),
+      phase: int.tryParse(text({'階段'}) ?? ''),
+      credits: double.tryParse(text({'學分'}) ?? ''),
+      hours: int.tryParse(text({'時數'}) ?? ''),
+      type: text({'修'}),
+      teachers: teachers
+          ?.map<LocalizedRefDto>(
+            (teacher) => (
+              id: teacher.id,
+              nameZh: teacher.name,
+              nameEn: null,
+            ),
+          )
+          .toList(),
+      classes: classes
+          ?.map<LocalizedRefDto>(
+            (classEntity) => (
+              id: classEntity.id,
+              nameZh: classEntity.name,
+              nameEn: null,
+            ),
+          )
+          .toList(),
+      schedule: schedule.isEmpty ? null : schedule,
+      status: null,
+      language: text({'授課語言'}),
+      remarks: text({'備註'}),
+    );
+  }
+
+  List<ReferenceDto>? _parseQueryRefs(Element cell) {
+    final refs = _parseCellRefs(cell);
+    if (refs != null) return refs;
+    final name = _parseCellText(cell);
+    return name == null ? null : [(id: null, name: name)];
+  }
+
+  ReferenceDto _stripEClassroomMarker(ReferenceDto classroom) {
+    final name = classroom.name;
+    return (
+      id: classroom.id,
+      name: name?.replaceFirst(RegExp(r'\s*\(?e\)?\s*$'), ''),
+    );
   }
 
   /// Parses the Chinese course table page (timetable grid + course list).

--- a/test/services/course_service_test.dart
+++ b/test/services/course_service_test.dart
@@ -311,6 +311,35 @@ void main() {
       });
     });
 
+    group('getCourseOffering', () {
+      test('should look up offering data by course number', () async {
+        final semesters = await courseService.getCourseSemesterList();
+        final sourceSemester = semesters.first;
+        final courseTable = await courseService.getCourseTable(
+          username: TestCredentials.username,
+          semester: sourceSemester,
+        );
+        final source = courseTable.firstWhere(
+          (schedule) => schedule.number?.isNotEmpty ?? false,
+        );
+
+        final offering = await courseService.getCourseOffering(source.number!);
+
+        expect(offering, isNotNull);
+        expect(offering!.schedule.number, source.number);
+        expect(offering.semester, sourceSemester);
+        expect(offering.schedule.course?.id, isNotEmpty);
+        expect(offering.schedule.course?.nameZh, isNotEmpty);
+        expect(offering.courseType, isNotNull);
+        expect(offering.schedule.teachers, isNotEmpty);
+        expect(offering.schedule.classes, isNotEmpty);
+      });
+
+      test('should return null for an unknown offering number', () async {
+        expect(await courseService.getCourseOffering('999999'), isNull);
+      });
+    });
+
     group('getCourse', () {
       test('should parse all course detail fields correctly', () async {
         final semesters = await courseService.getCourseSemesterList();

--- a/tool/html_snapshot/presets.dart
+++ b/tool/html_snapshot/presets.dart
@@ -210,6 +210,23 @@ final _presetList = <SnapshotPreset>[
     ),
   ),
   SnapshotPreset(
+    name: 'course.offering_header_zh',
+    service: .course,
+    description:
+        'Course offering lookup header (Chinese). Required: --course-number.',
+    allSkipReason: 'requires --course-number',
+    buildRequest: _offeringHeader,
+  ),
+  SnapshotPreset(
+    name: 'course.offering_query_zh',
+    service: .course,
+    description:
+        'Course offering query result (Chinese). Required: --course-number.',
+    allSkipReason: 'requires --course-number',
+    buildRequest: _offeringQuery,
+  ),
+
+  SnapshotPreset(
     name: 'course.syllabus',
     service: .course,
     description:
@@ -363,6 +380,108 @@ SnapshotRequestBuilder _courseSemesterRequiredId({
       ],
     );
   };
+}
+
+Future<SnapshotRequest> _offeringHeader(
+  SnapshotContext context,
+  ArgResults args,
+) async {
+  final courseNumber = _requiredOption(args, 'course-number');
+  return SnapshotRequest(
+    service: .course,
+    path: 'tw/ShowSyllabus.jsp',
+    query: {'snum': courseNumber},
+    extension: 'html',
+    fileParts: ['c$courseNumber', 'zh'],
+  );
+}
+
+Future<SnapshotRequest> _offeringQuery(
+  SnapshotContext context,
+  ArgResults args,
+) async {
+  final courseNumber = _requiredOption(args, 'course-number');
+  final headerResponse = await context
+      .client(.course)
+      .get(
+        'tw/ShowSyllabus.jsp',
+        queryParameters: {'snum': courseNumber},
+      );
+  final header = _parseOfferingSnapshotHeader(
+    headerResponse.data,
+    courseNumber: courseNumber,
+  );
+
+  return SnapshotRequest(
+    service: .course,
+    path: 'tw/QueryCourse.jsp',
+    method: 'POST',
+    data: {
+      'year': header.year,
+      'sem': header.term,
+      // The legacy form encodes "all divisions" as one SQL-style value.
+      'matric': "'0','1','4','5','6','7','8','9','A','C','D','E','F'",
+      'unit': '＊',
+      'cname': header.courseName,
+      'ccode': '',
+      'tname': '',
+      'stime': '0',
+    },
+    contentType: Headers.formUrlEncodedContentType,
+    extension: 'html',
+    fileParts: [
+      ..._semesterFileParts(
+        SemesterRef(year: header.year, term: header.term),
+      ),
+      'c$courseNumber',
+      'zh',
+    ],
+  );
+}
+
+({int year, int term, String courseName}) _parseOfferingSnapshotHeader(
+  String html, {
+  required String courseNumber,
+}) {
+  final document = parse(html);
+  for (final table in document.querySelectorAll('table')) {
+    final rows = table.querySelectorAll('tr');
+    if (rows.length < 2) continue;
+    final labels = rows.first.children.map((cell) => cell.text.trim()).toList();
+    final numberIndex = labels.indexWhere(
+      (label) => label == '課號' || label == 'Course Number',
+    );
+    final nameIndex = labels.indexWhere(
+      (label) => label == '課程名稱' || label == 'Course Name',
+    );
+    if (numberIndex < 0 || nameIndex < 0) continue;
+    final values = rows[1].children;
+    if (numberIndex >= values.length ||
+        nameIndex >= values.length ||
+        values[numberIndex].text.trim() != courseNumber) {
+      continue;
+    }
+    final courseName = values[nameIndex].text.trim();
+    if (courseName.isEmpty) break;
+    final semesterIndex = labels.indexOf('學年期');
+
+    final semester = semesterIndex >= 0 && semesterIndex < values.length
+        ? RegExp(
+            r'^(\d+)\s*-\s*([0-3])$',
+          ).firstMatch(values[semesterIndex].text.trim())
+        : null;
+    if (semester != null) {
+      return (
+        year: int.parse(semester.group(1)!),
+        term: int.parse(semester.group(2)!),
+        courseName: courseName,
+      );
+    }
+    break;
+  }
+  throw CliException(
+    'Could not resolve offering $courseNumber from the syllabus header.',
+  );
 }
 
 Future<SnapshotRequest> _syllabus(


### PR DESCRIPTION
## Summary

Add `CourseService.getCourseOffering` to fetch offering data using only the course number.

This provides a Service-layer data source for the independent course-detail refresh flow tracked in #374, without requiring the caller to supply a semester, catalog code, teacher ID, or course-table data.

## Implementation

The lookup uses two course-system requests:

1. `ShowSyllabus.jsp?snum=<course-number>` resolves the semester and offering header.
2. `QueryCourse.jsp` queries that semester by course name, then selects the matching row by course number.

The returned `CourseOfferingDto` includes:

- semester
- course catalog reference
- credits, hours, phase, and course type
- teachers and classes
- schedule periods and classrooms
- enrollment and withdrawal counts
- language and remarks

`null` is returned when the syllabus endpoint explicitly reports that the course number does not exist. Malformed responses, duplicate rows, inconsistent query results, and network failures remain errors.

The mock service supports the same lookup contract by searching its existing semester course tables.

## Snapshot capture

Add presets for both requests:

- `course.offering_header_zh`
- `course.offering_query_zh`

Both presets were exercised against course number `366960`; two captures succeeded and the query result contained the requested offering row.

## Validation

- `flutter test test/services/course_service_test.dart --plain-name getCourseOffering -r expanded --dart-define-from-file=test/test_config.json`
  - 2 tests passed
- Snapshot preset registry compiled successfully
- Dart diagnostics passed for the changed service, test, and snapshot files

Part of #374
