### PR TITLE
feat: show student semester and cumulative rankings on score screen

### DIFF
--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -99,7 +99,7 @@ score:
       departmentLevel: Dept.
     semester: Semester
     cumulative: Cumulative
-    rankAndTotal: ${rank} / ${total}
+    rankAndTotal: ${rank} / ${total} (${percentage}%)
     empty: No rankings yet
   status:
     notEntered: Not entered

--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -100,6 +100,7 @@ score:
     semester: Semester
     cumulative: Cumulative
     rankAndTotal: ${rank} / ${total}
+    empty: No rankings yet
   status:
     notEntered: Not entered
     withdraw: Withdrawn

--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -91,6 +91,15 @@ score:
     semesterAverage: Semester Avg
     creditsPassed: Credits Passed
     totalCredits: Total Credits
+  ranking:
+    title: Rankings
+    type:
+      classLevel: Class
+      groupLevel: Group
+      departmentLevel: Dept.
+    semester: Semester
+    cumulative: Cumulative
+    rankAndTotal: ${rank} / ${total}
   status:
     notEntered: Not entered
     withdraw: Withdrawn

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 456 (228 per locale)
+/// Strings: 472 (236 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -190,6 +190,7 @@ class _Translations$score$en_US extends Translations$score$zh_TW {
 	@override String courseNumber({required Object number, required Object code}) => 'No: ${number}  Code: ${code}';
 	@override String get none => 'N/A';
 	@override late final _Translations$score$summary$en_US summary = _Translations$score$summary$en_US._(_root);
+	@override late final _Translations$score$ranking$en_US ranking = _Translations$score$ranking$en_US._(_root);
 	@override late final _Translations$score$status$en_US status = _Translations$score$status$en_US._(_root);
 }
 
@@ -449,6 +450,20 @@ class _Translations$score$summary$en_US extends Translations$score$summary$zh_TW
 	@override String get totalCredits => 'Total Credits';
 }
 
+// Path: score.ranking
+class _Translations$score$ranking$en_US extends Translations$score$ranking$zh_TW {
+	_Translations$score$ranking$en_US._(TranslationsEnUs root) : this._root = root, super.internal(root);
+
+	final TranslationsEnUs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Rankings';
+	@override late final _Translations$score$ranking$type$en_US type = _Translations$score$ranking$type$en_US._(_root);
+	@override String get semester => 'Semester';
+	@override String get cumulative => 'Cumulative';
+	@override String rankAndTotal({required Object rank, required Object total}) => '${rank} / ${total}';
+}
+
 // Path: score.status
 class _Translations$score$status$en_US extends Translations$score$status$zh_TW {
 	_Translations$score$status$en_US._(TranslationsEnUs root) : this._root = root, super.internal(root);
@@ -662,6 +677,18 @@ class _Translations$intro$features$campusLife$en_US extends Translations$intro$f
 	@override String get description => 'Access campus life information, with more features coming soon.';
 }
 
