### PR TITLE
support configurable first page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -189,17 +189,17 @@ Future<void> main() async {
   // Prewarm the dependency graph before widgets subscribe. Riverpod cannot
   // invalidate its root scope while Flutter is mounting the initial frame.
   container.read(courseRepositoryProvider);
-  final authenticatedLocation = await resolveAuthenticatedLocation(
+  final landingLocation = await resolveLandingLocation(
     preferencesRepository,
   );
   final initialLocation = switch ((user, hadStoredLogin)) {
-    (final User _, _) => authenticatedLocation,
+    (final User _, _) => landingLocation,
     (null, true) => AppRoutes.login,
     (null, false) => AppRoutes.intro,
   };
   final router = createAppRouter(
     initialLocation: initialLocation,
-    authenticatedLocation: authenticatedLocation,
+    landingLocation: landingLocation,
     container: container,
   );
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -162,7 +162,8 @@ Future<void> main() async {
   await LocaleSettings.useDeviceLocale();
 
   // Initialize Remote Config and preference defaults
-  await container.read(preferencesRepositoryProvider).init();
+  final preferencesRepository = container.read(preferencesRepositoryProvider);
+  await preferencesRepository.init();
 
   // Run force-update check and wire Remote Config live updates.
   await UpdateService.init(container);
@@ -188,13 +189,17 @@ Future<void> main() async {
   // Prewarm the dependency graph before widgets subscribe. Riverpod cannot
   // invalidate its root scope while Flutter is mounting the initial frame.
   container.read(courseRepositoryProvider);
+  final authenticatedLocation = await resolveAuthenticatedLocation(
+    preferencesRepository,
+  );
   final initialLocation = switch ((user, hadStoredLogin)) {
-    (final User _, _) => AppRoutes.home,
+    (final User _, _) => authenticatedLocation,
     (null, true) => AppRoutes.login,
     (null, false) => AppRoutes.intro,
   };
   final router = createAppRouter(
     initialLocation: initialLocation,
+    authenticatedLocation: authenticatedLocation,
     container: container,
   );
 

--- a/lib/repositories/preferences_repository.dart
+++ b/lib/repositories/preferences_repository.dart
@@ -28,6 +28,9 @@ enum PrefKey<T> {
   /// Whether to use mock data instead of live NTUT services.
   demoMode<bool>(.boolean, false),
 
+  /// Whether authenticated navigation starts on the course table instead of home.
+  startWithCourseTable<bool>(.boolean, false),
+
   /// Whether the danger zone section is shown on the profile screen.
   showDangerZone<bool>(.boolean, false),
 

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -49,7 +49,7 @@ abstract class AppRoutes {
 ///
 /// Falls back to home if preferences cannot be read so a storage failure does
 /// not block app startup or a successful login.
-Future<String> resolveAuthenticatedLocation(
+Future<String> resolveLandingLocation(
   PreferencesRepository preferencesRepository,
 ) async {
   try {
@@ -93,7 +93,7 @@ const _publicRoutes = {
 /// Optional updates are surfaced as a dismissible banner instead.
 GoRouter createAppRouter({
   required String initialLocation,
-  required String authenticatedLocation,
+  required String landingLocation,
   required ProviderContainer container,
 }) => GoRouter(
   navigatorKey: rootNavigatorKey,
@@ -113,7 +113,7 @@ GoRouter createAppRouter({
     // but no update is actually available.
     if (state.matchedLocation == AppRoutes.update && updateConfig == null) {
       final hasSession = container.read(sessionProvider);
-      return hasSession ? authenticatedLocation : AppRoutes.intro;
+      return hasSession ? landingLocation : AppRoutes.intro;
     }
 
     // Auth gate: redirect unauthenticated users to login.

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:tattoo/repositories/auth_repository.dart';
+import 'package:tattoo/repositories/preferences_repository.dart';
 import 'package:tattoo/screens/main/calendar/calendar_screen.dart';
 import 'package:tattoo/screens/main/course_table/course_table_screen.dart';
 import 'package:tattoo/screens/main/home/home_screen.dart';
@@ -44,6 +45,27 @@ abstract class AppRoutes {
   static const update = '/update';
 }
 
+/// Resolves the landing route used after authentication.
+///
+/// Falls back to home if preferences cannot be read so a storage failure does
+/// not block app startup or a successful login.
+Future<String> resolveAuthenticatedLocation(
+  PreferencesRepository preferencesRepository,
+) async {
+  try {
+    final startWithCourseTable = await preferencesRepository.get(
+      PrefKey.startWithCourseTable,
+    );
+    return switch (startWithCourseTable) {
+      true => AppRoutes.courseTable,
+      false => AppRoutes.home,
+    };
+  } catch (error) {
+    debugPrint('Failed to resolve authenticated landing preference: $error');
+    return AppRoutes.home;
+  }
+}
+
 Widget _framed(Widget child) => CenteredMaxWidthFrame(child: child);
 
 /// Bridges [sessionProvider] to a [Listenable] for [GoRouter.refreshListenable].
@@ -71,6 +93,7 @@ const _publicRoutes = {
 /// Optional updates are surfaced as a dismissible banner instead.
 GoRouter createAppRouter({
   required String initialLocation,
+  required String authenticatedLocation,
   required ProviderContainer container,
 }) => GoRouter(
   navigatorKey: rootNavigatorKey,
@@ -90,7 +113,7 @@ GoRouter createAppRouter({
     // but no update is actually available.
     if (state.matchedLocation == AppRoutes.update && updateConfig == null) {
       final hasSession = container.read(sessionProvider);
-      return hasSession ? AppRoutes.home : AppRoutes.intro;
+      return hasSession ? authenticatedLocation : AppRoutes.intro;
     }
 
     // Auth gate: redirect unauthenticated users to login.

--- a/lib/screens/welcome/change_password_screen.dart
+++ b/lib/screens/welcome/change_password_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:tattoo/i18n/strings.g.dart';
+import 'package:tattoo/repositories/preferences_repository.dart';
 import 'package:tattoo/router/app_router.dart';
 import 'package:tattoo/screens/welcome/change_password_providers.dart';
 
@@ -65,7 +66,10 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
 
     if (success && mounted) {
       if (widget.isExpired) {
-        context.go(AppRoutes.home);
+        final authenticatedLocation = await resolveAuthenticatedLocation(
+          ref.read(preferencesRepositoryProvider),
+        );
+        if (mounted) context.go(authenticatedLocation);
       } else {
         context.pop();
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/welcome/change_password_screen.dart
+++ b/lib/screens/welcome/change_password_screen.dart
@@ -66,10 +66,10 @@ class _ChangePasswordScreenState extends ConsumerState<ChangePasswordScreen> {
 
     if (success && mounted) {
       if (widget.isExpired) {
-        final authenticatedLocation = await resolveAuthenticatedLocation(
+        final landingLocation = await resolveLandingLocation(
           ref.read(preferencesRepositoryProvider),
         );
-        if (mounted) context.go(authenticatedLocation);
+        if (mounted) context.go(landingLocation);
       } else {
         context.pop();
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/welcome/login_screen.dart
+++ b/lib/screens/welcome/login_screen.dart
@@ -8,6 +8,7 @@ import 'package:tattoo/i18n/strings.g.dart';
 import 'package:tattoo/models/login_exception.dart';
 import 'package:tattoo/repositories/auth_repository.dart';
 import 'package:tattoo/repositories/campus_wifi_repository.dart';
+import 'package:tattoo/repositories/preferences_repository.dart';
 import 'package:tattoo/router/app_router.dart';
 import 'package:tattoo/services/demo_mode.dart';
 import 'package:tattoo/utils/launch_url.dart';
@@ -139,7 +140,10 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           _showMessage(t.ntutWifi.provisioning.failed);
         }
       }
-      if (mounted) context.go(AppRoutes.home);
+      final authenticatedLocation = await resolveAuthenticatedLocation(
+        ref.read(preferencesRepositoryProvider),
+      );
+      if (mounted) context.go(authenticatedLocation);
     } on DioException {
       if (mounted) _setError(t.errors.connectionFailed);
     } on LoginException catch (e) {

--- a/lib/screens/welcome/login_screen.dart
+++ b/lib/screens/welcome/login_screen.dart
@@ -140,10 +140,10 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           _showMessage(t.ntutWifi.provisioning.failed);
         }
       }
-      final authenticatedLocation = await resolveAuthenticatedLocation(
+      final landingLocation = await resolveLandingLocation(
         ref.read(preferencesRepositoryProvider),
       );
-      if (mounted) context.go(authenticatedLocation);
+      if (mounted) context.go(landingLocation);
     } on DioException {
       if (mounted) _setError(t.errors.connectionFailed);
     } on LoginException catch (e) {

--- a/test/repositories/preferences_repository_test.dart
+++ b/test/repositories/preferences_repository_test.dart
@@ -13,6 +13,9 @@ void main() {
       expect(PrefKey.demoMode.type, PrefType.boolean);
       expect(PrefKey.demoMode.defaultValue, false);
 
+      expect(PrefKey.startWithCourseTable.type, PrefType.boolean);
+      expect(PrefKey.startWithCourseTable.defaultValue, false);
+
       expect(PrefKey.showDangerZone.type, PrefType.boolean);
       expect(PrefKey.showDangerZone.defaultValue, false);
 


### PR DESCRIPTION
# 支援應用程式開啟畫面自訂

## 總覽

因舊版本 App 首頁為課表，多數人比較習慣 App 一打開馬上出現課表。
所以新增一個 Preference。
尚未新增設定頁面，將在稍晚的 PR 提供。

## 修改
lib/repositories/preferences_repository.dart
- 新增「登入後預設開啟課表」的 Preference 設定。

lib/main.dart
- App 啟動時讀取 Preference，決定已登入使用者要進入首頁或課表。

lib/router/app_router.dart
- 集中處理登入後目的地解析。
- Preference 讀取失敗時回退至首頁。
- 強制更新解除後沿用設定的目的地。

lib/screens/welcome/login_screen.dart
- 登入成功後依 Preference 導向首頁或課表。

test/repositories/preferences_repository_test.dart
- 補上新增 Preference 的型別與預設值測試。