### PR TITLE
feat: control app features via Remote Config preferences

### DIFF
--- a/lib/repositories/preferences_repository.dart
+++ b/lib/repositories/preferences_repository.dart
@@ -34,14 +34,35 @@ enum PrefKey<T> {
   /// Whether the Weblate button is shown on the about page.
   showWeblateButton<bool>(.boolean, false),
 
-  /// Whether the Wi-Fi auto-connect button is shown on the profile screen.
+  /// Whether the Wi-Fi auto-connect button is shown on the home screen.
   showWifiButton<bool>(.boolean, false),
 
   /// Whether to show the detailed error dialog on uncaught exceptions.
   ///
   /// Defaults to `kDebugMode` (true in debug, false in release). Can be
   /// overridden via the regedit screen or Remote Config for on-device debugging.
-  showErrorDialog<bool>(.boolean, kDebugMode);
+  showErrorDialog<bool>(.boolean, kDebugMode),
+
+  /// Whether the next course schedule carousel is shown on the home screen.
+  showCourseSchedule<bool>(.boolean, true),
+
+  /// Whether the vote / kiosk login button is shown on the home screen.
+  showVoteButton<bool>(.boolean, false),
+
+  /// Whether the iStudy QR scanner button is shown on the home screen.
+  showScannerButton<bool>(.boolean, true),
+
+  /// Whether the portal entry button is shown on the home screen.
+  showPortalButton<bool>(.boolean, true),
+
+  /// Whether the academic calendar button is shown on the home screen.
+  showCalendarButton<bool>(.boolean, true),
+
+  /// Whether the change password button is shown on the profile screen.
+  showChangePasswordButton<bool>(.boolean, true),
+
+  /// Whether the change avatar button is shown on the profile screen.
+  showChangeAvatarButton<bool>(.boolean, true);
 
   const PrefKey(this.type, this.defaultValue);
   final PrefType type;

--- a/lib/screens/main/home/home_screen.dart
+++ b/lib/screens/main/home/home_screen.dart
@@ -225,31 +225,31 @@ class _MainHomeScreenState extends ConsumerState<MainHomeScreen> {
         description: t.home.npcClub.description,
         onTap: () => launchUrl(.parse(t.home.npcClub.url)),
       ),
-      ...(_showVoteEntry()
-          ? <Widget>[
-              OptionEntryTile.icon(
-                icon: Icons.how_to_vote_outlined,
-                title: t.nav.vote,
-                description: t.home.vote.description.spaced,
-                onTap: () => context.push(AppRoutes.kioskLoginQr),
-              ),
-            ]
-          : <Widget>[]),
-      OptionEntryTile.icon(
-        icon: Icons.qr_code_scanner,
-        title: t.scanner.loginIStudy.spaced,
-        onTap: () => context.push(AppRoutes.scanner),
-      ),
-      OptionEntryTile.icon(
-        icon: Icons.switch_access_shortcut_outlined,
-        title: t.nav.portal,
-        onTap: () => context.push(AppRoutes.portal),
-      ),
-      OptionEntryTile.icon(
-        icon: Icons.calendar_month,
-        title: t.nav.calendar,
-        onTap: () => context.push(AppRoutes.calendar),
-      ),
+      if (ref.pref(PrefKey.showVoteButton))
+        OptionEntryTile.icon(
+          icon: Icons.how_to_vote_outlined,
+          title: t.nav.vote,
+          description: t.home.vote.description.spaced,
+          onTap: () => context.push(AppRoutes.kioskLoginQr),
+        ),
+      if (ref.pref(PrefKey.showScannerButton))
+        OptionEntryTile.icon(
+          icon: Icons.qr_code_scanner,
+          title: t.scanner.loginIStudy.spaced,
+          onTap: () => context.push(AppRoutes.scanner),
+        ),
+      if (ref.pref(PrefKey.showPortalButton))
+        OptionEntryTile.icon(
+          icon: Icons.switch_access_shortcut_outlined,
+          title: t.nav.portal,
+          onTap: () => context.push(AppRoutes.portal),
+        ),
+      if (ref.pref(PrefKey.showCalendarButton))
+        OptionEntryTile.icon(
+          icon: Icons.calendar_month,
+          title: t.nav.calendar,
+          onTap: () => context.push(AppRoutes.calendar),
+        ),
       if (Theme.of(context).platform == TargetPlatform.android &&
           ref.pref(PrefKey.showWifiButton))
         OptionEntryTile.icon(
@@ -269,33 +269,34 @@ class _MainHomeScreenState extends ConsumerState<MainHomeScreen> {
                 child: Column(
                   spacing: 16,
                   children: [
-                    NextCourseCarousel(
-                      key: ValueKey(displayedDate),
-                      courses: courses,
-                      initialCourseIndex: initialCourseIndex,
-                      loading: isCourseScheduleLoading,
-                      error: hasCourseScheduleError,
-                      onRetry: () => _retryCourseSchedule(latestSemesterId),
-                      onPreviousDate: () => _showAdjacentCourseDate(
-                        courseTable,
-                        semesterDateRange,
-                        displayedDate,
-                        today,
-                        .previous,
+                    if (ref.pref(PrefKey.showCourseSchedule))
+                      NextCourseCarousel(
+                        key: ValueKey(displayedDate),
+                        courses: courses,
+                        initialCourseIndex: initialCourseIndex,
+                        loading: isCourseScheduleLoading,
+                        error: hasCourseScheduleError,
+                        onRetry: () => _retryCourseSchedule(latestSemesterId),
+                        onPreviousDate: () => _showAdjacentCourseDate(
+                          courseTable,
+                          semesterDateRange,
+                          displayedDate,
+                          today,
+                          .previous,
+                        ),
+                        onNextDate: () => _showAdjacentCourseDate(
+                          courseTable,
+                          semesterDateRange,
+                          displayedDate,
+                          today,
+                          .next,
+                        ),
+                        onCourseTap: (course) {
+                          if (course.courseNumber case final number?) {
+                            showCourseTableDetailSheet(context, number: number);
+                          }
+                        },
                       ),
-                      onNextDate: () => _showAdjacentCourseDate(
-                        courseTable,
-                        semesterDateRange,
-                        displayedDate,
-                        today,
-                        .next,
-                      ),
-                      onCourseTap: (course) {
-                        if (course.courseNumber case final number?) {
-                          showCourseTableDetailSheet(context, number: number);
-                        }
-                      },
-                    ),
                     Column(
                       spacing: 8,
                       children: options,
@@ -365,8 +366,3 @@ String _courseDateLabel(DateTime date, {required DateTime today}) {
 String _formatTime(DateTime time) =>
     '${time.hour.toString().padLeft(2, '0')}:'
     '${time.minute.toString().padLeft(2, '0')}';
-
-bool _showVoteEntry() => DateTime.now()
-    .toUtc()
-    .add(const Duration(hours: 8))
-    .isBefore(.utc(2026, 5, 16));

--- a/lib/screens/main/home/home_screen.dart
+++ b/lib/screens/main/home/home_screen.dart
@@ -26,8 +26,6 @@ class MainHomeScreen extends ConsumerStatefulWidget {
 
 class _MainHomeScreenState extends ConsumerState<MainHomeScreen> {
   bool _updateSnackbarCheckScheduled = false;
-  DateTime? _selectedDate;
-  DateTime? _selectionDay;
 
   @override
   void initState() {
@@ -81,6 +79,105 @@ class _MainHomeScreenState extends ConsumerState<MainHomeScreen> {
       ),
     );
   }
+
+  @override
+  Widget build(BuildContext context) {
+    final options = [
+      OptionEntryTile.svg(
+        svgIconAsset: "assets/tat_icon.svg",
+        actionIcon: .exitToApp,
+        title: t.home.projectTattoo.title.spaced,
+        description: t.home.projectTattoo.description,
+        onTap: () => launchUrl(.parse(t.home.projectTattoo.url)),
+      ),
+      OptionEntryTile.icon(
+        icon: Icons.explore_outlined,
+        actionIcon: .exitToApp,
+        title: t.home.ideation.title.spaced,
+        description: t.home.ideation.description,
+        onTap: () => launchUrl(
+          .parse(t.home.ideation.url),
+        ),
+      ),
+      OptionEntryTile.svg(
+        svgIconAsset: "assets/npc_logo.svg",
+        actionIcon: .exitToApp,
+        title: t.home.npcClub.title,
+        description: t.home.npcClub.description,
+        onTap: () => launchUrl(.parse(t.home.npcClub.url)),
+      ),
+      if (ref.pref(PrefKey.showVoteButton))
+        OptionEntryTile.icon(
+          icon: Icons.how_to_vote_outlined,
+          title: t.nav.vote,
+          description: t.home.vote.description.spaced,
+          onTap: () => context.push(AppRoutes.kioskLoginQr),
+        ),
+      if (ref.pref(PrefKey.showScannerButton))
+        OptionEntryTile.icon(
+          icon: Icons.qr_code_scanner,
+          title: t.scanner.loginIStudy.spaced,
+          onTap: () => context.push(AppRoutes.scanner),
+        ),
+      if (ref.pref(PrefKey.showPortalButton))
+        OptionEntryTile.icon(
+          icon: Icons.switch_access_shortcut_outlined,
+          title: t.nav.portal,
+          onTap: () => context.push(AppRoutes.portal),
+        ),
+      if (ref.pref(PrefKey.showCalendarButton))
+        OptionEntryTile.icon(
+          icon: Icons.calendar_month,
+          title: t.nav.calendar,
+          onTap: () => context.push(AppRoutes.calendar),
+        ),
+      if (Theme.of(context).platform == TargetPlatform.android &&
+          ref.pref(PrefKey.showWifiButton))
+        OptionEntryTile.icon(
+          icon: Icons.wifi,
+          title: t.home.campusWifi.spaced,
+          onTap: () => context.push(AppRoutes.ntutWifi),
+        ),
+    ];
+
+    return Scaffold(
+      body: SafeArea(
+        child: CustomScrollView(
+          slivers: [
+            SliverPadding(
+              padding: const .all(16),
+              sliver: SliverToBoxAdapter(
+                child: Column(
+                  spacing: 16,
+                  children: [
+                    if (ref.pref(PrefKey.showCourseSchedule))
+                      const _HomeCourseSchedule(),
+                    Column(
+                      spacing: 8,
+                      children: options,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeCourseSchedule extends ConsumerStatefulWidget {
+  const _HomeCourseSchedule();
+
+  @override
+  ConsumerState<_HomeCourseSchedule> createState() =>
+      _HomeCourseScheduleState();
+}
+
+class _HomeCourseScheduleState extends ConsumerState<_HomeCourseSchedule> {
+  DateTime? _selectedDate;
+  DateTime? _selectionDay;
 
   void _showAdjacentCourseDate(
     CourseTableData? courseTable,
@@ -201,113 +298,33 @@ class _MainHomeScreenState extends ConsumerState<MainHomeScreen> {
         preferredTodayCourseIndex(meetings, now: now),
       (false, _) => 0,
     };
-    final options = [
-      OptionEntryTile.svg(
-        svgIconAsset: "assets/tat_icon.svg",
-        actionIcon: .exitToApp,
-        title: t.home.projectTattoo.title.spaced,
-        description: t.home.projectTattoo.description,
-        onTap: () => launchUrl(.parse(t.home.projectTattoo.url)),
-      ),
-      OptionEntryTile.icon(
-        icon: Icons.explore_outlined,
-        actionIcon: .exitToApp,
-        title: t.home.ideation.title.spaced,
-        description: t.home.ideation.description,
-        onTap: () => launchUrl(
-          .parse(t.home.ideation.url),
-        ),
-      ),
-      OptionEntryTile.svg(
-        svgIconAsset: "assets/npc_logo.svg",
-        actionIcon: .exitToApp,
-        title: t.home.npcClub.title,
-        description: t.home.npcClub.description,
-        onTap: () => launchUrl(.parse(t.home.npcClub.url)),
-      ),
-      if (ref.pref(PrefKey.showVoteButton))
-        OptionEntryTile.icon(
-          icon: Icons.how_to_vote_outlined,
-          title: t.nav.vote,
-          description: t.home.vote.description.spaced,
-          onTap: () => context.push(AppRoutes.kioskLoginQr),
-        ),
-      if (ref.pref(PrefKey.showScannerButton))
-        OptionEntryTile.icon(
-          icon: Icons.qr_code_scanner,
-          title: t.scanner.loginIStudy.spaced,
-          onTap: () => context.push(AppRoutes.scanner),
-        ),
-      if (ref.pref(PrefKey.showPortalButton))
-        OptionEntryTile.icon(
-          icon: Icons.switch_access_shortcut_outlined,
-          title: t.nav.portal,
-          onTap: () => context.push(AppRoutes.portal),
-        ),
-      if (ref.pref(PrefKey.showCalendarButton))
-        OptionEntryTile.icon(
-          icon: Icons.calendar_month,
-          title: t.nav.calendar,
-          onTap: () => context.push(AppRoutes.calendar),
-        ),
-      if (Theme.of(context).platform == TargetPlatform.android &&
-          ref.pref(PrefKey.showWifiButton))
-        OptionEntryTile.icon(
-          icon: Icons.wifi,
-          title: t.home.campusWifi.spaced,
-          onTap: () => context.push(AppRoutes.ntutWifi),
-        ),
-    ];
 
-    return Scaffold(
-      body: SafeArea(
-        child: CustomScrollView(
-          slivers: [
-            SliverPadding(
-              padding: const .all(16),
-              sliver: SliverToBoxAdapter(
-                child: Column(
-                  spacing: 16,
-                  children: [
-                    if (ref.pref(PrefKey.showCourseSchedule))
-                      NextCourseCarousel(
-                        key: ValueKey(displayedDate),
-                        courses: courses,
-                        initialCourseIndex: initialCourseIndex,
-                        loading: isCourseScheduleLoading,
-                        error: hasCourseScheduleError,
-                        onRetry: () => _retryCourseSchedule(latestSemesterId),
-                        onPreviousDate: () => _showAdjacentCourseDate(
-                          courseTable,
-                          semesterDateRange,
-                          displayedDate,
-                          today,
-                          .previous,
-                        ),
-                        onNextDate: () => _showAdjacentCourseDate(
-                          courseTable,
-                          semesterDateRange,
-                          displayedDate,
-                          today,
-                          .next,
-                        ),
-                        onCourseTap: (course) {
-                          if (course.courseNumber case final number?) {
-                            showCourseTableDetailSheet(context, number: number);
-                          }
-                        },
-                      ),
-                    Column(
-                      spacing: 8,
-                      children: options,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ],
-        ),
+    return NextCourseCarousel(
+      key: ValueKey(displayedDate),
+      courses: courses,
+      initialCourseIndex: initialCourseIndex,
+      loading: isCourseScheduleLoading,
+      error: hasCourseScheduleError,
+      onRetry: () => _retryCourseSchedule(latestSemesterId),
+      onPreviousDate: () => _showAdjacentCourseDate(
+        courseTable,
+        semesterDateRange,
+        displayedDate,
+        today,
+        .previous,
       ),
+      onNextDate: () => _showAdjacentCourseDate(
+        courseTable,
+        semesterDateRange,
+        displayedDate,
+        today,
+        .next,
+      ),
+      onCourseTap: (course) {
+        if (course.courseNumber case final number?) {
+          showCourseTableDetailSheet(context, number: number);
+        }
+      },
     );
   }
 }

--- a/lib/screens/main/profile/about_screen.dart
+++ b/lib/screens/main/profile/about_screen.dart
@@ -66,6 +66,44 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
     final showWeblateButton = ref.pref(PrefKey.showWeblateButton);
     final theme = Theme.of(context);
 
+    final relatedLinks = [
+      OptionEntryTile.icon(
+        icon: Icons.code,
+        title: 'GitHub',
+        description: t.about.viewSource,
+        onTap: () => launchUrl(
+          .parse('https://github.com/NTUT-NPC/tattoo'),
+        ),
+      ),
+      OptionEntryTile.icon(
+        icon: Icons.article_outlined,
+        title: t.about.openSourceLicenses,
+        description: t.about.viewOpenSourceLicenses.spaced,
+        onTap: () => showLicensePage(
+          context: context,
+          applicationLegalese: t.about.copyright.spaced,
+          applicationName: t.general.appTitle,
+          applicationVersion: packageInfoAsync.value ?? '...',
+        ),
+      ),
+      if (showWeblateButton)
+        OptionEntryTile.icon(
+          icon: Icons.translate,
+          title: 'Weblate',
+          description: t.about.helpTranslate.spaced,
+          onTap: () => launchUrl(
+            .parse('https://translate.ntut.app'),
+          ),
+        ),
+      OptionEntryTile.icon(
+        icon: Icons.privacy_tip,
+        title: t.about.privacyPolicy,
+        description: t.about.viewPrivacyPolicy,
+        onTap: () => launchUrl(
+          .parse(t.about.privacyPolicyUrl),
+        ),
+      ),
+    ];
     return Scaffold(
       appBar: AppBar(
         title: Text(t.profile.options.about.spaced),
@@ -122,42 +160,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                       spacing: 8,
                       children: [
                         SectionHeader(title: t.about.relatedLinks),
-                        OptionEntryTile.icon(
-                          icon: Icons.code,
-                          title: 'GitHub',
-                          description: t.about.viewSource,
-                          onTap: () => launchUrl(
-                            .parse('https://github.com/NTUT-NPC/tattoo'),
-                          ),
-                        ),
-                        OptionEntryTile.icon(
-                          icon: Icons.article_outlined,
-                          title: t.about.openSourceLicenses,
-                          description: t.about.viewOpenSourceLicenses.spaced,
-                          onTap: () => showLicensePage(
-                            context: context,
-                            applicationLegalese: t.about.copyright.spaced,
-                            applicationName: t.general.appTitle,
-                            applicationVersion: packageInfoAsync.value ?? '...',
-                          ),
-                        ),
-                        if (showWeblateButton)
-                          OptionEntryTile.icon(
-                            icon: Icons.translate,
-                            title: 'Weblate',
-                            description: t.about.helpTranslate.spaced,
-                            onTap: () => launchUrl(
-                              .parse('https://translate.ntut.app'),
-                            ),
-                          ),
-                        OptionEntryTile.icon(
-                          icon: Icons.privacy_tip,
-                          title: t.about.privacyPolicy,
-                          description: t.about.viewPrivacyPolicy,
-                          onTap: () => launchUrl(
-                            .parse(t.about.privacyPolicyUrl),
-                          ),
-                        ),
+                        ...relatedLinks,
                       ],
                     ),
 

--- a/lib/screens/main/profile/profile_screen.dart
+++ b/lib/screens/main/profile/profile_screen.dart
@@ -9,7 +9,9 @@ import 'package:tattoo/components/option_entry_tile.dart';
 import 'package:tattoo/components/section_header.dart';
 import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/repositories/auth_repository.dart';
+import 'package:tattoo/repositories/preferences_repository.dart';
 import 'package:tattoo/router/app_router.dart';
+import 'package:tattoo/screens/main/profile/preference_providers.dart';
 import 'package:tattoo/screens/main/profile/profile_card.dart';
 import 'package:tattoo/screens/main/profile/profile_danger_zone.dart';
 import 'package:tattoo/utils/auto_spacing.dart';
@@ -84,23 +86,31 @@ class ProfileScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     // settings options for the profile tab
-    final options = [
-      SectionHeader(title: t.profile.sections.accountSettings),
-      OptionEntryTile.icon(
-        icon: Icons.password,
-        title: t.profile.options.changePassword,
-        onTap: () => context.push(
-          AppRoutes.changePassword,
-          extra: {
-            'isExpired': false,
-          },
+    final accountOptions = [
+      if (ref.pref(PrefKey.showChangePasswordButton))
+        OptionEntryTile.icon(
+          icon: Icons.password,
+          title: t.profile.options.changePassword,
+          onTap: () => context.push(
+            AppRoutes.changePassword,
+            extra: {
+              'isExpired': false,
+            },
+          ),
         ),
-      ),
-      OptionEntryTile.icon(
-        icon: Icons.image,
-        title: t.profile.options.changeAvatar,
-        onTap: () => _changeAvatar(context, ref),
-      ),
+      if (ref.pref(PrefKey.showChangeAvatarButton))
+        OptionEntryTile.icon(
+          icon: Icons.image,
+          title: t.profile.options.changeAvatar,
+          onTap: () => _changeAvatar(context, ref),
+        ),
+    ];
+
+    final options = [
+      if (accountOptions.isNotEmpty) ...[
+        SectionHeader(title: t.profile.sections.accountSettings),
+        ...accountOptions,
+      ],
 
       SectionHeader(title: 'TAT'),
       OptionEntryTile.icon(

--- a/test/repositories/preferences_repository_test.dart
+++ b/test/repositories/preferences_repository_test.dart
@@ -8,10 +8,43 @@ import 'package:tattoo/repositories/preferences_repository.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  group('PrefKey.showErrorDialog', () {
-    test('has expected type and default value', () {
+  group('PrefKey', () {
+    test('all keys have expected types and defaults', () {
+      expect(PrefKey.demoMode.type, PrefType.boolean);
+      expect(PrefKey.demoMode.defaultValue, false);
+
+      expect(PrefKey.showDangerZone.type, PrefType.boolean);
+      expect(PrefKey.showDangerZone.defaultValue, false);
+
+      expect(PrefKey.showWeblateButton.type, PrefType.boolean);
+      expect(PrefKey.showWeblateButton.defaultValue, false);
+
+      expect(PrefKey.showWifiButton.type, PrefType.boolean);
+      expect(PrefKey.showWifiButton.defaultValue, false);
+
       expect(PrefKey.showErrorDialog.type, PrefType.boolean);
       expect(PrefKey.showErrorDialog.defaultValue, kDebugMode);
+
+      expect(PrefKey.showCourseSchedule.type, PrefType.boolean);
+      expect(PrefKey.showCourseSchedule.defaultValue, true);
+
+      expect(PrefKey.showVoteButton.type, PrefType.boolean);
+      expect(PrefKey.showVoteButton.defaultValue, false);
+
+      expect(PrefKey.showScannerButton.type, PrefType.boolean);
+      expect(PrefKey.showScannerButton.defaultValue, true);
+
+      expect(PrefKey.showPortalButton.type, PrefType.boolean);
+      expect(PrefKey.showPortalButton.defaultValue, true);
+
+      expect(PrefKey.showCalendarButton.type, PrefType.boolean);
+      expect(PrefKey.showCalendarButton.defaultValue, true);
+
+      expect(PrefKey.showChangePasswordButton.type, PrefType.boolean);
+      expect(PrefKey.showChangePasswordButton.defaultValue, true);
+
+      expect(PrefKey.showChangeAvatarButton.type, PrefType.boolean);
+      expect(PrefKey.showChangeAvatarButton.defaultValue, true);
     });
 
     test('can be written and read from TypedPreferenceStore', () async {
@@ -24,16 +57,20 @@ void main() {
           InMemorySharedPreferencesAsync.empty();
       final store = TypedPreferenceStore(SharedPreferencesAsync());
 
-      expect(await store.read(.showErrorDialog), isNull);
+      for (final key in PrefKey.values) {
+        expect(await store.read(key), isNull);
 
-      await store.write(.showErrorDialog, true);
-      expect(await store.read(.showErrorDialog), isTrue);
+        if (key.type == PrefType.boolean) {
+          await store.write(key as PrefKey<bool>, true);
+          expect(await store.read(key), isTrue);
 
-      await store.write(.showErrorDialog, false);
-      expect(await store.read(.showErrorDialog), isFalse);
+          await store.write(key, false);
+          expect(await store.read(key), isFalse);
+        }
 
-      await store.remove(.showErrorDialog);
-      expect(await store.read(.showErrorDialog), isNull);
+        await store.remove(key);
+        expect(await store.read(key), isNull);
+      }
     });
   });
 }

--- a/test/screens/main/home/home_screen_test.dart
+++ b/test/screens/main/home/home_screen_test.dart
@@ -4,11 +4,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tattoo/database/database.dart';
+import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/models/course.dart';
 import 'package:tattoo/repositories/course_repository.dart';
+import 'package:tattoo/repositories/preferences_repository.dart';
 import 'package:tattoo/screens/main/course_table_providers.dart';
 import 'package:tattoo/screens/main/home/home_providers.dart';
 import 'package:tattoo/screens/main/home/home_screen.dart';
+import 'package:tattoo/screens/main/home/next_course_carousel.dart';
+import 'package:tattoo/screens/main/profile/preference_providers.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 
 void main() {
   testWidgets('preserves loading until the course table emits data', (
@@ -125,6 +130,89 @@ void main() {
     expect(find.text('Monday course'), findsNothing);
     expect(find.byIcon(Icons.coffee_outlined), findsNWidgets(2));
   });
+
+  testWidgets('hides next course carousel when showCourseSchedule is false', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          preferenceValueProvider(
+            PrefKey.showCourseSchedule,
+          ).overrideWithValue(false),
+          courseTableSemestersProvider.overrideWith(
+            (ref) => Stream.value(const []),
+          ),
+        ],
+        child: const MaterialApp(home: MainHomeScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(NextCourseCarousel), findsNothing);
+  });
+
+  testWidgets('shows wifi and vote button when preference is enabled', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          preferenceValueProvider(
+            PrefKey.showWifiButton,
+          ).overrideWithValue(true),
+          preferenceValueProvider(
+            PrefKey.showVoteButton,
+          ).overrideWithValue(true),
+          courseTableSemestersProvider.overrideWith(
+            (ref) => Stream.value(const []),
+          ),
+        ],
+        child: MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.android),
+          home: const MainHomeScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text(t.home.campusWifi.spaced), findsOneWidget);
+    expect(find.text(t.nav.vote), findsOneWidget);
+  });
+
+  testWidgets(
+    'hides dynamic tools when preferences are disabled while keeping standard links',
+    (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            preferenceValueProvider(
+              PrefKey.showScannerButton,
+            ).overrideWithValue(false),
+            preferenceValueProvider(
+              PrefKey.showPortalButton,
+            ).overrideWithValue(false),
+            preferenceValueProvider(
+              PrefKey.showCalendarButton,
+            ).overrideWithValue(false),
+            courseTableSemestersProvider.overrideWith(
+              (ref) => Stream.value(const []),
+            ),
+          ],
+          child: const MaterialApp(home: MainHomeScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(t.home.projectTattoo.title.spaced), findsOneWidget);
+      expect(find.text(t.home.ideation.title.spaced), findsOneWidget);
+      expect(find.text(t.home.npcClub.title), findsOneWidget);
+      expect(find.text(t.scanner.loginIStudy.spaced), findsNothing);
+      expect(find.text(t.nav.portal), findsNothing);
+      expect(find.text(t.nav.calendar), findsNothing);
+    },
+  );
 }
 
 Widget _homeWithSchedule({

--- a/test/screens/main/profile/about_screen_test.dart
+++ b/test/screens/main/profile/about_screen_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:tattoo/i18n/strings.g.dart';
+import 'package:tattoo/models/contributor.dart';
+import 'package:tattoo/repositories/preferences_repository.dart';
+import 'package:tattoo/screens/main/profile/about_screen.dart';
+import 'package:tattoo/screens/main/profile/preference_providers.dart';
+import 'package:tattoo/services/github_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    LocaleSettings.setLocale(AppLocale.zhTw);
+    PackageInfo.setMockInitialValues(
+      appName: 'Tattoo',
+      packageName: 'com.tat.tattoo',
+      version: '1.0.0',
+      buildNumber: '1',
+      buildSignature: '',
+    );
+  });
+
+  testWidgets(
+    'shows standard links and Weblate button when preference is enabled',
+    (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            preferenceValueProvider(
+              PrefKey.showWeblateButton,
+            ).overrideWithValue(true),
+            contributorsProvider.overrideWith(
+              (ref) async => [
+                Contributor(
+                  login: 'alice',
+                  avatarUrl: 'https://example.com/alice.png',
+                  htmlUrl: 'https://github.com/alice',
+                  type: 'User',
+                ),
+              ],
+            ),
+          ],
+          child: const MaterialApp(home: AboutScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('GitHub'), findsOneWidget);
+      expect(find.text(t.about.openSourceLicenses), findsOneWidget);
+      expect(find.text('Weblate'), findsOneWidget);
+      expect(find.text(t.about.privacyPolicy), findsOneWidget);
+      expect(find.text('alice'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'hides Weblate button when preference is disabled while keeping standard links',
+    (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            preferenceValueProvider(
+              PrefKey.showWeblateButton,
+            ).overrideWithValue(false),
+          ],
+          child: const MaterialApp(home: AboutScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('GitHub'), findsOneWidget);
+      expect(find.text(t.about.openSourceLicenses), findsOneWidget);
+      expect(find.text('Weblate'), findsNothing);
+      expect(find.text(t.about.privacyPolicy), findsOneWidget);
+    },
+  );
+}

--- a/test/screens/main/profile/profile_screen_test.dart
+++ b/test/screens/main/profile/profile_screen_test.dart
@@ -18,6 +18,7 @@ import 'package:tattoo/screens/main/profile/profile_screen.dart';
 import 'package:tattoo/screens/main/user_providers.dart';
 import 'package:tattoo/services/portal/mock_portal_service.dart';
 import 'package:tattoo/services/student_query/mock_student_query_service.dart';
+import 'package:tattoo/utils/auto_spacing.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -41,13 +42,14 @@ void main() {
     });
 
     testWidgets(
-      'shows the profile entry on Android when preference is enabled',
+      'shows change password and change avatar when preferences are enabled',
       (tester) async {
-        preferencesRepository.showWifiButtonValue = true;
+        preferencesRepository.overrides[PrefKey.showChangePasswordButton] =
+            true;
+        preferencesRepository.overrides[PrefKey.showChangeAvatarButton] = true;
         await tester.pumpWidget(
           _buildApp(
             const ProfileScreen(),
-            platform: TargetPlatform.android,
             overrides: [
               userProfileProvider.overrideWith((ref) => Stream.value(null)),
               userAvatarProvider.overrideWith((ref) async => null),
@@ -62,19 +64,23 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text(t.profile.options.ntutWifi), findsOneWidget);
-        expect(find.text(t.ntutWifi.entryDescription), findsOneWidget);
+        expect(find.text(t.profile.options.changePassword), findsOneWidget);
+        expect(find.text(t.profile.options.changeAvatar), findsOneWidget);
+        expect(find.text(t.profile.options.about.spaced), findsOneWidget);
+        expect(find.text(t.profile.options.npcClub), findsOneWidget);
+        expect(find.text(t.profile.options.logout), findsOneWidget);
       },
     );
 
     testWidgets(
-      'hides the profile entry on Android when preference is disabled',
+      'hides change password and change avatar when preferences are disabled',
       (tester) async {
-        preferencesRepository.showWifiButtonValue = false;
+        preferencesRepository.overrides[PrefKey.showChangePasswordButton] =
+            false;
+        preferencesRepository.overrides[PrefKey.showChangeAvatarButton] = false;
         await tester.pumpWidget(
           _buildApp(
             const ProfileScreen(),
-            platform: TargetPlatform.android,
             overrides: [
               userProfileProvider.overrideWith((ref) => Stream.value(null)),
               userAvatarProvider.overrideWith((ref) async => null),
@@ -89,35 +95,13 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text(t.profile.options.ntutWifi), findsNothing);
-        expect(find.text(t.ntutWifi.entryDescription), findsNothing);
+        expect(find.text(t.profile.options.changePassword), findsNothing);
+        expect(find.text(t.profile.options.changeAvatar), findsNothing);
+        expect(find.text(t.profile.options.about.spaced), findsOneWidget);
+        expect(find.text(t.profile.options.npcClub), findsOneWidget);
+        expect(find.text(t.profile.options.logout), findsOneWidget);
       },
     );
-
-    testWidgets('hides the profile entry on non-Android platforms', (
-      tester,
-    ) async {
-      await tester.pumpWidget(
-        _buildApp(
-          const ProfileScreen(),
-          platform: TargetPlatform.iOS,
-          overrides: [
-            userProfileProvider.overrideWith((ref) => Stream.value(null)),
-            userAvatarProvider.overrideWith((ref) async => null),
-            activeRegistrationProvider.overrideWith(
-              (ref) => Stream.value(null),
-            ),
-            preferencesRepositoryProvider.overrideWith((ref) {
-              return preferencesRepository;
-            }),
-          ],
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.text(t.profile.options.ntutWifi), findsNothing);
-      expect(find.text(t.ntutWifi.entryDescription), findsNothing);
-    });
   });
 }
 
@@ -137,20 +121,20 @@ class _FakePreferencesRepository extends PreferencesRepository {
 
   final AppDatabase _database;
 
-  bool showWifiButtonValue = false;
+  final Map<PrefKey, Object> overrides = {};
 
   @override
   Future<T> get<T>(PrefKey<T> key) async {
-    if (key == PrefKey.showWifiButton) return showWifiButtonValue as T;
+    if (overrides.containsKey(key)) return overrides[key] as T;
     return key.defaultValue;
   }
 
   @override
   Future<ResolvedPreference> resolve(PrefKey key) async {
-    if (key == PrefKey.showWifiButton) {
+    if (overrides.containsKey(key)) {
       return ResolvedPreference(
         key: key,
-        value: showWifiButtonValue,
+        value: overrides[key]!,
         source: PrefSource.local,
       );
     }


### PR DESCRIPTION
## Description

Gates dynamic features and tool entries behind Firebase Remote Config via the typed `PrefKey` preference source stack, while keeping standard/core capabilities unconditional.

## Key Changes

- **Preferences Repository (`lib/repositories/preferences_repository.dart`)**:
  - `showCourseSchedule` (default: `true`) — Next course schedule carousel on Home
  - `showVoteButton` (default: `false`) — Student council election kiosk QR login entry on Home (replaces hardcoded date check)
  - `showScannerButton` (default: `true`) — iStudy QR scanner tool on Home
  - `showPortalButton` (default: `true`) — NTUT Portal directory access on Home
  - `showCalendarButton` (default: `true`) — Academic calendar tool on Home
  - `showChangePasswordButton` (default: `true`) — Change password option on Profile
  - `showChangeAvatarButton` (default: `true`) — Change avatar option on Profile
- **UI Integration**:
  - `HomeScreen`: Gated next course carousel, vote button, scanner, portal, and calendar options.
  - `ProfileScreen`: Gated change password and change avatar options.
  - `AboutScreen`: Standard legal links and contributors rendered unconditionally; Weblate button remains preference-gated.
- **Testing**:
  - Updated `preferences_repository_test.dart`, `home_screen_test.dart`, and `profile_screen_test.dart`.
  - Added `about_screen_test.dart` covering About page preference rendering.

## Verification

- `flutter analyze`: 0 issues found.
- `flutter test`: All 99 unit and widget tests passed.