### PR TITLE
add dark mode support across the app

### DIFF
--- a/lib/components/anchored_popup_menu.dart
+++ b/lib/components/anchored_popup_menu.dart
@@ -178,8 +178,6 @@ class AnchoredPopupMenuStyle {
 
   /// App-wide floating popup menu styling shared by floating controls.
   static const floatingSurface = AnchoredPopupMenuStyle(
-    color: Color(0xF5FFFFFF),
-    shadowColor: Color(0x14000000),
     surfaceTintColor: Colors.transparent,
     shape: RoundedRectangleBorder(
       borderRadius: .all(.circular(16)),

--- a/lib/components/floating_action_bar.dart
+++ b/lib/components/floating_action_bar.dart
@@ -456,8 +456,12 @@ class _FloatingActionBarSurface extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
     return Material(
-      color: Colors.white.withValues(alpha: 0.84),
+      color: isDark
+          ? Colors.grey[900]!.withValues(alpha: 0.84)
+          : Colors.white.withValues(alpha: 0.84),
       elevation: 4,
       shadowColor: Colors.black.withValues(alpha: 0.08),
       surfaceTintColor: Colors.transparent,

--- a/lib/components/notices.dart
+++ b/lib/components/notices.dart
@@ -36,7 +36,7 @@ class ClearNotice extends StatelessWidget {
   /// that reads [IconTheme]). If [icon] is another custom widget, this color
   /// does not automatically change that widget's appearance.
   ///
-  /// Defaults to `Colors.grey[600]` when omitted.
+  /// Defaults to `theme.colorScheme.onSurfaceVariant` when omitted.
   final Color? color;
 
   /// Optional text style override for [text].
@@ -44,7 +44,8 @@ class ClearNotice extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final resolvedColor = color ?? Colors.grey[600];
+    final theme = Theme.of(context);
+    final resolvedColor = color ?? theme.colorScheme.onSurfaceVariant;
 
     return Padding(
       padding: const .symmetric(horizontal: 16),
@@ -124,7 +125,7 @@ class ClearNoticeVertical extends StatelessWidget {
   /// that reads [IconTheme]). If [icon] is another custom widget, this color
   /// does not automatically change that widget's appearance.
   ///
-  /// Defaults to `Colors.grey[600]` when omitted.
+  /// Defaults to `theme.colorScheme.onSurfaceVariant` when omitted.
   final Color? color;
 
   /// Creates a vertical notice with rich-text support.
@@ -138,7 +139,7 @@ class ClearNoticeVertical extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final resolvedColor = color ?? Colors.grey[600];
+    final resolvedColor = color ?? theme.colorScheme.onSurfaceVariant;
 
     return Column(
       mainAxisSize: .min,

--- a/lib/components/option_entry_tile.dart
+++ b/lib/components/option_entry_tile.dart
@@ -130,7 +130,7 @@ class OptionEntryTile extends StatelessWidget {
   /// Optional color for the leading icon or SVG. Defaults to the theme's primary color.
   final Color? color;
 
-  /// Optional color for the tile border. Defaults to the theme's outlineVariant color.
+  /// Optional color for the tile border. Defaults to the theme's outline color.
   final Color? borderColor;
 
   @override
@@ -149,7 +149,7 @@ class OptionEntryTile extends StatelessWidget {
           decoration: BoxDecoration(
             borderRadius: borderRadius,
             border: Border.all(
-              color: borderColor ?? colorScheme.outlineVariant,
+              color: borderColor ?? colorScheme.outline,
             ),
           ),
           child: Padding(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -226,6 +226,13 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: themeColor),
       ),
+      darkTheme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: themeColor,
+          brightness: .dark,
+        ),
+      ),
+      themeMode: .system,
       routerConfig: router,
     );
   }

--- a/lib/screens/main/calendar/calendar_screen.dart
+++ b/lib/screens/main/calendar/calendar_screen.dart
@@ -84,6 +84,7 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
   }
 
   Widget _buildBody(Map<DateTime, List<CalendarEvent>> eventsMap) {
+    final theme = Theme.of(context);
     final selectedKey = DateTime(
       _selectedDay.year,
       _selectedDay.month,
@@ -120,6 +121,12 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
           eventLoader: (day) =>
               eventsMap[DateTime(day.year, day.month, day.day)] ?? const [],
           calendarFormat: .month,
+          calendarStyle: CalendarStyle(
+            markerDecoration: BoxDecoration(
+              color: theme.colorScheme.primary,
+              shape: .circle,
+            ),
+          ),
           headerStyle: const HeaderStyle(formatButtonVisible: false),
         ),
         const SizedBox(height: 8.0),

--- a/lib/screens/main/course_table/course_table_cell.dart
+++ b/lib/screens/main/course_table/course_table_cell.dart
@@ -39,15 +39,27 @@ class CourseTableCell extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final containerColor = HSLColor.fromColor(
-      cellColor,
-    ).withLightness(0.9).withSaturation(0.4).toColor();
-    final borderColor = HSLColor.fromColor(
-      cellColor,
-    ).withLightness(0.3).withSaturation(0.6).toColor();
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    final containerColor =
+        HSLColor.fromColor(
+              cellColor,
+            )
+            .withLightness(isDark ? 0.7 : 0.9)
+            .withSaturation(isDark ? 0.2 : 0.4)
+            .toColor();
+
+    final borderColor =
+        HSLColor.fromColor(
+              cellColor,
+            )
+            .withLightness(isDark ? 0.3 : 0.3)
+            .withSaturation(isDark ? 0.5 : 0.6)
+            .toColor();
+
     final borderStyle = Border.all(
       color: borderColor,
-      width: 1,
+      width: 1.5,
     );
     final borderRadius = BorderRadius.circular(8);
     final theme = Theme.of(context);
@@ -55,6 +67,7 @@ class CourseTableCell extends StatelessWidget {
         ? courseTableCellData.courseName
         : courseTableCellData.number ?? '';
     final classroomName = courseTableCellData.classroomName;
+    final fontColor = Colors.grey[900];
     final splashColor = borderColor.withValues(alpha: 0.22);
     final highlightColor = borderColor.withValues(alpha: 0.14);
 
@@ -89,6 +102,7 @@ class CourseTableCell extends StatelessWidget {
                       AutoSizeText(
                         courseTitle.spaced,
                         style: theme.textTheme.bodyMedium?.copyWith(
+                          color: fontColor,
                           fontSize: 12,
                           fontWeight: .w700,
                         ),
@@ -102,6 +116,7 @@ class CourseTableCell extends StatelessWidget {
                         AutoSizeText(
                           classroomName.spaced,
                           style: theme.textTheme.bodySmall?.copyWith(
+                            color: fontColor,
                             fontSize: 8,
                             fontWeight: .w400,
                           ),

--- a/lib/screens/main/course_table/course_table_grid.dart
+++ b/lib/screens/main/course_table/course_table_grid.dart
@@ -133,7 +133,7 @@ class CourseTableGrid extends StatelessWidget {
           primary: false,
           toolbarHeight: _tableHeaderHeight,
           automaticallyImplyLeading: false,
-          backgroundColor: Colors.grey[100],
+          // backgroundColor: Colors.grey[100],
           surfaceTintColor: Colors.transparent,
           scrolledUnderElevation: 0,
           elevation: 0,

--- a/lib/screens/main/home/next_course_card.dart
+++ b/lib/screens/main/home/next_course_card.dart
@@ -8,9 +8,6 @@ const _nextCourseCardShadow = BoxShadow(
   blurRadius: 16,
   offset: Offset(0, 4),
 );
-const _nextCourseCardBlue = Color.fromARGB(255, 223, 234, 255);
-const _nextCourseCardSurface = Color(0xFFF8FAFF);
-const _nextCourseCardMint = Color.fromARGB(255, 211, 255, 231);
 
 class NextCourseCard extends StatelessWidget {
   const NextCourseCard({
@@ -25,17 +22,28 @@ class NextCourseCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final gradientColors = isDark
+        ? const [Color(0xFF25483F), Color(0xFF1D2936), Color(0xFF293B59)]
+        : const [Color(0xFFD3FFE7), Color(0xFFF8FAFF), Color(0xFFDFEAFF)];
+    const gradientStops = [0.0, 0.6, 1.0];
+    final titleColor = isDark
+        ? const Color(0xFFF0F5FF)
+        : theme.colorScheme.onSurface;
+    final infoColor = isDark
+        ? const Color(0xFFBECBD9)
+        : theme.colorScheme.onSurfaceVariant;
     final textScaler = MediaQuery.textScalerOf(context);
     final courseTitleTextStyle = theme.textTheme.titleLarge?.copyWith(
       fontWeight: .w700,
-      color: theme.colorScheme.onSurface,
+      color: titleColor,
       height: 1.2,
     );
     final courseTitleLineHeight =
         textScaler.scale(courseTitleTextStyle?.fontSize ?? 22) *
         (courseTitleTextStyle?.height ?? 1.2);
     final infoTextStyle = theme.textTheme.labelMedium?.copyWith(
-      color: theme.colorScheme.onSurfaceVariant,
+      color: infoColor,
       height: 1.4,
     );
     final stateLabel = switch (course.state) {
@@ -53,15 +61,11 @@ class NextCourseCard extends StatelessWidget {
       width: double.infinity,
       child: DecoratedBox(
         decoration: BoxDecoration(
-          gradient: const RadialGradient(
+          gradient: RadialGradient(
             center: .bottomRight,
             radius: 1.35,
-            colors: [
-              _nextCourseCardMint,
-              _nextCourseCardSurface,
-              _nextCourseCardBlue,
-            ],
-            stops: [0, 0.6, 1],
+            colors: gradientColors,
+            stops: gradientStops,
           ),
           borderRadius: borderRadius,
           boxShadow: const [_nextCourseCardShadow],
@@ -82,7 +86,7 @@ class NextCourseCard extends StatelessWidget {
                   Text(
                     header.spaced,
                     style: theme.textTheme.labelMedium?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
+                      color: infoColor,
                       fontWeight: .w600,
                     ),
                   ),

--- a/lib/screens/main/profile/about_screen.dart
+++ b/lib/screens/main/profile/about_screen.dart
@@ -127,6 +127,13 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                             'assets/tat_icon.svg',
                             width: 80,
                             height: 80,
+                            colorFilter: switch (theme.brightness) {
+                              .dark => .mode(
+                                theme.colorScheme.onSurfaceVariant,
+                                .srcIn,
+                              ),
+                              .light => null,
+                            },
                           ),
                         ),
                         Text(
@@ -247,7 +254,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                       TextSpan(text: t.about.copyright.spaced),
                       style: theme.textTheme.bodySmall?.copyWith(
                         height: 1.6,
-                        color: Colors.grey[600],
+                        color: theme.colorScheme.onSurfaceVariant,
                       ),
                       textAlign: .center,
                     ),

--- a/lib/screens/main/profile/regedit_screen.dart
+++ b/lib/screens/main/profile/regedit_screen.dart
@@ -208,22 +208,22 @@ class _PrefSubtitle extends StatelessWidget {
     return switch (pref.source) {
       .override => (
         text: t.regedit.status.localOverride,
-        bgColor: Colors.blue.withValues(alpha: 0.15),
+        bgColor: Colors.blue.shade100,
         textColor: Colors.blue.shade800,
       ),
       .remote => (
         text: t.regedit.status.remote,
-        bgColor: Colors.purple.withValues(alpha: 0.15),
+        bgColor: Colors.purple.shade100,
         textColor: Colors.purple.shade800,
       ),
       .local => (
         text: t.regedit.status.local,
-        bgColor: Colors.grey.withValues(alpha: 0.2),
+        bgColor: Colors.grey.shade200,
         textColor: Colors.grey.shade800,
       ),
       .forced => (
         text: t.regedit.status.remoteOverride,
-        bgColor: Colors.red.withValues(alpha: 0.15),
+        bgColor: Colors.red.shade100,
         textColor: Colors.red.shade800,
       ),
     };

--- a/lib/screens/main/scanner/scanner_screen.dart
+++ b/lib/screens/main/scanner/scanner_screen.dart
@@ -154,10 +154,6 @@ class _ScannerScreenState extends ConsumerState<ScannerScreen> {
       extendBodyBehindAppBar: false,
       appBar: AppBar(
         title: Text(t.scanner.title),
-        backgroundColor: Theme.of(context).colorScheme.primary, // 使用主題主色
-        surfaceTintColor: Colors.transparent,
-        elevation: 0,
-        foregroundColor: Colors.white,
       ),
       body: Stack(
         children: [

--- a/lib/screens/update_screen.dart
+++ b/lib/screens/update_screen.dart
@@ -23,73 +23,70 @@ class UpdateScreen extends ConsumerWidget {
     final requiredVersion = config.requiredVersion;
     final detail = config.detail;
     final isForced = config.isForcedUpdate;
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final colorScheme = theme.colorScheme;
 
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false,
-        backgroundColor: Colors.transparent,
-        elevation: 0,
       ),
       body: SafeArea(
         child: CustomScrollView(
           slivers: [
             SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+              padding: const .symmetric(horizontal: 32, vertical: 24),
               sliver: SliverFillRemaining(
                 hasScrollBody: false,
                 child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  mainAxisAlignment: .center,
+                  crossAxisAlignment: .stretch,
                   children: [
                     const SizedBox(height: 16),
                     const Icon(Icons.system_update_outlined, size: 80),
                     const SizedBox(height: 32),
                     Text(
                       t.forceUpdate.title,
-                      style: Theme.of(context).textTheme.headlineSmall
-                          ?.copyWith(
-                            fontWeight: FontWeight.bold,
-                          ),
-                      textAlign: TextAlign.center,
+                      style: textTheme.headlineSmall?.copyWith(
+                        fontWeight: .bold,
+                      ),
+                      textAlign: .center,
                     ),
                     const SizedBox(height: 16),
                     Text(
                       t.forceUpdate.message.spaced,
-                      style: Theme.of(context).textTheme.bodyLarge,
-                      textAlign: TextAlign.center,
+                      style: textTheme.bodyLarge,
+                      textAlign: .center,
                     ),
                     if (requiredVersion.isNotEmpty) ...[
                       const SizedBox(height: 8),
                       Text(
                         t.forceUpdate.requiredVersion(version: requiredVersion),
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          fontWeight: FontWeight.w600,
+                        style: textTheme.bodyMedium?.copyWith(
+                          fontWeight: .w600,
                         ),
-                        textAlign: TextAlign.center,
+                        textAlign: .center,
                       ),
                     ],
                     if (isForced) ...[
                       const SizedBox(height: 8),
                       Text(
                         t.forceUpdate.isForced,
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: Theme.of(context).colorScheme.error,
-                          fontWeight: FontWeight.bold,
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: colorScheme.error,
+                          fontWeight: .bold,
                         ),
-                        textAlign: TextAlign.center,
+                        textAlign: .center,
                       ),
                     ],
                     if (detail.isNotEmpty) ...[
                       const SizedBox(height: 12),
                       Text(
                         detail,
-                        style:
-                            Theme.of(
-                              context,
-                            ).textTheme.bodyMedium?.copyWith(
-                              color: Colors.grey[600],
-                            ),
-                        textAlign: TextAlign.center,
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                        textAlign: .center,
                       ),
                     ],
                     const SizedBox(height: 40),
@@ -125,7 +122,8 @@ class UpdateScreen extends ConsumerWidget {
     } else {
       // Fallback platform-specific store URLs when compile-time STORE_URL is not set
       // e.g. for local/manual builds.
-      if (Theme.of(context).platform == TargetPlatform.iOS) {
+      final theme = Theme.of(context);
+      if (theme.platform == .iOS) {
         url = 'https://apps.apple.com/app/id1513875597';
       } else {
         url = 'https://play.google.com/store/apps/details?id=club.ntut.npc.tat';

--- a/lib/screens/welcome/change_password_screen.dart
+++ b/lib/screens/welcome/change_password_screen.dart
@@ -287,18 +287,18 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
                             child: ElevatedButton(
                               style: ElevatedButton.styleFrom(
                                 backgroundColor: theme.colorScheme.primary,
-                                foregroundColor: Colors.white,
+                                foregroundColor: theme.colorScheme.onPrimary,
                               ),
                               onPressed: state.isLoading ? null : _submit,
                               child: Padding(
                                 padding: const EdgeInsets.all(12.0),
                                 child: state.isLoading
-                                    ? const SizedBox(
+                                    ? SizedBox(
                                         height: 20,
                                         width: 20,
                                         child: CircularProgressIndicator(
                                           strokeWidth: 2,
-                                          color: Colors.white,
+                                          color: theme.colorScheme.onPrimary,
                                         ),
                                       )
                                     : Text(t.changePassword.submit),

--- a/lib/screens/welcome/intro_screen.dart
+++ b/lib/screens/welcome/intro_screen.dart
@@ -26,6 +26,13 @@ class _IntroScreenState extends State<IntroScreen>
     final icon = SvgPicture.asset(
       'assets/tat_icon.svg',
       height: verticalPadding,
+      colorFilter: switch (theme.brightness) {
+        .dark => .mode(
+          theme.colorScheme.onSurfaceVariant,
+          .srcIn,
+        ),
+        .light => null,
+      },
     );
 
     final body = Column(
@@ -54,7 +61,7 @@ class _IntroScreenState extends State<IntroScreen>
         'assets/npc_horizontal.svg',
         height: 24,
         colorFilter: .mode(
-          Colors.grey[600]!,
+          theme.colorScheme.onSurfaceVariant,
           .srcIn,
         ),
       ),

--- a/lib/screens/welcome/login_screen.dart
+++ b/lib/screens/welcome/login_screen.dart
@@ -334,7 +334,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                             style: theme.textTheme.bodySmall?.copyWith(
                               fontSize: 16,
                               height: 1.6,
-                              color: Colors.grey[600],
+                              color: theme.colorScheme.onSurfaceVariant,
                             ),
                             textAlign: .center,
                           ),

--- a/lib/screens/welcome/login_screen.dart
+++ b/lib/screens/welcome/login_screen.dart
@@ -396,18 +396,18 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                             child: ElevatedButton(
                               style: ElevatedButton.styleFrom(
                                 backgroundColor: theme.colorScheme.primary,
-                                foregroundColor: Colors.white,
+                                foregroundColor: theme.colorScheme.onPrimary,
                               ),
                               onPressed: _isLoading ? null : _attemptLogin,
                               child: Padding(
                                 padding: const .all(6.0),
                                 child: _isLoading
-                                    ? const SizedBox(
+                                    ? SizedBox(
                                         height: 20,
                                         width: 20,
                                         child: CircularProgressIndicator(
                                           strokeWidth: 2,
-                                          color: Colors.white,
+                                          color: theme.colorScheme.onPrimary,
                                         ),
                                       )
                                     : Text(t.login.loginButton),

--- a/lib/shells/adaptive_navigation_scaffold.dart
+++ b/lib/shells/adaptive_navigation_scaffold.dart
@@ -42,6 +42,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
       builder: (context, constraints) {
         final useNavigationRail =
             constraints.maxWidth >= navigationRailBreakpoint;
+        final theme = Theme.of(context);
 
         return Scaffold(
           body: useNavigationRail
@@ -61,6 +62,13 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
                           'assets/tat_icon.svg',
                           width: 40,
                           height: 40,
+                          colorFilter: switch (theme.brightness) {
+                            .dark => .mode(
+                              theme.colorScheme.onSurfaceVariant,
+                              .srcIn,
+                            ),
+                            .light => null,
+                          },
                         ),
                       ),
                       destinations: [

--- a/lib/shells/showcase_shell.dart
+++ b/lib/shells/showcase_shell.dart
@@ -83,7 +83,7 @@ class ShowcaseShell extends StatelessWidget {
                         Text(
                           subtitle,
                           style: theme.textTheme.bodyMedium?.copyWith(
-                            color: Colors.grey[600],
+                            color: theme.colorScheme.onSurfaceVariant,
                           ),
                           textAlign: .center,
                         ),


### PR DESCRIPTION
# 為整個 App 新增深色模式支援

## 總覽

為 App 建立跟隨系統的深色模式，讓 Material 元件、主要畫面與既有自訂 UI 在深色環境下維持清楚的層次與對比。

## 修改內容

- 在 `main.dart` 新增 `darkTheme`，沿用相同的 seed color，並設定 `ThemeMode.system`。
- 將登入、改密碼、通知、更新頁與 onboarding 的次要文字改用 `colorScheme.onSurfaceVariant` 等主題色。
- 讓登入與改密碼按鈕、loading indicator 使用 `colorScheme.onPrimary`。
- 為 `tat_icon.svg` 與 NPC logo/水平 logo 的使用處加入深色模式下的主題色處理。
- 調整首頁下一堂課卡片，在深色模式使用獨立的深色漸層與文字配色。
- 調整 Floating Action Bar 與 anchored popup menu，使 surface 和陰影能跟隨目前主題。
- 調整課表課程 cell 的明度、飽和度與文字顏色計算，保留不同課程之間的辨識度。
- 調整課表與日曆中的主題相關顏色，移除不必要的固定 AppBar 顏色。
- 移除 scanner AppBar 的固定主題色，改用 Material 主題預設樣式。
- 調整 OptionEntryTile 的 outline 顏色，使其在深色模式下更清楚。

<img width="150" alt="Screenshot_20260906_040100" src="https://github.com/user-attachments/assets/5ad32f22-e266-49f7-af14-1a2f9dce74a9" />
<img width="150" alt="Screenshot_20260906_040104" src="https://github.com/user-attachments/assets/b656471c-72b3-4add-b655-60ee200da70e" />
<img width="150" alt="Screenshot_20260906_040140" src="https://github.com/user-attachments/assets/481df364-c489-4000-9795-faa41cfc312f" />
<img width="150" alt="Screenshot_20260906_040155" src="https://github.com/user-attachments/assets/50d31b5e-6b15-40bb-899f-9e96a03f1f73" />
<img width="150" alt="Screenshot_20260906_040205" src="https://github.com/user-attachments/assets/02ab064d-9111-40e2-82fb-3a598f001279" />
<img width="150" alt="Screenshot_20260906_040212" src="https://github.com/user-attachments/assets/547e6df6-b679-427c-b1da-d6be1ce9d562" />
<img width="150" alt="Screenshot_20260906_040237" src="https://github.com/user-attachments/assets/6c02112e-70b8-4b74-a287-76670e0215ed" />


## 刻意保留

- 個人資料卡的品牌背景與固定配色。
- 課表目前使用的課程識別色、設定來源標籤與語意色，經視覺檢查後保留現況。
- QR code 白色背景與 scanner 黑白遮罩，這些屬於辨識/掃描所需的功能性顏色。

## Follow-up

- Preference setting 尚未加入深色模式選項；目前先跟隨系統設定。
- 需要再以實機或模擬器檢查各主要頁面的最終視覺效果。