### PR TITLE
ci: centralize dependency cache writes

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -4,6 +4,35 @@ description: Install development tools with mise and get dependencies
 inputs:
   platform:
     description: The target platform (e.g., ios, android)
+  save-caches:
+    description: Whether mise may save its populated tool cache
+    default: "false"
+
+outputs:
+  pub-cache-hit:
+    description: Whether the exact Flutter pub cache was restored
+    value: ${{ steps.pub-cache.outputs.cache-hit }}
+  pub-cache-primary-key:
+    description: Primary key used to restore the Flutter pub cache
+    value: ${{ steps.pub-cache.outputs.cache-primary-key }}
+  gradle-cache-hit:
+    description: Whether the exact Gradle cache was restored
+    value: ${{ steps.gradle-cache.outputs.cache-hit }}
+  gradle-cache-primary-key:
+    description: Primary key used to restore the Gradle cache
+    value: ${{ steps.gradle-cache.outputs.cache-primary-key }}
+  android-sdk-cache-hit:
+    description: Whether the exact Android SDK cache was restored
+    value: ${{ steps.android-sdk-cache.outputs.cache-hit }}
+  android-sdk-cache-primary-key:
+    description: Primary key used to restore the Android SDK cache
+    value: ${{ steps.android-sdk-cache.outputs.cache-primary-key }}
+  spm-cache-hit:
+    description: Whether the exact Swift Package Manager cache was restored
+    value: ${{ steps.spm-cache.outputs.cache-hit }}
+  spm-cache-primary-key:
+    description: Primary key used to restore the Swift Package Manager cache
+    value: ${{ steps.spm-cache.outputs.cache-primary-key }}
 
 runs:
   using: composite
@@ -18,6 +47,7 @@ runs:
             'flutter'
           ) }}
         add_shims_to_path: false # Use direct bin paths
+        cache_save: ${{ inputs.save-caches }}
 
     - name: Verify Flutter version
       id: flutter-version
@@ -39,9 +69,9 @@ runs:
       env:
         BUNDLE_FROZEN: "true"
 
-
-    - name: Setup Flutter pub cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+    - name: Restore Flutter pub cache
+      id: pub-cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
         path: ~/.pub-cache
@@ -52,9 +82,10 @@ runs:
       shell: bash
       run: flutter pub get --enforce-lockfile
 
-    - name: Setup Gradle cache
+    - name: Restore Gradle cache
+      id: gradle-cache
       if: ${{ inputs.platform == 'android' }}
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         key: ${{ runner.os }}-gradle-${{ hashFiles('android/**/*.gradle*', 'android/**/gradle.properties', 'android/gradle/wrapper/gradle-wrapper.properties') }}
         path: |
@@ -63,9 +94,10 @@ runs:
         restore-keys: |
           ${{ runner.os }}-gradle-
 
-    - name: Setup Android SDK cache
+    - name: Restore Android SDK cache
+      id: android-sdk-cache
       if: ${{ inputs.platform == 'android' }}
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         key: ${{ runner.os }}-android-sdk-${{ steps.flutter-version.outputs.flutter_version }}
         # Update paths when updating Flutter version
@@ -83,16 +115,16 @@ runs:
         XCODE_VERSION=$(xcodebuild -version | sed -n 's/^Xcode //p')
         echo "xcode_version=$XCODE_VERSION" >> "$GITHUB_OUTPUT"
 
-    - name: Setup Swift Package Manager cache
+    - name: Restore Swift Package Manager cache
+      id: spm-cache
       if: ${{ inputs.platform == 'ios' }}
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         key: ${{ runner.os }}-spm-${{ runner.arch }}-xcode-${{ steps.xcode_version.outputs.xcode_version }}-${{ hashFiles('ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
         path: build/ios/SourcePackages
         restore-keys: |
           ${{ runner.os }}-spm-${{ runner.arch }}-xcode-${{ steps.xcode_version.outputs.xcode_version }}-
           ${{ runner.os }}-spm-${{ runner.arch }}-
-
 
     - name: Check iOS config drift
       id: ios-drift

--- a/.github/workflows/seed-caches.yaml
+++ b/.github/workflows/seed-caches.yaml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  android:
+  flutter:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -28,10 +28,46 @@ jobs:
       - name: Setup project
         uses: ./.github/actions/setup-project
         with:
+          save-caches: "true"
+
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup project
+        id: setup
+        uses: ./.github/actions/setup-project
+        with:
           platform: android
+          save-caches: "true"
 
       - name: Warm Gradle and Android SDK caches
         run: flutter build apk --debug --no-pub
+
+      - name: Save Flutter pub cache
+        if: ${{ steps.setup.outputs.pub-cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: ${{ steps.setup.outputs.pub-cache-primary-key }}
+          path: ~/.pub-cache
+
+      - name: Save Gradle cache
+        if: ${{ steps.setup.outputs.gradle-cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: ${{ steps.setup.outputs.gradle-cache-primary-key }}
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+
+      - name: Save Android SDK cache
+        if: ${{ steps.setup.outputs.android-sdk-cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: ${{ steps.setup.outputs.android-sdk-cache-primary-key }}
+          path: /usr/local/lib/android/sdk/cmake/3.22.1
 
   ios:
     runs-on: macos-26
@@ -40,9 +76,25 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup project
+        id: setup
         uses: ./.github/actions/setup-project
         with:
           platform: ios
+          save-caches: "true"
 
       - name: Warm Swift Package Manager cache
         run: flutter build ios --no-pub --no-codesign
+
+      - name: Save Flutter pub cache
+        if: ${{ steps.setup.outputs.pub-cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: ${{ steps.setup.outputs.pub-cache-primary-key }}
+          path: ~/.pub-cache
+
+      - name: Save Swift Package Manager cache
+        if: ${{ steps.setup.outputs.spm-cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: ${{ steps.setup.outputs.spm-cache-primary-key }}
+          path: build/ios/SourcePackages


### PR DESCRIPTION
Depends on #404.

## Summary

- make mise and dependency caches read-only in normal CI workflows
- save populated pub, Gradle, Android SDK, and Swift Package Manager caches only from the centralized seed workflow
- add a Linux Flutter-only seed job so Analyze can restore its distinct mise cache key
- trigger cache seeding when tool versions, dependency locks, platform build inputs, or cache workflow configuration change
- retain `ruby/setup-ruby`'s small Bundler cache because warm restores reduce setup by roughly 20 seconds per platform

## Why

Recent PR builds created up to 8.89 GB of branch-scoped caches. Mise entries accounted for 7.69 GB of the 10.98 GB active cache inventory, evicting reusable default-branch caches and turning setup into the dominant CI cost.

Centralizing writes keeps the large caches on the base branch while pull requests restore them read-only. Exact cache hits skip redundant seed uploads; prefix hits are warmed and saved under the current primary key.

## Verification

- parsed `.github/actions/setup-project/action.yml` and `.github/workflows/seed-caches.yaml` with Ruby YAML
- confirmed PR #404's head is an ancestor of this branch
- confirmed explicit cache saves exist only in `seed-caches.yaml`
- confirmed the pinned `actions/cache` revision provides both `restore` and `save` sub-actions
- confirmed the SPM restore and save paths both use `build/ios/SourcePackages`
