### PR TITLE
feat: show teacher syllabuses in tabs

### DIFF
--- a/lib/screens/main/course_table/course_table_detail_sheet.dart
+++ b/lib/screens/main/course_table/course_table_detail_sheet.dart
@@ -195,10 +195,17 @@ class _SyllabusTabsState extends State<_SyllabusTabs>
       return;
     }
 
-    final previousIndex = _controller.index;
+    final previousTeacherCode = oldWidget.details.isEmpty
+        ? null
+        : oldWidget.details[_controller.index].teacher.code;
+    final updatedIndex = previousTeacherCode == null
+        ? -1
+        : widget.details.indexWhere(
+            (detail) => detail.teacher.code == previousTeacherCode,
+          );
     _controller.dispose();
     _controller = _createController(
-      initialIndex: previousIndex < widget.details.length ? previousIndex : 0,
+      initialIndex: updatedIndex < 0 ? 0 : updatedIndex,
     );
   }
 

--- a/lib/screens/main/course_table/course_table_detail_sheet.dart
+++ b/lib/screens/main/course_table/course_table_detail_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tattoo/components/chip_tab_switcher.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/models/course.dart';
 import 'package:tattoo/repositories/course_repository.dart';
@@ -150,11 +151,8 @@ class _CourseDetailContent extends ConsumerWidget {
         ),
         if (syllabusAsync case final syllabusAsync?)
           switch (syllabusAsync) {
-            AsyncData(value: final syllabuses) => Column(
-              children: [
-                for (final detail in syllabuses)
-                  _SyllabusSections(detail: detail),
-              ],
+            AsyncData(value: final syllabuses) => _SyllabusTabs(
+              details: syllabuses,
             ),
             AsyncError(:final error) => _DetailState(
               icon: Icons.error_outline,
@@ -171,6 +169,90 @@ class _CourseDetailContent extends ConsumerWidget {
   }
 }
 
+class _SyllabusTabs extends StatefulWidget {
+  const _SyllabusTabs({required this.details});
+
+  final List<TeacherSyllabusDetail> details;
+
+  @override
+  State<_SyllabusTabs> createState() => _SyllabusTabsState();
+}
+
+class _SyllabusTabsState extends State<_SyllabusTabs>
+    with SingleTickerProviderStateMixin {
+  late TabController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = _createController();
+  }
+
+  @override
+  void didUpdateWidget(_SyllabusTabs oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.details.length == widget.details.length) {
+      return;
+    }
+
+    final previousIndex = _controller.index;
+    _controller.dispose();
+    _controller = _createController(
+      initialIndex: previousIndex < widget.details.length ? previousIndex : 0,
+    );
+  }
+
+  TabController _createController({int initialIndex = 0}) {
+    final controller = TabController(
+      length: widget.details.length,
+      initialIndex: initialIndex,
+      vsync: this,
+    );
+    controller.addListener(_handleTabChanged);
+    return controller;
+  }
+
+  void _handleTabChanged() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.details.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      children: [
+        ChipTabSwitcher(
+          controller: _controller,
+          padding: const .symmetric(horizontal: 8),
+          tabs: [
+            for (final detail in widget.details)
+              (_normalizedText(
+                        localized(
+                          detail.teacher.nameZh,
+                          detail.teacher.nameEn,
+                        ),
+                      ) ??
+                      t.general.unknown)
+                  .spaced,
+          ],
+        ),
+        _SyllabusSections(detail: widget.details[_controller.index]),
+      ],
+    );
+  }
+}
+
 class _SyllabusSections extends StatelessWidget {
   const _SyllabusSections({required this.detail});
 
@@ -179,9 +261,6 @@ class _SyllabusSections extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final teacherName = _normalizedText(
-      localized(detail.teacher.nameZh, detail.teacher.nameEn),
-    );
     return Card(
       margin: const .all(8),
       elevation: 0,
@@ -196,14 +275,9 @@ class _SyllabusSections extends StatelessWidget {
           child: Column(
             crossAxisAlignment: .start,
             children: [
-              if (teacherName case final teacherName?)
-                Text(
-                  teacherName.spaced,
-                  style: theme.textTheme.titleLarge,
-                ),
               for (final (index, section)
                   in detail.syllabus.sections.indexed) ...[
-                if (index > 0 || teacherName != null) const Divider(height: 24),
+                if (index > 0) const Divider(height: 24),
                 Text(
                   section.title.spaced,
                   style: theme.textTheme.titleMedium,


### PR DESCRIPTION
## Summary

- show one teacher syllabus at a time instead of expanding every syllabus
- reuse `ChipTabSwitcher` for the horizontally scrollable teacher selector
- preserve the selected teacher when syllabus results update

## Verification

- `flutter analyze lib/screens/main/course_table/course_table_detail_sheet.dart`
- exercised the multi-teacher “Special Projects (I)” demo course on Android and switched between teacher chips
