### PR TITLE
feat: handle iSchool Plus VPN exception and display connection warning

### DIFF
--- a/lib/i18n/en-US.i18n.yaml
+++ b/lib/i18n/en-US.i18n.yaml
@@ -20,6 +20,7 @@ errors:
   sessionExpired: Session expired. Please sign in again.
   credentialsInvalid: Credentials are no longer valid. Please sign in again.
   connectionFailed: Cannot connect to the server. Please check your network connection.
+  ischoolPlusVpnRequired: Cannot connect to iSchool Plus. Please connect to campus VPN when off-campus.
 intro:
   features:
     courseTable:

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 630 (315 per locale)
+/// Strings: 632 (316 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -96,6 +96,7 @@ class _Translations$errors$en_US extends Translations$errors$zh_TW {
 	@override String get sessionExpired => 'Session expired. Please sign in again.';
 	@override String get credentialsInvalid => 'Credentials are no longer valid. Please sign in again.';
 	@override String get connectionFailed => 'Cannot connect to the server. Please check your network connection.';
+	@override String get ischoolPlusVpnRequired => 'Cannot connect to iSchool Plus. Please connect to campus VPN when off-campus.';
 }
 
 // Path: intro
@@ -926,6 +927,7 @@ extension on TranslationsEnUs {
 			'errors.sessionExpired' => 'Session expired. Please sign in again.',
 			'errors.credentialsInvalid' => 'Credentials are no longer valid. Please sign in again.',
 			'errors.connectionFailed' => 'Cannot connect to the server. Please check your network connection.',
+			'errors.ischoolPlusVpnRequired' => 'Cannot connect to iSchool Plus. Please connect to campus VPN when off-campus.',
 			'intro.features.courseTable.title' => 'Courses',
 			'intro.features.courseTable.description' => 'Quickly view your course schedule and switch between semesters.',
 			'intro.features.scores.title' => 'Scores',

--- a/lib/i18n/strings_zh_TW.g.dart
+++ b/lib/i18n/strings_zh_TW.g.dart
@@ -137,6 +137,9 @@ class Translations$errors$zh_TW {
 
 	/// zh-TW: '無法連線到伺服器，請檢查網路連線'
 	String get connectionFailed => '無法連線到伺服器，請檢查網路連線';
+
+	/// zh-TW: '無法連線至北科i學園PLUS，校外連線請先開啟校園VPN'
+	String get ischoolPlusVpnRequired => '無法連線至北科i學園PLUS，校外連線請先開啟校園VPN';
 }
 
 // Path: intro
@@ -1509,6 +1512,7 @@ extension on Translations {
 			'errors.sessionExpired' => '登入狀態已過期，請重新登入',
 			'errors.credentialsInvalid' => '登入憑證已失效，請重新登入',
 			'errors.connectionFailed' => '無法連線到伺服器，請檢查網路連線',
+			'errors.ischoolPlusVpnRequired' => '無法連線至北科i學園PLUS，校外連線請先開啟校園VPN',
 			'intro.features.courseTable.title' => '查課表',
 			'intro.features.courseTable.description' => '快速查看課表和課程資訊，並可快速切換學期。',
 			'intro.features.scores.title' => '看成績',

--- a/lib/i18n/zh-TW.i18n.yaml
+++ b/lib/i18n/zh-TW.i18n.yaml
@@ -20,6 +20,7 @@ errors:
   sessionExpired: 登入狀態已過期，請重新登入
   credentialsInvalid: 登入憑證已失效，請重新登入
   connectionFailed: 無法連線到伺服器，請檢查網路連線
+  ischoolPlusVpnRequired: 無法連線至北科i學園PLUS，校外連線請先開啟校園VPN
 intro:
   features:
     courseTable:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -98,9 +98,12 @@ Future<void> main() async {
   }
 
   void showErrorSnackBar(Object error) {
-    final message = isNetworkError(error)
-        ? t.errors.networkError
-        : t.errors.unexpected;
+    final message = switch (error) {
+      _ when isISchoolPlusConnectionError(error) =>
+        t.errors.ischoolPlusVpnRequired,
+      _ when isNetworkError(error) => t.errors.networkError,
+      _ => t.errors.unexpected,
+    };
 
     rootScaffoldMessengerKey.currentState
       ?..hideCurrentSnackBar()

--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -376,9 +376,14 @@ class AuthRepository {
         if (e.error is SessionExpiredException) {
           Error.throwWithStackTrace(e.error!, e.stackTrace);
         }
+        if (e.error is ISchoolPlusVpnRequiredException) {
+          Error.throwWithStackTrace(e.error!, e.stackTrace);
+        }
         rethrow;
       }
     } on DioException {
+      rethrow;
+    } on ISchoolPlusVpnRequiredException {
       rethrow;
     } catch (_) {
       try {

--- a/lib/screens/main/portal/portal_screen.dart
+++ b/lib/screens/main/portal/portal_screen.dart
@@ -6,9 +6,11 @@ import 'package:tattoo/components/section_header.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/auth_repository.dart';
 import 'package:tattoo/repositories/portal_repository.dart';
+import 'package:tattoo/services/i_school_plus/i_school_plus_service.dart';
 import 'package:tattoo/utils/auto_spacing.dart';
 import 'package:tattoo/utils/launch_url.dart';
 import 'package:tattoo/utils/localized.dart';
+import 'package:tattoo/utils/network_error.dart';
 
 final _portalApplicationCatalogProvider = StreamProvider(
   (ref) => ref.watch(portalRepositoryProvider).watchApplicationCatalog(),
@@ -27,12 +29,22 @@ class PortalScreen extends ConsumerWidget {
         ref.read(authRepositoryProvider),
         serviceCode,
       );
-    } on DioException {
+    } on ISchoolPlusVpnRequiredException {
       if (!context.mounted) return;
       ScaffoldMessenger.of(context)
         ..hideCurrentSnackBar()
         ..showSnackBar(
-          SnackBar(content: Text(t.errors.connectionFailed)),
+          SnackBar(content: Text(t.errors.ischoolPlusVpnRequired)),
+        );
+    } on DioException catch (e) {
+      if (!context.mounted) return;
+      final message = isISchoolPlusConnectionError(e)
+          ? t.errors.ischoolPlusVpnRequired
+          : t.errors.connectionFailed;
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(content: Text(message)),
         );
     }
   }

--- a/lib/screens/main/scanner/scanner_screen.dart
+++ b/lib/screens/main/scanner/scanner_screen.dart
@@ -9,6 +9,7 @@ import 'package:tattoo/screens/main/scanner/scanner_guide_bottom_sheet.dart';
 import 'package:tattoo/services/portal/portal_service.dart';
 import 'package:tattoo/utils/auto_spacing.dart';
 import 'package:tattoo/utils/http.dart';
+import 'package:tattoo/utils/network_error.dart';
 
 class ScannerScreen extends ConsumerStatefulWidget {
   const ScannerScreen({super.key});
@@ -188,6 +189,9 @@ class _ScannerScreenState extends ConsumerState<ScannerScreen> {
         return '[${error.type}] $msg';
       }
       return '[${error.type}] ${t.scanner.errors['unknown']}';
+    }
+    if (isISchoolPlusConnectionError(error)) {
+      return t.errors.ischoolPlusVpnRequired;
     }
     return switch (error) {
       SessionExpiredException() => t.errors.sessionExpired,

--- a/lib/services/i_school_plus/i_school_plus_service.dart
+++ b/lib/services/i_school_plus/i_school_plus_service.dart
@@ -58,6 +58,22 @@ typedef MaterialDto = ({
   bool streamable,
 });
 
+/// Thrown when connection to iSchool+ (iStudy / istudy.ntut.edu.tw) fails,
+/// typically because the service is placed behind the campus VPN and unreachable
+/// from off-campus networks.
+class ISchoolPlusVpnRequiredException implements Exception {
+  final String message;
+  final Object? cause;
+
+  const ISchoolPlusVpnRequiredException([
+    this.message = 'ISchoolPlus connection failed (VPN required off-campus)',
+    this.cause,
+  ]);
+
+  @override
+  String toString() => 'ISchoolPlusVpnRequiredException: $message';
+}
+
 /// Provides the singleton [ISchoolPlusService] instance.
 final iSchoolPlusServiceProvider = Provider<ISchoolPlusService>((ref) {
   if (ref.watch(isDemoProvider)) {

--- a/lib/services/i_school_plus/ntut_i_school_plus_service.dart
+++ b/lib/services/i_school_plus/ntut_i_school_plus_service.dart
@@ -4,6 +4,7 @@ import 'package:dio_redirect_interceptor/dio_redirect_interceptor.dart';
 import 'package:html/parser.dart';
 import 'package:tattoo/services/i_school_plus/i_school_plus_service.dart';
 import 'package:tattoo/utils/http.dart';
+import 'package:tattoo/utils/network_error.dart';
 
 class NtutISchoolPlusService implements ISchoolPlusService {
   late final Dio _iSchoolPlusDio;
@@ -12,16 +13,46 @@ class NtutISchoolPlusService implements ISchoolPlusService {
   /// course switches.
   String? _selectedInternalId;
 
-  NtutISchoolPlusService() {
-    _iSchoolPlusDio = createDio()
-      ..options.baseUrl = 'https://istudy.ntut.edu.tw/learn/'
-      ..interceptors.insert(0, InvalidCookieFilter()) // Prepend cookie filter
-      ..interceptors.add(_SessionCheckInterceptor())
-      ..transformer = PlainTextTransformer();
+  NtutISchoolPlusService({Dio? dio}) {
+    _iSchoolPlusDio =
+        dio ??
+        (createDio()
+          ..options.baseUrl = 'https://istudy.ntut.edu.tw/learn/'
+          ..interceptors.insert(
+            0,
+            InvalidCookieFilter(),
+          ) // Prepend cookie filter
+          ..interceptors.add(_ISchoolPlusInterceptor())
+          ..transformer = PlainTextTransformer());
+  }
+
+  Future<T> _wrap<T>(Future<T> Function() action) async {
+    try {
+      return await action();
+    } on DioException catch (e) {
+      if (e.error is ISchoolPlusVpnRequiredException) {
+        Error.throwWithStackTrace(e.error!, e.stackTrace);
+      }
+      if (e.error is SessionExpiredException) {
+        Error.throwWithStackTrace(e.error!, e.stackTrace);
+      }
+      if (e.response?.statusCode == 403) {
+        throw const SessionExpiredException(
+          'ISchoolPlus session expired',
+        );
+      }
+      if (isNetworkError(e)) {
+        throw ISchoolPlusVpnRequiredException(
+          'ISchoolPlus connection failed (VPN required off-campus)',
+          e,
+        );
+      }
+      rethrow;
+    }
   }
 
   @override
-  Future<List<ISchoolCourseDto>> getCourseList() async {
+  Future<List<ISchoolCourseDto>> getCourseList() => _wrap(() async {
     final response = await _iSchoolPlusDio.get('mooc_sysbar.php');
 
     final document = parse(response.data);
@@ -48,7 +79,7 @@ class NtutISchoolPlusService implements ISchoolPlusService {
     }
 
     return courses;
-  }
+  });
 
   Future<void> _selectCourse(ISchoolCourseDto course) async {
     if (course.internalId == _selectedInternalId) return;
@@ -64,48 +95,56 @@ class NtutISchoolPlusService implements ISchoolPlusService {
   }
 
   @override
-  Future<List<StudentDto>> getStudents(ISchoolCourseDto course) async {
-    await _selectCourse(course);
+  Future<List<StudentDto>> getStudents(ISchoolCourseDto course) =>
+      _wrap(() async {
+        await _selectCourse(course);
 
-    final response = await _iSchoolPlusDio.get('learn_ranking.php');
+        final response = await _iSchoolPlusDio.get('learn_ranking.php');
 
-    // Parse the HTML and extract the table of student rankings
-    final document = parse(response.data);
-    final studyRankingsTable = document.querySelector('.content>.data2 tbody');
-    if (studyRankingsTable == null) {
-      throw Exception(
-        'No student data found for course ${course.courseNumber}.',
-      );
-    }
-
-    // Extract second column from each row for student ID and name
-    // Example cell: "111360109 (何承軒)"
-    final students = studyRankingsTable.children
-        .map((row) => row.children[1].children.first.text)
-        .toList();
-    if (students.isEmpty) {
-      throw Exception('No students found for course ${course.courseNumber}.');
-    }
-
-    return students
-        .map((student) {
-          final parts = student.split(' (');
-          final id = parts[0];
-          final name = parts[1].replaceAll(')', '').trim();
-
-          return (
-            id: id.isEmpty ? null : id,
-            name: name.isEmpty ? null : name,
+        // Parse the HTML and extract the table of student rankings
+        final document = parse(response.data);
+        final studyRankingsTable = document.querySelector(
+          '.content>.data2 tbody',
+        );
+        if (studyRankingsTable == null) {
+          throw Exception(
+            'No student data found for course ${course.courseNumber}.',
           );
-        })
-        .where(
-          (student) => student.id != 'istudyoaa', // Filter out system account
-        )
-        .toList();
-  }
+        }
+
+        // Extract second column from each row for student ID and name
+        // Example cell: "111360109 (何承軒)"
+        final students = studyRankingsTable.children
+            .map((row) => row.children[1].children.first.text)
+            .toList();
+        if (students.isEmpty) {
+          throw Exception(
+            'No students found for course ${course.courseNumber}.',
+          );
+        }
+
+        return students
+            .map((student) {
+              final parts = student.split(' (');
+              final id = parts[0];
+              final name = parts[1].replaceAll(')', '').trim();
+
+              return (
+                id: id.isEmpty ? null : id,
+                name: name.isEmpty ? null : name,
+              );
+            })
+            .where(
+              (student) =>
+                  student.id != 'istudyoaa', // Filter out system account
+            )
+            .toList();
+      });
 
   @override
-  Future<List<MaterialRefDto>> getMaterials(ISchoolCourseDto course) async {
+  Future<List<MaterialRefDto>> getMaterials(
+    ISchoolCourseDto course,
+  ) => _wrap(() async {
     await _selectCourse(course);
 
     // Fetch and parse the SCORM manifest XML for file listings
@@ -134,12 +173,12 @@ class NtutISchoolPlusService implements ISchoolPlusService {
         href: href,
       );
     }).toList();
-  }
+  });
 
   @override
   Future<MaterialDto> getMaterial(
     MaterialRefDto material,
-  ) async {
+  ) => _wrap(() async {
     await _selectCourse(material.course);
 
     // Step 1: Get launch.php to extract the course ID (cid)
@@ -257,21 +296,30 @@ class NtutISchoolPlusService implements ISchoolPlusService {
       referer: null,
       streamable: false,
     );
-  }
+  });
 }
 
-/// Detects expired sessions in ISchoolPlus responses.
+/// Detects expired sessions and VPN connection failures in ISchoolPlus responses.
 ///
 /// iSchool+ returns HTTP 403 when the session has expired, which Dio would
 /// normally surface as a [DioException]. This interceptor converts it to a
 /// [SessionExpiredException] so that [AuthRepository.withAuth] retries with
 /// re-authentication instead of treating it as a network error.
-class _SessionCheckInterceptor extends Interceptor {
+///
+/// Connection failures to iSchool+ (placed behind campus VPN) throw
+/// [ISchoolPlusVpnRequiredException].
+class _ISchoolPlusInterceptor extends Interceptor {
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) {
     if (err.response?.statusCode == 403) {
       throw const SessionExpiredException(
         'ISchoolPlus session expired',
+      );
+    }
+    if (isNetworkError(err)) {
+      throw ISchoolPlusVpnRequiredException(
+        'ISchoolPlus connection failed (VPN required off-campus)',
+        err,
       );
     }
     handler.next(err);

--- a/lib/services/portal/ntut_portal_service.dart
+++ b/lib/services/portal/ntut_portal_service.dart
@@ -11,6 +11,8 @@ import 'package:tattoo/models/login_exception.dart';
 import 'package:tattoo/services/portal/portal_service.dart';
 import 'package:tattoo/utils/http.dart';
 
+import 'package:tattoo/utils/network_error.dart';
+
 typedef _PortalApplicationPageDto = ({
   String code,
   String name,
@@ -39,16 +41,18 @@ class NtutPortalService implements PortalService {
   Future<void> _portalLocaleOperation = Future.value();
   bool _portalLocaleStateUncertain = false;
 
-  NtutPortalService() {
+  NtutPortalService({Dio? dio}) {
     // Emulate the NTUT iOS app's HTTP client
-    _portalDio = createDio()
-      ..options.baseUrl = 'https://app.ntut.edu.tw/'
-      ..options.headers = {
-        'User-Agent': 'Direk ios App',
-        // Prevent keep-alive connection reuse — NTUT servers close their end
-        // after multipart uploads, causing stale connection errors.
-        'Connection': 'close',
-      };
+    _portalDio =
+        dio ??
+        (createDio()
+          ..options.baseUrl = 'https://app.ntut.edu.tw/'
+          ..options.headers = {
+            'User-Agent': 'Direk ios App',
+            // Prevent keep-alive connection reuse — NTUT servers close their end
+            // after multipart uploads, causing stale connection errors.
+            'Connection': 'close',
+          });
   }
 
   @override
@@ -183,11 +187,22 @@ class NtutPortalService implements PortalService {
 
       // Submit the SSO form and follow redirects
       // Sets the necessary cookies for the target service
-      await _portalDio.post(
-        actionUrl,
-        data: formData,
-        options: Options(contentType: Headers.formUrlEncodedContentType),
-      );
+      try {
+        await _portalDio.post(
+          actionUrl,
+          data: formData,
+          options: Options(contentType: Headers.formUrlEncodedContentType),
+        );
+      } on DioException catch (e) {
+        if (serviceCode == PortalServiceCode.iSchoolPlusService.code &&
+            isISchoolPlusConnectionError(e)) {
+          throw ISchoolPlusVpnRequiredException(
+            'ISchoolPlus SSO connection failed (VPN required off-campus)',
+            e,
+          );
+        }
+        rethrow;
+      }
     });
   }
 
@@ -203,27 +218,38 @@ class NtutPortalService implements PortalService {
           (interceptor) => interceptor is RedirectInterceptor,
         );
 
-      final response = await dioWithoutRedirects.post(
-        actionUrl,
-        data: formData,
-        options: Options(
-          contentType: Headers.formUrlEncodedContentType,
-          followRedirects: false,
-          validateStatus: (status) => status != null && status < 400,
-        ),
-      );
+      try {
+        final response = await dioWithoutRedirects.post(
+          actionUrl,
+          data: formData,
+          options: Options(
+            contentType: Headers.formUrlEncodedContentType,
+            followRedirects: false,
+            validateStatus: (status) => status != null && status < 400,
+          ),
+        );
 
-      final location = response.headers.value('location');
-      if (location == null) {
-        throw Exception('SSO redirect not received. Are you logged in?');
-      }
+        final location = response.headers.value('location');
+        if (location == null) {
+          throw Exception('SSO redirect not received. Are you logged in?');
+        }
 
-      // The portal may return http:// URLs; upgrade to https://
-      var uri = Uri.parse(location);
-      if (uri.scheme == 'http') {
-        uri = uri.replace(scheme: 'https');
+        // The portal may return http:// URLs; upgrade to https://
+        var uri = Uri.parse(location);
+        if (uri.scheme == 'http') {
+          uri = uri.replace(scheme: 'https');
+        }
+        return uri;
+      } on DioException catch (e) {
+        if (serviceCode == PortalServiceCode.iSchoolPlusService.code &&
+            isISchoolPlusConnectionError(e)) {
+          throw ISchoolPlusVpnRequiredException(
+            'ISchoolPlus SSO connection failed (VPN required off-campus)',
+            e,
+          );
+        }
+        rethrow;
       }
-      return uri;
     });
   }
 

--- a/lib/utils/http.dart
+++ b/lib/utils/http.dart
@@ -12,6 +12,8 @@ import 'package:native_dio_adapter/native_dio_adapter.dart';
 import 'package:tattoo/services/firebase_service.dart';
 
 export 'package:dio/dio.dart';
+export 'package:tattoo/services/i_school_plus/i_school_plus_service.dart'
+    show ISchoolPlusVpnRequiredException;
 
 /// Thrown when an NTUT service returns a success response but the content
 /// indicates the session has expired (e.g., a redirect page instead of data).

--- a/lib/utils/network_error.dart
+++ b/lib/utils/network_error.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:tattoo/services/i_school_plus/i_school_plus_service.dart';
 import 'package:tattoo/utils/network_error_stub.dart'
     if (dart.library.io) 'package:tattoo/utils/network_error_io.dart';
 
@@ -6,4 +7,18 @@ import 'package:tattoo/utils/network_error_stub.dart'
 bool isNetworkError(Object error) {
   if (error is DioException) return true;
   return isNativeNetworkError(error);
+}
+
+/// Determines whether an error is caused by iSchool+ / iStudy connection
+/// failure (e.g. unreachable due to campus VPN requirement).
+bool isISchoolPlusConnectionError(Object error) {
+  if (error is ISchoolPlusVpnRequiredException) return true;
+  if (error is DioException) {
+    if (error.error is ISchoolPlusVpnRequiredException) return true;
+    final uri = error.requestOptions.uri;
+    if (uri.host.contains('istudy.ntut.edu.tw') && isNetworkError(error)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/test/repositories/auth_repository_test.dart
+++ b/test/repositories/auth_repository_test.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
@@ -6,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 import 'package:tattoo/database/database.dart';
 import 'package:tattoo/repositories/auth_repository.dart';
+import 'package:tattoo/services/i_school_plus/i_school_plus_service.dart';
 import 'package:tattoo/services/portal/mock_portal_service.dart';
 import 'package:tattoo/services/portal/portal_service.dart';
 import 'package:tattoo/services/student_query/mock_student_query_service.dart';
@@ -140,6 +142,45 @@ void main() {
         );
         expect(secureStorage['username'], '111360109');
         expect(secureStorage['password'], 'password');
+      },
+    );
+
+    test(
+      'withAuth rethrows ISchoolPlusVpnRequiredException without re-authenticating',
+      () async {
+        await repository.login('111360109', 'password');
+        final initialLoginCount = portalService.loginCalls.length;
+
+        expect(
+          () => repository.withAuth(() async {
+            throw const ISchoolPlusVpnRequiredException('VPN required');
+          }),
+          throwsA(isA<ISchoolPlusVpnRequiredException>()),
+        );
+
+        expect(portalService.loginCalls.length, initialLoginCount);
+      },
+    );
+
+    test(
+      'withAuth unwraps DioException wrapping ISchoolPlusVpnRequiredException',
+      () async {
+        await repository.login('111360109', 'password');
+        final initialLoginCount = portalService.loginCalls.length;
+
+        expect(
+          () => repository.withAuth(() async {
+            throw DioException(
+              requestOptions: RequestOptions(
+                path: 'https://istudy.ntut.edu.tw',
+              ),
+              error: const ISchoolPlusVpnRequiredException('VPN required'),
+            );
+          }),
+          throwsA(isA<ISchoolPlusVpnRequiredException>()),
+        );
+
+        expect(portalService.loginCalls.length, initialLoginCount);
       },
     );
   });

--- a/test/services/ntut_i_school_plus_service_test.dart
+++ b/test/services/ntut_i_school_plus_service_test.dart
@@ -1,0 +1,145 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tattoo/services/i_school_plus/ntut_i_school_plus_service.dart';
+import 'package:tattoo/utils/http.dart';
+
+void main() {
+  group('NtutISchoolPlusService Error Handling', () {
+    test(
+      'getCourseList throws ISchoolPlusVpnRequiredException on connection error',
+      () async {
+        final dio = Dio()
+          ..httpClientAdapter = _FailingAdapter(
+            error: const SocketException('Connection refused / VPN required'),
+            type: DioExceptionType.connectionError,
+          );
+
+        final service = NtutISchoolPlusService(dio: dio);
+
+        expect(
+          () => service.getCourseList(),
+          throwsA(isA<ISchoolPlusVpnRequiredException>()),
+        );
+      },
+    );
+
+    test(
+      'getCourseList throws SessionExpiredException on 403 response',
+      () async {
+        final dio = Dio()
+          ..httpClientAdapter = _FailingAdapter(
+            statusCode: 403,
+            type: DioExceptionType.badResponse,
+          );
+
+        final service = NtutISchoolPlusService(dio: dio);
+
+        expect(
+          () => service.getCourseList(),
+          throwsA(isA<SessionExpiredException>()),
+        );
+      },
+    );
+
+    test(
+      'getStudents throws ISchoolPlusVpnRequiredException on timeout',
+      () async {
+        final dio = Dio()
+          ..httpClientAdapter = _FailingAdapter(
+            type: DioExceptionType.connectionTimeout,
+          );
+
+        final service = NtutISchoolPlusService(dio: dio);
+
+        expect(
+          () => service.getStudents((
+            courseNumber: '352902',
+            internalId: '10099386',
+          )),
+          throwsA(isA<ISchoolPlusVpnRequiredException>()),
+        );
+      },
+    );
+
+    test(
+      'getMaterials throws ISchoolPlusVpnRequiredException on network failure',
+      () async {
+        final dio = Dio()
+          ..httpClientAdapter = _FailingAdapter(
+            error: const SocketException('Failed host lookup'),
+            type: DioExceptionType.connectionError,
+          );
+
+        final service = NtutISchoolPlusService(dio: dio);
+
+        expect(
+          () => service.getMaterials((
+            courseNumber: '352902',
+            internalId: '10099386',
+          )),
+          throwsA(isA<ISchoolPlusVpnRequiredException>()),
+        );
+      },
+    );
+
+    test(
+      'getMaterial throws ISchoolPlusVpnRequiredException on network failure',
+      () async {
+        final dio = Dio()
+          ..httpClientAdapter = _FailingAdapter(
+            type: DioExceptionType.receiveTimeout,
+          );
+
+        final service = NtutISchoolPlusService(dio: dio);
+
+        expect(
+          () => service.getMaterial((
+            course: (courseNumber: '352902', internalId: '10099386'),
+            title: 'Slide 1',
+            href: 'res01',
+          )),
+          throwsA(isA<ISchoolPlusVpnRequiredException>()),
+        );
+      },
+    );
+  });
+}
+
+class _FailingAdapter implements HttpClientAdapter {
+  final Object? error;
+  final int? statusCode;
+  final DioExceptionType type;
+
+  _FailingAdapter({
+    this.error,
+    this.statusCode,
+    this.type = DioExceptionType.unknown,
+  });
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (statusCode != null) {
+      return ResponseBody.fromString(
+        'Forbidden',
+        statusCode!,
+        headers: {
+          Headers.contentTypeHeader: [Headers.textPlainContentType],
+        },
+      );
+    }
+    throw DioException(
+      requestOptions: options,
+      error: error,
+      type: type,
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/test/services/ntut_portal_service_sso_vpn_test.dart
+++ b/test/services/ntut_portal_service_sso_vpn_test.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tattoo/services/i_school_plus/i_school_plus_service.dart';
+import 'package:tattoo/services/portal/ntut_portal_service.dart';
+import 'package:tattoo/services/portal/portal_service.dart';
+
+void main() {
+  group('NtutPortalService SSO ISchoolPlus VPN Handling', () {
+    test(
+      'sso throws ISchoolPlusVpnRequiredException when iStudy connection fails',
+      () async {
+        final dio = Dio()
+          ..httpClientAdapter = _SsoFailingAdapter(
+            serviceCode: PortalServiceCode.iSchoolPlusService.code,
+          );
+
+        final portalService = NtutPortalService(dio: dio);
+
+        expect(
+          () => portalService.sso(PortalServiceCode.iSchoolPlusService.code),
+          throwsA(isA<ISchoolPlusVpnRequiredException>()),
+        );
+      },
+    );
+
+    test(
+      'getSsoUrl throws ISchoolPlusVpnRequiredException when iStudy connection fails',
+      () async {
+        final dio = Dio()
+          ..httpClientAdapter = _SsoFailingAdapter(
+            serviceCode: PortalServiceCode.iSchoolPlusService.code,
+          );
+
+        final portalService = NtutPortalService(dio: dio);
+
+        expect(
+          () => portalService.getSsoUrl(
+            PortalServiceCode.iSchoolPlusService.code,
+          ),
+          throwsA(isA<ISchoolPlusVpnRequiredException>()),
+        );
+      },
+    );
+  });
+}
+
+class _SsoFailingAdapter implements HttpClientAdapter {
+  final String serviceCode;
+
+  _SsoFailingAdapter({required this.serviceCode});
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    // 1. Return valid SSO form for ssoIndex.do
+    if (options.path.contains('ssoIndex.do')) {
+      const html = '''
+<html>
+  <body>
+    <form name="ssoForm" action="https://istudy.ntut.edu.tw/oauth/login" method="POST">
+      <input type="hidden" name="token" value="abc123xyz" />
+    </form>
+  </body>
+</html>
+''';
+      return ResponseBody.fromString(
+        html,
+        200,
+        headers: {
+          Headers.contentTypeHeader: ['text/html'],
+        },
+      );
+    }
+
+    // 2. Post to istudy.ntut.edu.tw fails with connection error (VPN required)
+    if (options.uri.host.contains('istudy.ntut.edu.tw')) {
+      throw DioException(
+        requestOptions: options,
+        error: const SocketException('Connection refused / VPN required'),
+        type: DioExceptionType.connectionError,
+      );
+    }
+
+    throw DioException(
+      requestOptions: options,
+      error: 'Unexpected request: ${options.uri}',
+      type: DioExceptionType.unknown,
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/test/utils/network_error_test.dart
+++ b/test/utils/network_error_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tattoo/services/i_school_plus/i_school_plus_service.dart';
 import 'package:tattoo/utils/network_error.dart';
 import 'package:tattoo/utils/network_error_stub.dart' as stub;
 
@@ -41,6 +42,55 @@ void main() {
       expect(isNetworkError(StateError('invalid state')), isFalse);
       expect(isNetworkError(FormatException('invalid format')), isFalse);
       expect(isNetworkError('error string'), isFalse);
+    });
+  });
+
+  group('isISchoolPlusConnectionError', () {
+    test('identifies ISchoolPlusVpnRequiredException', () {
+      expect(
+        isISchoolPlusConnectionError(const ISchoolPlusVpnRequiredException()),
+        isTrue,
+      );
+    });
+
+    test(
+      'identifies DioException wrapping ISchoolPlusVpnRequiredException',
+      () {
+        final dioError = DioException(
+          requestOptions: RequestOptions(path: 'https://example.com'),
+          error: const ISchoolPlusVpnRequiredException(),
+        );
+        expect(isISchoolPlusConnectionError(dioError), isTrue);
+      },
+    );
+
+    test('identifies DioException targeting istudy.ntut.edu.tw', () {
+      final dioError = DioException(
+        requestOptions: RequestOptions(
+          path: 'https://istudy.ntut.edu.tw/learn/mooc_sysbar.php',
+        ),
+        type: DioExceptionType.connectionTimeout,
+      );
+      expect(isISchoolPlusConnectionError(dioError), isTrue);
+    });
+
+    test('returns false for DioException targeting other hosts', () {
+      final dioError = DioException(
+        requestOptions: RequestOptions(path: 'https://example.com/test'),
+        type: DioExceptionType.connectionTimeout,
+      );
+      expect(isISchoolPlusConnectionError(dioError), isFalse);
+    });
+
+    test('returns false for generic errors', () {
+      expect(
+        isISchoolPlusConnectionError(Exception('something failed')),
+        isFalse,
+      );
+      expect(
+        isISchoolPlusConnectionError(const SocketException('err')),
+        isFalse,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
When accessing i-Study (iSchool+) from outside the campus network without VPN, requests fail due to connection/timeout errors rather than authentication failures. This PR introduces proper exception handling for iSchool+ VPN requirements across the service and presentation layers.

## Key Changes
- **Service & Repository Layers**:
  - Introduced `ISchoolPlusVpnRequiredException` to represent unreachable iStudy / iSchool+ network states.
  - Wrapped `NtutISchoolPlusService` and `NtutPortalService` SSO requests targeting `istudy.ntut.edu.tw` to translate network/connection failures into `ISchoolPlusVpnRequiredException`.
  - Updated `AuthRepository.withAuth` to rethrow `ISchoolPlusVpnRequiredException` (and wrapped `DioException`) directly instead of incorrectly treating connection failures as session expirations or attempting redundant re-authentication.
- **Error Presentation & i18n**:
  - Added localized error messages (`errors.ischoolPlusVpnRequired`) in `zh-TW` and `en-US` explaining that i-Study requires campus network or VPN connection.
  - Handled `isISchoolPlusConnectionError` in global error mapping (`main.dart`) and added snackbar presentations on `PortalScreen` and `ScannerScreen`.
- **Unit Tests**:
  - `test/services/ntut_i_school_plus_service_test.dart`: Verifies network/timeout errors throw `ISchoolPlusVpnRequiredException`.
  - `test/services/ntut_portal_service_sso_vpn_test.dart`: Verifies portal SSO flow detects iStudy connection failure and throws `ISchoolPlusVpnRequiredException`.
  - `test/utils/network_error_test.dart`: Verifies `isISchoolPlusConnectionError` identification.
  - `test/repositories/auth_repository_test.dart`: Verifies `withAuth` passes through VPN required exceptions without re-authenticating.