### PR TITLE
feat: move campus Wi-Fi button to home screen

### DIFF
--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -76,6 +76,7 @@ home:
     title: NTUT Programming Club
     description: If you have ideas or want to contribute, feel free to reach out anytime.
     url: https://ntut.club
+  campusWifi: Connect to Campus Wi-Fi
   vote:
     description: Student four-in-one democratic election voting is open. Come vote at Yida Corridor before 4:00 PM on 5/15.
 score:

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 604 (302 per locale)
+/// Strings: 606 (303 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -175,6 +175,7 @@ class _Translations$home$en_US extends Translations$home$zh_TW {
 	@override late final _Translations$home$projectTattoo$en_US projectTattoo = _Translations$home$projectTattoo$en_US._(_root);
 	@override late final _Translations$home$ideation$en_US ideation = _Translations$home$ideation$en_US._(_root);
 	@override late final _Translations$home$npcClub$en_US npcClub = _Translations$home$npcClub$en_US._(_root);
+	@override String get campusWifi => 'Connect to Campus Wi-Fi';
 	@override late final _Translations$home$vote$en_US vote = _Translations$home$vote$en_US._(_root);
 }
 
@@ -946,6 +947,7 @@ extension on TranslationsEnUs {
 			'home.npcClub.title' => 'NTUT Programming Club',
 			'home.npcClub.description' => 'If you have ideas or want to contribute, feel free to reach out anytime.',
 			'home.npcClub.url' => 'https://ntut.club',
+			'home.campusWifi' => 'Connect to Campus Wi-Fi',
 			'home.vote.description' => 'Student four-in-one democratic election voting is open. Come vote at Yida Corridor before 4:00 PM on 5/15.',
 			'score.loadFailed' => 'Failed to load scores',
 			'score.refreshFailed' => 'Failed to refresh scores',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -258,6 +258,10 @@ class Translations$home$zh_TW {
 	late final Translations$home$projectTattoo$zh_TW projectTattoo = Translations$home$projectTattoo$zh_TW.internal(_root);
 	late final Translations$home$ideation$zh_TW ideation = Translations$home$ideation$zh_TW.internal(_root);
 	late final Translations$home$npcClub$zh_TW npcClub = Translations$home$npcClub$zh_TW.internal(_root);
+
+	/// zh-TW: '連接校園Wi-Fi'
+	String get campusWifi => '連接校園Wi-Fi';
+
 	late final Translations$home$vote$zh_TW vote = Translations$home$vote$zh_TW.internal(_root);
 }
 
@@ -1501,6 +1505,7 @@ extension on Translations {
 			'home.npcClub.title' => '北科程式設計研究社',
 			'home.npcClub.description' => '有任何想法或是想加入開發，隨時歡迎聯絡我們！',
 			'home.npcClub.url' => 'https://ntut.club',
+			'home.campusWifi' => '連接校園Wi-Fi',
 			'home.vote.description' => '學生四合一民主選舉活動，5/15下午四點前來一大川堂投票吧！',
 			'score.loadFailed' => '成績載入失敗',
 			'score.refreshFailed' => '成績更新失敗',

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -76,6 +76,7 @@ home:
     title: 北科程式設計研究社
     description: 有任何想法或是想加入開發，隨時歡迎聯絡我們！
     url: https://ntut.club
+  campusWifi: 連接校園Wi-Fi
   vote:
     description: 學生四合一民主選舉活動，5/15下午四點前來一大川堂投票吧！
 score:

--- a/lib/screens/main/home/home_screen.dart
+++ b/lib/screens/main/home/home_screen.dart
@@ -3,7 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:tattoo/components/option_entry_tile.dart';
 import 'package:tattoo/i18n/strings.g.dart';
+import 'package:tattoo/repositories/preferences_repository.dart';
 import 'package:tattoo/router/app_router.dart';
+import 'package:tattoo/screens/main/profile/preference_providers.dart';
 import 'package:tattoo/services/update_service.dart';
 import 'package:tattoo/utils/auto_spacing.dart';
 import 'package:tattoo/utils/launch_url.dart';
@@ -122,6 +124,13 @@ class _MainHomeScreenState extends ConsumerState<MainHomeScreen> {
         title: t.nav.calendar,
         onTap: () => context.push(AppRoutes.calendar),
       ),
+      if (Theme.of(context).platform == TargetPlatform.android &&
+          ref.pref(PrefKey.showWifiButton))
+        OptionEntryTile.icon(
+          icon: Icons.wifi,
+          title: t.home.campusWifi.spaced,
+          onTap: () => context.push(AppRoutes.ntutWifi),
+        ),
     ];
 
     return Scaffold(

--- a/lib/screens/main/profile/profile_screen.dart
+++ b/lib/screens/main/profile/profile_screen.dart
@@ -9,9 +9,7 @@ import 'package:tattoo/components/option_entry_tile.dart';
 import 'package:tattoo/components/section_header.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/auth_repository.dart';
-import 'package:tattoo/repositories/preferences_repository.dart';
 import 'package:tattoo/router/app_router.dart';
-import 'package:tattoo/screens/main/profile/preference_providers.dart';
 import 'package:tattoo/screens/main/profile/profile_card.dart';
 import 'package:tattoo/screens/main/profile/profile_danger_zone.dart';
 import 'package:tattoo/utils/auto_spacing.dart';
@@ -103,14 +101,6 @@ class ProfileScreen extends ConsumerWidget {
         title: t.profile.options.changeAvatar,
         onTap: () => _changeAvatar(context, ref),
       ),
-      if (Theme.of(context).platform == TargetPlatform.android &&
-          ref.pref(PrefKey.showWifiButton))
-        OptionEntryTile.icon(
-          icon: Icons.wifi,
-          title: t.profile.options.ntutWifi,
-          description: t.ntutWifi.entryDescription,
-          onTap: () => context.push(AppRoutes.ntutWifi),
-        ),
 
       SectionHeader(title: 'TAT'),
       OptionEntryTile.icon(


### PR DESCRIPTION
Move the NTUT-802.1X entry tile from profile to home, rename it to「連接校園Wi-Fi」/「Connect to Campus Wi-Fi」, and drop the description.

### Changes
- **Removed** the campus Wi-Fi `OptionEntryTile` from `ProfileScreen`
- **Added** it to `MainHomeScreen` (Android-only, gated by `PrefKey.showWifiButton`, no description)
- **Added** `home.campusWifi` i18n key in both locales
- Regenerated slang `.g.dart` files