+// Path: score.ranking.type
+class _Translations$score$ranking$type$en_US extends Translations$score$ranking$type$zh_TW {
+	_Translations$score$ranking$type$en_US._(TranslationsEnUs root) : this._root = root, super.internal(root);
+
+	final TranslationsEnUs _root; // ignore: unused_field
+
+	// Translations
+	@override String get classLevel => 'Class';
+	@override String get groupLevel => 'Group';
+	@override String get departmentLevel => 'Dept.';
+}
+
 // Path: profile.dangerZone.items
 class _Translations$profile$dangerZone$items$en_US extends Translations$profile$dangerZone$items$zh_TW {
 	_Translations$profile$dangerZone$items$en_US._(TranslationsEnUs root) : this._root = root, super.internal(root);
@@ -774,6 +801,13 @@ extension on TranslationsEnUs {
 			'score.summary.semesterAverage' => 'Semester Avg',
 			'score.summary.creditsPassed' => 'Credits Passed',
 			'score.summary.totalCredits' => 'Total Credits',
+			'score.ranking.title' => 'Rankings',
+			'score.ranking.type.classLevel' => 'Class',
+			'score.ranking.type.groupLevel' => 'Group',
+			'score.ranking.type.departmentLevel' => 'Dept.',
+			'score.ranking.semester' => 'Semester',
+			'score.ranking.cumulative' => 'Cumulative',
+			'score.ranking.rankAndTotal' => ({required Object rank, required Object total}) => '${rank} / ${total}',
 			'score.status.notEntered' => 'Not entered',
 			'score.status.withdraw' => 'Withdrawn',
 			'score.status.undelivered' => 'Not submitted',

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -461,7 +461,7 @@ class _Translations$score$ranking$en_US extends Translations$score$ranking$zh_TW
 	@override late final _Translations$score$ranking$type$en_US type = _Translations$score$ranking$type$en_US._(_root);
 	@override String get semester => 'Semester';
 	@override String get cumulative => 'Cumulative';
-	@override String rankAndTotal({required Object rank, required Object total}) => '${rank} / ${total}';
+	@override String rankAndTotal({required Object rank, required Object total, required Object percentage}) => '${rank} / ${total} (${percentage}%)';
 	@override String get empty => 'No rankings yet';
 }
 
@@ -808,7 +808,7 @@ extension on TranslationsEnUs {
 			'score.ranking.type.departmentLevel' => 'Dept.',
 			'score.ranking.semester' => 'Semester',
 			'score.ranking.cumulative' => 'Cumulative',
-			'score.ranking.rankAndTotal' => ({required Object rank, required Object total}) => '${rank} / ${total}',
+			'score.ranking.rankAndTotal' => ({required Object rank, required Object total, required Object percentage}) => '${rank} / ${total} (${percentage}%)',
 			'score.ranking.empty' => 'No rankings yet',
 			'score.status.notEntered' => 'Not entered',
 			'score.status.withdraw' => 'Withdrawn',

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -462,6 +462,7 @@ class _Translations$score$ranking$en_US extends Translations$score$ranking$zh_TW
 	@override String get semester => 'Semester';
 	@override String get cumulative => 'Cumulative';
 	@override String rankAndTotal({required Object rank, required Object total}) => '${rank} / ${total}';
+	@override String get empty => 'No rankings yet';
 }
 
 // Path: score.status
@@ -808,6 +809,7 @@ extension on TranslationsEnUs {
 			'score.ranking.semester' => 'Semester',
 			'score.ranking.cumulative' => 'Cumulative',
 			'score.ranking.rankAndTotal' => ({required Object rank, required Object total}) => '${rank} / ${total}',
+			'score.ranking.empty' => 'No rankings yet',
 			'score.status.notEntered' => 'Not entered',
 			'score.status.withdraw' => 'Withdrawn',
 			'score.status.undelivered' => 'Not submitted',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -717,6 +717,9 @@ class Translations$score$ranking$zh_TW {
 
 	/// zh-TW: '${rank} / ${total}'
 	String rankAndTotal({required Object rank, required Object total}) => '${rank} / ${total}';
+
+	/// zh-TW: '尚無排名'
+	String get empty => '尚無排名';
 }
 
 // Path: score.status
@@ -1228,6 +1231,7 @@ extension on Translations {
 			'score.ranking.semester' => '學期',
 			'score.ranking.cumulative' => '歷年',
 			'score.ranking.rankAndTotal' => ({required Object rank, required Object total}) => '${rank} / ${total}',
+			'score.ranking.empty' => '尚無排名',
 			'score.status.notEntered' => '未輸入',
 			'score.status.withdraw' => '撤選',
 			'score.status.undelivered' => '未送成績',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -715,8 +715,8 @@ class Translations$score$ranking$zh_TW {
 	/// zh-TW: '歷年'
 	String get cumulative => '歷年';
 
-	/// zh-TW: '${rank} / ${total}'
-	String rankAndTotal({required Object rank, required Object total}) => '${rank} / ${total}';
+	/// zh-TW: '${rank} / ${total} (${percentage}%)'
+	String rankAndTotal({required Object rank, required Object total, required Object percentage}) => '${rank} / ${total} (${percentage}%)';
 
 	/// zh-TW: '尚無排名'
 	String get empty => '尚無排名';
@@ -1230,7 +1230,7 @@ extension on Translations {
 			'score.ranking.type.departmentLevel' => '系所',
 			'score.ranking.semester' => '學期',
 			'score.ranking.cumulative' => '歷年',
-			'score.ranking.rankAndTotal' => ({required Object rank, required Object total}) => '${rank} / ${total}',
+			'score.ranking.rankAndTotal' => ({required Object rank, required Object total, required Object percentage}) => '${rank} / ${total} (${percentage}%)',
 			'score.ranking.empty' => '尚無排名',
 			'score.status.notEntered' => '未輸入',
 			'score.status.withdraw' => '撤選',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -286,6 +286,7 @@ class Translations$score$zh_TW {
 	String get none => '無';
 
 	late final Translations$score$summary$zh_TW summary = Translations$score$summary$zh_TW.internal(_root);
+	late final Translations$score$ranking$zh_TW ranking = Translations$score$ranking$zh_TW.internal(_root);
 	late final Translations$score$status$zh_TW status = Translations$score$status$zh_TW.internal(_root);
 }
 
@@ -695,6 +696,29 @@ class Translations$score$summary$zh_TW {
 	String get totalCredits => '修課總學分';
 }
 
+// Path: score.ranking
+class Translations$score$ranking$zh_TW {
+	Translations$score$ranking$zh_TW.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// zh-TW: '排名資訊'
+	String get title => '排名資訊';
+
+	late final Translations$score$ranking$type$zh_TW type = Translations$score$ranking$type$zh_TW.internal(_root);
+
+	/// zh-TW: '學期'
+	String get semester => '學期';
+
+	/// zh-TW: '歷年'
+	String get cumulative => '歷年';
+
+	/// zh-TW: '${rank} / ${total}'
+	String rankAndTotal({required Object rank, required Object total}) => '${rank} / ${total}';
+}
+
 // Path: score.status
 class Translations$score$status$zh_TW {
 	Translations$score$status$zh_TW.internal(this._root);
@@ -1045,6 +1069,24 @@ class Translations$intro$features$campusLife$zh_TW {
 	String get description => '彙整其他校園生活資訊，更多功能敬請期待。';
 }
 
+// Path: score.ranking.type
+class Translations$score$ranking$type$zh_TW {
+	Translations$score$ranking$type$zh_TW.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// zh-TW: '班級'
+	String get classLevel => '班級';
+
+	/// zh-TW: '分組'
+	String get groupLevel => '分組';
+
+	/// zh-TW: '系所'
+	String get departmentLevel => '系所';
+}
+
 // Path: profile.dangerZone.items
 class Translations$profile$dangerZone$items$zh_TW {
 	Translations$profile$dangerZone$items$zh_TW.internal(this._root);
@@ -1179,6 +1221,13 @@ extension on Translations {
 			'score.summary.semesterAverage' => '學期平均',
 			'score.summary.creditsPassed' => '實得學分',
 			'score.summary.totalCredits' => '修課總學分',
+			'score.ranking.title' => '排名資訊',
+			'score.ranking.type.classLevel' => '班級',
+			'score.ranking.type.groupLevel' => '分組',
+			'score.ranking.type.departmentLevel' => '系所',
+			'score.ranking.semester' => '學期',
+			'score.ranking.cumulative' => '歷年',
+			'score.ranking.rankAndTotal' => ({required Object rank, required Object total}) => '${rank} / ${total}',
 			'score.status.notEntered' => '未輸入',
 			'score.status.withdraw' => '撤選',
 			'score.status.undelivered' => '未送成績',

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -99,7 +99,7 @@ score:
       departmentLevel: 系所
     semester: 學期
     cumulative: 歷年
-    rankAndTotal: ${rank} / ${total}
+    rankAndTotal: ${rank} / ${total} (${percentage}%)
     empty: 尚無排名
   status:
     notEntered: 未輸入

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -100,6 +100,7 @@ score:
     semester: 學期
     cumulative: 歷年
     rankAndTotal: ${rank} / ${total}
+    empty: 尚無排名
   status:
     notEntered: 未輸入
     withdraw: 撤選

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -91,6 +91,15 @@ score:
     semesterAverage: 學期平均
     creditsPassed: 實得學分
     totalCredits: 修課總學分
+  ranking:
+    title: 排名資訊
+    type:
+      classLevel: 班級
+      groupLevel: 分組
+      departmentLevel: 系所
+    semester: 學期
+    cumulative: 歷年
+    rankAndTotal: ${rank} / ${total}
   status:
     notEntered: 未輸入
     withdraw: 撤選

--- a/lib/screens/main/score/score_screen.dart
+++ b/lib/screens/main/score/score_screen.dart
@@ -238,18 +238,29 @@ class _SemesterScoreList extends StatelessWidget {
             ),
             if (hasScores)
               SliverPadding(
-                padding: const .symmetric(horizontal: 16),
+                padding: .fromLTRB(
+                  16,
+                  0,
+                  16,
+                  _floatingBarBottomInset + bottomInset,
+                ),
                 sliver: SliverList(
-                  delegate: SliverChildBuilderDelegate((context, scoreIndex) {
-                    final score = scores[scoreIndex];
-                    return Column(
-                      children: [
-                        _ScoreTile(score: score),
-                        if (scoreIndex != scores.length - 1)
-                          const Divider(height: 1),
-                      ],
-                    );
-                  }, childCount: scores.length),
+                  delegate: SliverChildBuilderDelegate((context, index) {
+                    if (index < scores.length) {
+                      final score = scores[index];
+                      return Column(
+                        children: [
+                          _ScoreTile(score: score),
+                          if (index != scores.length - 1)
+                            const Divider(height: 1),
+                        ],
+                      );
+                    } else {
+                      return Skeleton.keep(
+                        child: _SemesterRankingCard(rankings: record.rankings),
+                      );
+                    }
+                  }, childCount: scores.length + (loading ? 0 : 1)),
                 ),
               )
             else
@@ -259,17 +270,6 @@ class _SemesterScoreList extends StatelessWidget {
                   child: Center(child: Text(t.score.noScoresThisSemester)),
                 ),
               ),
-            if (!loading)
-              SliverToBoxAdapter(
-                child: Skeleton.keep(
-                  child: _SemesterRankingCard(rankings: record.rankings),
-                ),
-              ),
-            SliverToBoxAdapter(
-              child: SizedBox(
-                height: _floatingBarBottomInset + bottomInset,
-              ),
-            ),
           ],
         ),
       ),
@@ -414,7 +414,7 @@ class _SemesterRankingCard extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const .symmetric(vertical: 8),
       child: DecoratedBox(
         decoration: BoxDecoration(
           color: colorScheme.surfaceContainerHighest,
@@ -496,22 +496,18 @@ class _SemesterRankingCard extends StatelessWidget {
                                 ),
                           ),
                           Text(
-                            t.score.ranking
-                                .rankAndTotal(
-                                  rank: ranking.semesterRank,
-                                  total: ranking.semesterTotal,
-                                )
-                                .spaced,
+                            _formatRankAndTotal(
+                              ranking.semesterRank,
+                              ranking.semesterTotal,
+                            ).spaced,
                             style: Theme.of(context).textTheme.bodyMedium,
                             textAlign: TextAlign.center,
                           ),
                           Text(
-                            t.score.ranking
-                                .rankAndTotal(
-                                  rank: ranking.grandTotalRank,
-                                  total: ranking.grandTotalTotal,
-                                )
-                                .spaced,
+                            _formatRankAndTotal(
+                              ranking.grandTotalRank,
+                              ranking.grandTotalTotal,
+                            ).spaced,
                             style: Theme.of(context).textTheme.bodyMedium,
                             textAlign: TextAlign.center,
                           ),
@@ -532,6 +528,17 @@ class _SemesterRankingCard extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+
+  String _formatRankAndTotal(int rank, int total) {
+    final percentage = total > 0
+        ? (rank / total * 100).toStringAsFixed(1)
+        : '0.0';
+    return t.score.ranking.rankAndTotal(
+      rank: rank,
+      total: total,
+      percentage: percentage,
     );
   }
 

--- a/lib/screens/main/score/score_screen.dart
+++ b/lib/screens/main/score/score_screen.dart
@@ -232,27 +232,13 @@ class _SemesterScoreList extends StatelessWidget {
           physics: const AlwaysScrollableScrollPhysics(),
           slivers: [
             SliverToBoxAdapter(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Skeleton.keep(
-                    child: _SemesterSummaryCard(summary: record.summary),
-                  ),
-                  if (record.rankings.isNotEmpty)
-                    Skeleton.keep(
-                      child: _SemesterRankingCard(rankings: record.rankings),
-                    ),
-                ],
+              child: Skeleton.keep(
+                child: _SemesterSummaryCard(summary: record.summary),
               ),
             ),
             if (hasScores)
               SliverPadding(
-                padding: .fromLTRB(
-                  16,
-                  0,
-                  16,
-                  _floatingBarBottomInset + bottomInset,
-                ),
+                padding: const .symmetric(horizontal: 16),
                 sliver: SliverList(
                   delegate: SliverChildBuilderDelegate((context, scoreIndex) {
                     final score = scores[scoreIndex];
@@ -273,6 +259,17 @@ class _SemesterScoreList extends StatelessWidget {
                   child: Center(child: Text(t.score.noScoresThisSemester)),
                 ),
               ),
+            if (record.rankings.isNotEmpty)
+              SliverToBoxAdapter(
+                child: Skeleton.keep(
+                  child: _SemesterRankingCard(rankings: record.rankings),
+                ),
+              ),
+            SliverToBoxAdapter(
+              child: SizedBox(
+                height: _floatingBarBottomInset + bottomInset,
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/screens/main/score/score_screen.dart
+++ b/lib/screens/main/score/score_screen.dart
@@ -259,7 +259,7 @@ class _SemesterScoreList extends StatelessWidget {
                   child: Center(child: Text(t.score.noScoresThisSemester)),
                 ),
               ),
-            if (record.rankings.isNotEmpty)
+            if (!loading)
               SliverToBoxAdapter(
                 child: Skeleton.keep(
                   child: _SemesterRankingCard(rankings: record.rankings),
@@ -433,88 +433,101 @@ class _SemesterRankingCard extends StatelessWidget {
                 ),
               ),
               const SizedBox(height: 12),
-              Table(
-                columnWidths: const {
-                  0: FlexColumnWidth(1.2),
-                  1: FlexColumnWidth(1.4),
-                  2: FlexColumnWidth(1.4),
-                },
-                defaultVerticalAlignment: TableCellVerticalAlignment.middle,
-                children: [
-                  TableRow(
-                    children: [
-                      const SizedBox(),
-                      Text(
-                        t.score.ranking.semester.spaced,
-                        style: Theme.of(context).textTheme.labelMedium
-                            ?.copyWith(
-                              color: colorScheme.onSurfaceVariant,
-                              fontWeight: FontWeight.bold,
-                            ),
-                        textAlign: TextAlign.center,
+              if (rankings.isEmpty)
+                Center(
+                  child: Padding(
+                    padding: const .symmetric(vertical: 8),
+                    child: Text(
+                      t.score.ranking.empty.spaced,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
                       ),
-                      Text(
-                        t.score.ranking.cumulative.spaced,
-                        style: Theme.of(context).textTheme.labelMedium
-                            ?.copyWith(
-                              color: colorScheme.onSurfaceVariant,
-                              fontWeight: FontWeight.bold,
-                            ),
-                        textAlign: TextAlign.center,
-                      ),
-                    ],
+                    ),
                   ),
-                  const TableRow(
-                    children: [
-                      SizedBox(height: 8),
-                      SizedBox(height: 8),
-                      SizedBox(height: 8),
-                    ],
-                  ),
-                  for (final ranking in rankings) ...[
+                )
+              else
+                Table(
+                  columnWidths: const {
+                    0: FlexColumnWidth(1.2),
+                    1: FlexColumnWidth(1.4),
+                    2: FlexColumnWidth(1.4),
+                  },
+                  defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+                  children: [
                     TableRow(
                       children: [
+                        const SizedBox(),
                         Text(
-                          _getRankingTypeLabel(ranking.rankingType).spaced,
-                          style: Theme.of(context).textTheme.bodyMedium
+                          t.score.ranking.semester.spaced,
+                          style: Theme.of(context).textTheme.labelMedium
                               ?.copyWith(
-                                color: colorScheme.onSurface,
+                                color: colorScheme.onSurfaceVariant,
                                 fontWeight: FontWeight.bold,
                               ),
-                        ),
-                        Text(
-                          t.score.ranking
-                              .rankAndTotal(
-                                rank: ranking.semesterRank,
-                                total: ranking.semesterTotal,
-                              )
-                              .spaced,
-                          style: Theme.of(context).textTheme.bodyMedium,
                           textAlign: TextAlign.center,
                         ),
                         Text(
-                          t.score.ranking
-                              .rankAndTotal(
-                                rank: ranking.grandTotalRank,
-                                total: ranking.grandTotalTotal,
-                              )
-                              .spaced,
-                          style: Theme.of(context).textTheme.bodyMedium,
+                          t.score.ranking.cumulative.spaced,
+                          style: Theme.of(context).textTheme.labelMedium
+                              ?.copyWith(
+                                color: colorScheme.onSurfaceVariant,
+                                fontWeight: FontWeight.bold,
+                              ),
                           textAlign: TextAlign.center,
                         ),
                       ],
                     ),
-                    if (ranking != rankings.last)
-                      const TableRow(
+                    const TableRow(
+                      children: [
+                        SizedBox(height: 8),
+                        SizedBox(height: 8),
+                        SizedBox(height: 8),
+                      ],
+                    ),
+                    for (final ranking in rankings) ...[
+                      TableRow(
                         children: [
-                          SizedBox(height: 8),
-                          SizedBox(height: 8),
-                          SizedBox(height: 8),
+                          Text(
+                            _getRankingTypeLabel(ranking.rankingType).spaced,
+                            style: Theme.of(context).textTheme.bodyMedium
+                                ?.copyWith(
+                                  color: colorScheme.onSurface,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                          ),
+                          Text(
+                            t.score.ranking
+                                .rankAndTotal(
+                                  rank: ranking.semesterRank,
+                                  total: ranking.semesterTotal,
+                                )
+                                .spaced,
+                            style: Theme.of(context).textTheme.bodyMedium,
+                            textAlign: TextAlign.center,
+                          ),
+                          Text(
+                            t.score.ranking
+                                .rankAndTotal(
+                                  rank: ranking.grandTotalRank,
+                                  total: ranking.grandTotalTotal,
+                                )
+                                .spaced,
+                            style: Theme.of(context).textTheme.bodyMedium,
+                            textAlign: TextAlign.center,
+                          ),
                         ],
                       ),
+                      if (ranking != rankings.last)
+                        const TableRow(
+                          children: [
+                            SizedBox(height: 8),
+                            SizedBox(height: 8),
+                            SizedBox(height: 8),
+                          ],
+                        ),
+                    ],
                   ],
-                ],
-              ),
+                ),
             ],
           ),
         ),

--- a/lib/screens/main/score/score_screen.dart
+++ b/lib/screens/main/score/score_screen.dart
@@ -7,6 +7,7 @@ import 'package:tattoo/components/chip_tab_switcher.dart';
 import 'package:tattoo/components/floating_action_bar.dart';
 import 'package:tattoo/database/database.dart';
 import 'package:tattoo/i18n/strings.g.dart';
+import 'package:tattoo/models/ranking.dart';
 import 'package:tattoo/repositories/student_repository.dart';
 import 'package:tattoo/screens/main/score/score_providers.dart';
 import 'package:tattoo/screens/main/score/score_view_helpers.dart';
@@ -231,8 +232,17 @@ class _SemesterScoreList extends StatelessWidget {
           physics: const AlwaysScrollableScrollPhysics(),
           slivers: [
             SliverToBoxAdapter(
-              child: Skeleton.keep(
-                child: _SemesterSummaryCard(summary: record.summary),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Skeleton.keep(
+                    child: _SemesterSummaryCard(summary: record.summary),
+                  ),
+                  if (record.rankings.isNotEmpty)
+                    Skeleton.keep(
+                      child: _SemesterRankingCard(rankings: record.rankings),
+                    ),
+                ],
               ),
             ),
             if (hasScores)
@@ -394,5 +404,132 @@ class _ScoreTile extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+class _SemesterRankingCard extends StatelessWidget {
+  final List<UserSemesterRanking> rankings;
+
+  const _SemesterRankingCard({required this.rankings});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                t.score.ranking.title,
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.primary,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Table(
+                columnWidths: const {
+                  0: FlexColumnWidth(1.2),
+                  1: FlexColumnWidth(1.4),
+                  2: FlexColumnWidth(1.4),
+                },
+                defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+                children: [
+                  TableRow(
+                    children: [
+                      const SizedBox(),
+                      Text(
+                        t.score.ranking.semester.spaced,
+                        style: Theme.of(context).textTheme.labelMedium
+                            ?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                              fontWeight: FontWeight.bold,
+                            ),
+                        textAlign: TextAlign.center,
+                      ),
+                      Text(
+                        t.score.ranking.cumulative.spaced,
+                        style: Theme.of(context).textTheme.labelMedium
+                            ?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                              fontWeight: FontWeight.bold,
+                            ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ),
+                  const TableRow(
+                    children: [
+                      SizedBox(height: 8),
+                      SizedBox(height: 8),
+                      SizedBox(height: 8),
+                    ],
+                  ),
+                  for (final ranking in rankings) ...[
+                    TableRow(
+                      children: [
+                        Text(
+                          _getRankingTypeLabel(ranking.rankingType).spaced,
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: colorScheme.onSurface,
+                                fontWeight: FontWeight.bold,
+                              ),
+                        ),
+                        Text(
+                          t.score.ranking
+                              .rankAndTotal(
+                                rank: ranking.semesterRank,
+                                total: ranking.semesterTotal,
+                              )
+                              .spaced,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                          textAlign: TextAlign.center,
+                        ),
+                        Text(
+                          t.score.ranking
+                              .rankAndTotal(
+                                rank: ranking.grandTotalRank,
+                                total: ranking.grandTotalTotal,
+                              )
+                              .spaced,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
+                    ),
+                    if (ranking != rankings.last)
+                      const TableRow(
+                        children: [
+                          SizedBox(height: 8),
+                          SizedBox(height: 8),
+                          SizedBox(height: 8),
+                        ],
+                      ),
+                  ],
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _getRankingTypeLabel(RankingType type) {
+    return switch (type) {
+      RankingType.classLevel => t.score.ranking.type.classLevel,
+      RankingType.groupLevel => t.score.ranking.type.groupLevel,
+      RankingType.departmentLevel => t.score.ranking.type.departmentLevel,
+    };
   }
 }


### PR DESCRIPTION
This PR adds the display of semester and cumulative rankings (class, group, and department level) on the score screen. It uses the existing `GradeRanking` data that is already fetched by the repository and stored in the database.

Note for future improvement:
- Display grade announcement time if grades are not out yet (the school system might write the announcement time in the table).