### PR TITLE
adaptive width navigation frame

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ MVVM pattern with Riverpod for DI and reactive state (manual providers, no codeg
 - `lib/router/` - go_router config (`app_router.dart`)
 - `lib/screens/` - Screen widgets organized by feature: `welcome/` (intro, login) and `main/` (home, course_table, score, calendar, portal, scanner, kiosk_login, profile). 4-tab `StatefulShellRoute` with `AnimatedShellContainer` for tab state preservation. Each tab owns its own `Scaffold`.
 - `lib/services/` - Clients that talk to external systems (NTUT HTTP services, Firebase, etc.) and `demo_mode.dart`
-- `lib/shells/` - Layout shells (AnimatedShellContainer for tab transitions, ShowcaseShell for onboarding)
+- `lib/shells/` - Layout shells (AnimatedShellContainer for tab transitions, ShowcaseShell for onboarding, CenteredMaxWidthFrame and AdaptiveNavigationScaffold for the 580 logical-pixel adaptive breakpoint)
 - `lib/utils/` - HTTP utilities (cookie jar, interceptors, native adapter), localization, avatar payload, the `PrefType` SharedPreferences value-type enum
 - `tool/` - Dart CLI tools (credentials management, HTML/XML snapshot capture, portal endpoints scraper)
 

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -138,7 +138,7 @@ GoRouter createAppRouter({
             GoRoute(
               path: AppRoutes.home,
               pageBuilder: (context, state) =>
-                  const NoTransitionPage(child: MainHomeScreen()),
+                  NoTransitionPage(child: _framed(const MainHomeScreen())),
             ),
           ],
         ),
@@ -147,7 +147,7 @@ GoRouter createAppRouter({
             GoRoute(
               path: AppRoutes.courseTable,
               pageBuilder: (context, state) =>
-                  const NoTransitionPage(child: CourseTableScreen()),
+                  NoTransitionPage(child: _framed(const CourseTableScreen())),
             ),
           ],
         ),
@@ -156,7 +156,7 @@ GoRouter createAppRouter({
             GoRoute(
               path: AppRoutes.score,
               pageBuilder: (context, state) =>
-                  const NoTransitionPage(child: ScoreScreen()),
+                  NoTransitionPage(child: _framed(const ScoreScreen())),
             ),
           ],
         ),
@@ -165,7 +165,7 @@ GoRouter createAppRouter({
             GoRoute(
               path: AppRoutes.profile,
               pageBuilder: (context, state) =>
-                  const NoTransitionPage(child: ProfileScreen()),
+                  NoTransitionPage(child: _framed(const ProfileScreen())),
             ),
           ],
         ),

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -18,6 +18,7 @@ import 'package:tattoo/screens/welcome/intro_screen.dart';
 import 'package:tattoo/screens/welcome/login_screen.dart';
 import 'package:tattoo/services/firebase_service.dart';
 import 'package:tattoo/shells/animated_shell_container.dart';
+import 'package:tattoo/shells/centered_max_width_frame.dart';
 
 final rootNavigatorKey = GlobalKey<NavigatorState>();
 final rootScaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
@@ -37,6 +38,8 @@ abstract class AppRoutes {
   static const regedit = '/regedit';
   static const changePassword = '/change-password';
 }
+
+Widget _framed(Widget child) => CenteredMaxWidthFrame(child: child);
 
 /// Bridges [sessionProvider] to a [Listenable] for [GoRouter.refreshListenable].
 class _SessionRefreshListenable extends ChangeNotifier {
@@ -80,7 +83,7 @@ GoRouter createAppRouter({
     ),
     GoRoute(
       path: AppRoutes.login,
-      builder: (context, state) => const LoginScreen(),
+      builder: (context, state) => _framed(const LoginScreen()),
     ),
     GoRoute(
       path: AppRoutes.changePassword,
@@ -88,15 +91,17 @@ GoRouter createAppRouter({
         final extra = state.extra as Map<String, dynamic>?;
         final isExpired = extra?['isExpired'] as bool? ?? false;
         final username = extra?['username'] as String?;
-        return ChangePasswordScreen(
-          isExpired: isExpired,
-          username: username,
+        return _framed(
+          ChangePasswordScreen(
+            isExpired: isExpired,
+            username: username,
+          ),
         );
       },
     ),
     GoRoute(
       path: AppRoutes.about,
-      builder: (context, state) => const AboutScreen(),
+      builder: (context, state) => _framed(const AboutScreen()),
     ),
     GoRoute(
       path: AppRoutes.scanner,
@@ -104,19 +109,19 @@ GoRouter createAppRouter({
     ),
     GoRoute(
       path: AppRoutes.regedit,
-      builder: (context, state) => const RegeditScreen(),
+      builder: (context, state) => _framed(const RegeditScreen()),
     ),
     GoRoute(
       path: AppRoutes.portal,
-      builder: (context, state) => const PortalScreen(),
+      builder: (context, state) => _framed(const PortalScreen()),
     ),
     GoRoute(
       path: AppRoutes.calendar,
-      builder: (context, state) => const CalendarScreen(),
+      builder: (context, state) => _framed(const CalendarScreen()),
     ),
     GoRoute(
       path: AppRoutes.kioskLoginQr,
-      builder: (context, state) => const KioskLoginQrScreen(),
+      builder: (context, state) => _framed(const KioskLoginQrScreen()),
     ),
     StatefulShellRoute(
       builder: (context, state, navigationShell) =>

--- a/lib/screens/main/course_table/course_table_detail_sheet.dart
+++ b/lib/screens/main/course_table/course_table_detail_sheet.dart
@@ -19,7 +19,9 @@ Future<void> showCourseTableDetailSheet(
     isScrollControlled: true,
     useSafeArea: true,
     backgroundColor: Theme.of(context).colorScheme.surfaceContainerLowest,
-    builder: (context) => Center(
+    builder: (context) => Align(
+      alignment: Alignment.bottomCenter,
+      heightFactor: 1,
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: contentMaxWidth),
         child: CourseTableDetailSheet(number: number),

--- a/lib/screens/main/course_table/course_table_detail_sheet.dart
+++ b/lib/screens/main/course_table/course_table_detail_sheet.dart
@@ -5,6 +5,7 @@ import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/models/course.dart';
 import 'package:tattoo/repositories/course_repository.dart';
 import 'package:tattoo/screens/main/course_table/course_table_providers.dart';
+import 'package:tattoo/shells/centered_max_width_frame.dart';
 import 'package:tattoo/utils/auto_spacing.dart';
 import 'package:tattoo/utils/localized.dart';
 
@@ -18,7 +19,12 @@ Future<void> showCourseTableDetailSheet(
     isScrollControlled: true,
     useSafeArea: true,
     backgroundColor: Theme.of(context).colorScheme.surfaceContainerLowest,
-    builder: (context) => CourseTableDetailSheet(number: number),
+    builder: (context) => Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: contentMaxWidth),
+        child: CourseTableDetailSheet(number: number),
+      ),
+    ),
   );
 }
 

--- a/lib/screens/main/course_table/course_table_detail_sheet.dart
+++ b/lib/screens/main/course_table/course_table_detail_sheet.dart
@@ -18,10 +18,6 @@ Future<void> showCourseTableDetailSheet(
     isScrollControlled: true,
     useSafeArea: true,
     backgroundColor: Theme.of(context).colorScheme.surfaceContainerLowest,
-    constraints: BoxConstraints(
-      minWidth: MediaQuery.sizeOf(context).width,
-      maxWidth: MediaQuery.sizeOf(context).width,
-    ),
     builder: (context) => CourseTableDetailSheet(number: number),
   );
 }

--- a/lib/screens/main/home_screen.dart
+++ b/lib/screens/main/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/router/app_router.dart';
 import 'package:tattoo/screens/main/profile/profile_providers.dart';
 import 'package:tattoo/screens/main/user_providers.dart';
+import 'package:tattoo/shells/adaptive_navigation_scaffold.dart';
 import 'package:tattoo/utils/auto_spacing.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
@@ -72,24 +73,28 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       },
     );
 
-    return Scaffold(
+    return AdaptiveNavigationScaffold(
       body: widget.navigationShell,
-      bottomNavigationBar: NavigationBar(
-        destinations: <NavigationDestination>[
-          NavigationDestination(icon: Icon(Icons.home), label: t.nav.home),
-          NavigationDestination(
-            icon: Icon(Icons.dashboard),
-            label: t.nav.courseTable,
-          ),
-          NavigationDestination(icon: Icon(Icons.school), label: t.nav.scores),
-          NavigationDestination(
-            icon: Icon(Icons.account_circle),
-            label: t.nav.profile,
-          ),
-        ],
-        selectedIndex: widget.navigationShell.currentIndex,
-        onDestinationSelected: _onDestinationSelected,
-      ),
+      destinations: <AdaptiveNavigationDestination>[
+        AdaptiveNavigationDestination(
+          icon: Icon(Icons.home),
+          label: t.nav.home,
+        ),
+        AdaptiveNavigationDestination(
+          icon: Icon(Icons.dashboard),
+          label: t.nav.courseTable,
+        ),
+        AdaptiveNavigationDestination(
+          icon: Icon(Icons.school),
+          label: t.nav.scores,
+        ),
+        AdaptiveNavigationDestination(
+          icon: Icon(Icons.account_circle),
+          label: t.nav.profile,
+        ),
+      ],
+      selectedIndex: widget.navigationShell.currentIndex,
+      onDestinationSelected: _onDestinationSelected,
     );
   }
 }

--- a/lib/shells/adaptive_navigation_scaffold.dart
+++ b/lib/shells/adaptive_navigation_scaffold.dart
@@ -49,6 +49,9 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
                   children: [
                     NavigationRail(
                       minWidth: navigationRailMinWidth,
+                      backgroundColor: Theme.of(
+                        context,
+                      ).colorScheme.surfaceContainer,
                       groupAlignment: 1,
                       labelType: .all,
                       scrollable: true,

--- a/lib/shells/adaptive_navigation_scaffold.dart
+++ b/lib/shells/adaptive_navigation_scaffold.dart
@@ -74,9 +74,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
                       selectedIndex: selectedIndex,
                       onDestinationSelected: onDestinationSelected,
                     ),
-                    Expanded(
-                      child: CenteredMaxWidthFrame(child: body),
-                    ),
+                    Expanded(child: body),
                   ],
                 )
               : CenteredMaxWidthFrame(child: body),

--- a/lib/shells/adaptive_navigation_scaffold.dart
+++ b/lib/shells/adaptive_navigation_scaffold.dart
@@ -7,9 +7,6 @@ const navigationRailBreakpoint = 580.0;
 /// Minimum width reserved for the compact navigation rail.
 const navigationRailMinWidth = 80.0;
 
-/// Maximum width of the centered main frame, including its navigation rail.
-const mainFrameMaxWidth = contentMaxWidth + navigationRailMinWidth;
-
 /// Shared data used to build bar and rail navigation destinations.
 class AdaptiveNavigationDestination {
   const AdaptiveNavigationDestination({
@@ -45,46 +42,45 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
         final useNavigationRail =
             constraints.maxWidth >= navigationRailBreakpoint;
 
-        return CenteredMaxWidthFrame(
-          maxWidth: useNavigationRail ? mainFrameMaxWidth : contentMaxWidth,
-          child: Scaffold(
-            body: useNavigationRail
-                ? Row(
-                    children: [
-                      NavigationRail(
-                        minWidth: navigationRailMinWidth,
-                        labelType: .all,
-                        scrollable: true,
-                        destinations: [
-                          for (final destination in destinations)
-                            NavigationRailDestination(
-                              icon: destination.icon,
-                              selectedIcon: destination.selectedIcon,
-                              label: Text(destination.label),
-                            ),
-                        ],
-                        selectedIndex: selectedIndex,
-                        onDestinationSelected: onDestinationSelected,
+        return Scaffold(
+          body: useNavigationRail
+              ? Row(
+                  children: [
+                    NavigationRail(
+                      minWidth: navigationRailMinWidth,
+                      labelType: .all,
+                      scrollable: true,
+                      destinations: [
+                        for (final destination in destinations)
+                          NavigationRailDestination(
+                            icon: destination.icon,
+                            selectedIcon: destination.selectedIcon,
+                            label: Text(destination.label),
+                          ),
+                      ],
+                      selectedIndex: selectedIndex,
+                      onDestinationSelected: onDestinationSelected,
+                    ),
+                    Expanded(
+                      child: CenteredMaxWidthFrame(child: body),
+                    ),
+                  ],
+                )
+              : CenteredMaxWidthFrame(child: body),
+          bottomNavigationBar: useNavigationRail
+              ? null
+              : NavigationBar(
+                  destinations: [
+                    for (final destination in destinations)
+                      NavigationDestination(
+                        icon: destination.icon,
+                        selectedIcon: destination.selectedIcon,
+                        label: destination.label,
                       ),
-                      Expanded(child: body),
-                    ],
-                  )
-                : body,
-            bottomNavigationBar: useNavigationRail
-                ? null
-                : NavigationBar(
-                    destinations: [
-                      for (final destination in destinations)
-                        NavigationDestination(
-                          icon: destination.icon,
-                          selectedIcon: destination.selectedIcon,
-                          label: destination.label,
-                        ),
-                    ],
-                    selectedIndex: selectedIndex,
-                    onDestinationSelected: onDestinationSelected,
-                  ),
-          ),
+                  ],
+                  selectedIndex: selectedIndex,
+                  onDestinationSelected: onDestinationSelected,
+                ),
         );
       },
     );

--- a/lib/shells/adaptive_navigation_scaffold.dart
+++ b/lib/shells/adaptive_navigation_scaffold.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:tattoo/shells/centered_max_width_frame.dart';
+
+/// Width at which the main navigation changes from a bar to a rail.
+const navigationRailBreakpoint = 580.0;
+
+/// Minimum width reserved for the compact navigation rail.
+const navigationRailMinWidth = 80.0;
+
+/// Maximum width of the centered main frame, including its navigation rail.
+const mainFrameMaxWidth = contentMaxWidth + navigationRailMinWidth;
+
+/// Shared data used to build bar and rail navigation destinations.
+class AdaptiveNavigationDestination {
+  const AdaptiveNavigationDestination({
+    required this.icon,
+    required this.label,
+    this.selectedIcon,
+  });
+
+  final Widget icon;
+  final Widget? selectedIcon;
+  final String label;
+}
+
+/// Displays bottom navigation in compact windows and a rail in wide windows.
+class AdaptiveNavigationScaffold extends StatelessWidget {
+  const AdaptiveNavigationScaffold({
+    super.key,
+    required this.body,
+    required this.destinations,
+    required this.selectedIndex,
+    required this.onDestinationSelected,
+  });
+
+  final Widget body;
+  final List<AdaptiveNavigationDestination> destinations;
+  final int selectedIndex;
+  final ValueChanged<int> onDestinationSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final useNavigationRail =
+            constraints.maxWidth >= navigationRailBreakpoint;
+
+        return CenteredMaxWidthFrame(
+          maxWidth: useNavigationRail ? mainFrameMaxWidth : contentMaxWidth,
+          child: Scaffold(
+            body: useNavigationRail
+                ? Row(
+                    children: [
+                      NavigationRail(
+                        minWidth: navigationRailMinWidth,
+                        labelType: .all,
+                        scrollable: true,
+                        destinations: [
+                          for (final destination in destinations)
+                            NavigationRailDestination(
+                              icon: destination.icon,
+                              selectedIcon: destination.selectedIcon,
+                              label: Text(destination.label),
+                            ),
+                        ],
+                        selectedIndex: selectedIndex,
+                        onDestinationSelected: onDestinationSelected,
+                      ),
+                      Expanded(child: body),
+                    ],
+                  )
+                : body,
+            bottomNavigationBar: useNavigationRail
+                ? null
+                : NavigationBar(
+                    destinations: [
+                      for (final destination in destinations)
+                        NavigationDestination(
+                          icon: destination.icon,
+                          selectedIcon: destination.selectedIcon,
+                          label: destination.label,
+                        ),
+                    ],
+                    selectedIndex: selectedIndex,
+                    onDestinationSelected: onDestinationSelected,
+                  ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/shells/adaptive_navigation_scaffold.dart
+++ b/lib/shells/adaptive_navigation_scaffold.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:tattoo/shells/centered_max_width_frame.dart';
 
 /// Width at which the main navigation changes from a bar to a rail.
@@ -51,6 +52,14 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
                       groupAlignment: 1,
                       labelType: .all,
                       scrollable: true,
+                      leading: Padding(
+                        padding: const .only(top: 8),
+                        child: SvgPicture.asset(
+                          'assets/tat_icon.svg',
+                          width: 40,
+                          height: 40,
+                        ),
+                      ),
                       destinations: [
                         for (final destination in destinations)
                           NavigationRailDestination(

--- a/lib/shells/adaptive_navigation_scaffold.dart
+++ b/lib/shells/adaptive_navigation_scaffold.dart
@@ -48,6 +48,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
                   children: [
                     NavigationRail(
                       minWidth: navigationRailMinWidth,
+                      groupAlignment: 1,
                       labelType: .all,
                       scrollable: true,
                       destinations: [

--- a/lib/shells/centered_max_width_frame.dart
+++ b/lib/shells/centered_max_width_frame.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+/// Maximum width used by phone-oriented screen content.
+const contentMaxWidth = 580.0;
+
+/// Centers [child] while keeping it at or below [maxWidth].
+///
+/// The surrounding area keeps the current scaffold background color. This
+/// widget only changes layout constraints and deliberately leaves [MediaQuery]
+/// unchanged so safe areas, keyboard insets, and overlays keep the real window
+/// metrics.
+class CenteredMaxWidthFrame extends StatelessWidget {
+  const CenteredMaxWidthFrame({
+    super.key,
+    required this.child,
+    this.maxWidth = contentMaxWidth,
+  });
+
+  final Widget child;
+  final double maxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: Theme.of(context).scaffoldBackgroundColor,
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: maxWidth),
+          child: SizedBox.expand(child: child),
+        ),
+      ),
+    );
+  }
+}

--- a/test/screens/main/course_table/course_table_detail_sheet_test.dart
+++ b/test/screens/main/course_table/course_table_detail_sheet_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tattoo/screens/main/course_table/course_table_detail_sheet.dart';
+import 'package:tattoo/screens/main/course_table/course_table_providers.dart';
+
+void main() {
+  testWidgets('keeps the modal background wide without filling the screen', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1000, 800);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          courseOfferingProvider.overrideWith((ref, number) => null),
+        ],
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) => TextButton(
+              onPressed: () => showCourseTableDetailSheet(
+                context,
+                number: '0000000',
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    final bottomSheet = find.byType(BottomSheet);
+    final bottomSheetSize = tester.getSize(bottomSheet);
+    expect(bottomSheetSize.width, 1000);
+    expect(bottomSheetSize.height, lessThan(800));
+    expect(tester.getBottomRight(bottomSheet).dy, 800);
+  });
+}

--- a/test/shells/adaptive_navigation_scaffold_test.dart
+++ b/test/shells/adaptive_navigation_scaffold_test.dart
@@ -97,7 +97,7 @@ void main() {
     expect(find.byType(NavigationBar), findsNothing);
   });
 
-  testWidgets('caps the wide main frame at 660 pixels', (tester) async {
+  testWidgets('pins the rail left and centers capped content', (tester) async {
     await setWindowSize(tester, width: 1000);
     const bodyKey = Key('navigation-body');
 
@@ -114,17 +114,18 @@ void main() {
 
     final railWidth = tester.getSize(find.byType(NavigationRail)).width;
     expect(railWidth, greaterThanOrEqualTo(navigationRailMinWidth));
+    expect(tester.getTopLeft(find.byType(NavigationRail)).dx, 0);
     expect(
       tester.getSize(find.byKey(bodyKey)).width,
-      lessThanOrEqualTo(contentMaxWidth),
+      contentMaxWidth,
     );
     expect(
       tester.getSize(find.byType(Scaffold).first).width,
-      mainFrameMaxWidth,
+      1000,
     );
     expect(
-      tester.getTopLeft(find.byType(Scaffold).first).dx,
-      (1000 - mainFrameMaxWidth) / 2,
+      tester.getTopLeft(find.byKey(bodyKey)).dx,
+      railWidth + (1000 - railWidth - contentMaxWidth) / 2,
     );
   });
 

--- a/test/shells/adaptive_navigation_scaffold_test.dart
+++ b/test/shells/adaptive_navigation_scaffold_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tattoo/shells/adaptive_navigation_scaffold.dart';
+import 'package:tattoo/shells/centered_max_width_frame.dart';
+
+void main() {
+  const destinations = [
+    AdaptiveNavigationDestination(
+      icon: Icon(Icons.home),
+      label: 'Home',
+    ),
+    AdaptiveNavigationDestination(
+      icon: Icon(Icons.school),
+      label: 'Scores',
+    ),
+  ];
+
+  Future<void> setWindowSize(
+    WidgetTester tester, {
+    required double width,
+    double height = 800,
+  }) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = Size(width, height);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+  }
+
+  testWidgets('centered frame fills narrow windows', (tester) async {
+    await setWindowSize(tester, width: 400);
+    const childKey = Key('frame-child');
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: CenteredMaxWidthFrame(
+          child: SizedBox(key: childKey),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(childKey)).width, 400);
+    expect(tester.getTopLeft(find.byKey(childKey)).dx, 0);
+  });
+
+  testWidgets('centered frame caps and centers wide windows', (tester) async {
+    await setWindowSize(tester, width: 800);
+    const childKey = Key('frame-child');
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: CenteredMaxWidthFrame(
+          child: SizedBox(key: childKey),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(childKey)).width, contentMaxWidth);
+    expect(
+      tester.getTopLeft(find.byKey(childKey)).dx,
+      (800 - contentMaxWidth) / 2,
+    );
+  });
+
+  testWidgets('uses navigation bar below 580 pixels', (tester) async {
+    await setWindowSize(tester, width: 579);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AdaptiveNavigationScaffold(
+          body: const SizedBox(),
+          destinations: destinations,
+          selectedIndex: 0,
+          onDestinationSelected: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.byType(NavigationBar), findsOneWidget);
+    expect(find.byType(NavigationRail), findsNothing);
+  });
+
+  testWidgets('uses navigation rail from 580 pixels', (tester) async {
+    await setWindowSize(tester, width: 580);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AdaptiveNavigationScaffold(
+          body: const SizedBox(),
+          destinations: destinations,
+          selectedIndex: 0,
+          onDestinationSelected: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.byType(NavigationRail), findsOneWidget);
+    expect(find.byType(NavigationBar), findsNothing);
+  });
+
+  testWidgets('caps the wide main frame at 660 pixels', (tester) async {
+    await setWindowSize(tester, width: 1000);
+    const bodyKey = Key('navigation-body');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AdaptiveNavigationScaffold(
+          body: const SizedBox(key: bodyKey),
+          destinations: destinations,
+          selectedIndex: 0,
+          onDestinationSelected: (_) {},
+        ),
+      ),
+    );
+
+    final railWidth = tester.getSize(find.byType(NavigationRail)).width;
+    expect(railWidth, greaterThanOrEqualTo(navigationRailMinWidth));
+    expect(
+      tester.getSize(find.byKey(bodyKey)).width,
+      lessThanOrEqualTo(contentMaxWidth),
+    );
+    expect(
+      tester.getSize(find.byType(Scaffold).first).width,
+      mainFrameMaxWidth,
+    );
+    expect(
+      tester.getTopLeft(find.byType(Scaffold).first).dx,
+      (1000 - mainFrameMaxWidth) / 2,
+    );
+  });
+
+  testWidgets('forwards destination selection', (tester) async {
+    await setWindowSize(tester, width: 579);
+    int? selectedIndex;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AdaptiveNavigationScaffold(
+          body: const SizedBox(),
+          destinations: destinations,
+          selectedIndex: 0,
+          onDestinationSelected: (index) => selectedIndex = index,
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Scores'));
+    await tester.pump();
+
+    expect(selectedIndex, 1);
+  });
+}

--- a/test/shells/adaptive_navigation_scaffold_test.dart
+++ b/test/shells/adaptive_navigation_scaffold_test.dart
@@ -104,7 +104,9 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: AdaptiveNavigationScaffold(
-          body: const SizedBox(key: bodyKey),
+          body: const CenteredMaxWidthFrame(
+            child: SizedBox(key: bodyKey),
+          ),
           destinations: destinations,
           selectedIndex: 0,
           onDestinationSelected: (_) {},


### PR DESCRIPTION
新增響應式導覽框架，依畫面寬度切換手機與寬螢幕版面。
- 窄螢幕維持原有底部導覽列
- 580px 以上的寬螢幕改用固定於左側的 Navigation Rail
- Rail 顯示 Logo、將導覽項目靠下排列，並配合目前主題背景
- 主要內容置中並限制最大寬度為 580px
- Login、變更密碼、About、註冊、Portal、Calendar 及 Kiosk QR 等獨立頁面套用相同限寬框架
- Intro 與 Scanner 等需要完整可用空間的頁面維持全螢幕
- Course detail modal 在寬螢幕下維持 580px 內容限寬，同時讓 modal 背景延伸至完整可用寬度
Rebase 後另外修正 Course detail sheet 被 Center 撐成全螢幕高度的問題；現在會維持底部對齊與內容所需高度，並新增 widget regression test。

<img width="500" alt="image" src="https://github.com/user-attachments/assets/5787e050-a248-43bc-811f-f6986bb13ff8" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/aa754759-d938-468e-b2d1-88bb4dac7b45" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/1c050291-7245-4e76-80df-1fe8e279f53f" />
