### PR TITLE
ci: disable persisted checkout credentials

### DIFF
--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup project
         uses: ./.github/actions/setup-project

--- a/.github/workflows/daily-release.yaml
+++ b/.github/workflows/daily-release.yaml
@@ -55,6 +55,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
@@ -75,6 +76,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           ref: ${{ steps.set-ref.outputs.ref }}
 
       - name: Check for changes
@@ -193,6 +195,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.target_ref }}
 
       - name: Setup project
@@ -287,6 +290,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.target_ref }}
 
       - name: Setup project

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -59,6 +59,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 
@@ -81,6 +82,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           ref: ${{ steps.set-ref.outputs.ref }}
 
       - name: Manage Build Number
@@ -152,6 +154,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.target_ref }}
 
       - name: Setup project
@@ -211,6 +214,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           ref: ${{ needs.prepare.outputs.target_ref }}
 
       - name: Setup project

--- a/.github/workflows/seed-caches.yaml
+++ b/.github/workflows/seed-caches.yaml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup project
         uses: ./.github/actions/setup-project
@@ -35,6 +37,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup project
         id: setup
@@ -74,6 +78,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup project
         id: setup


### PR DESCRIPTION
Depends on #410.

## Summary

- disable checkout credential persistence in every workflow
- keep GitHub authentication explicit through existing token inputs and environment variables

## Why

[CodeRabbit flagged persisted checkout credentials in #410](https://github.com/NTUT-NPC/tattoo/pull/410#discussion_r3943228877). The same setting exists in every workflow, so this follow-up applies the hardening consistently.

No workflow requires authenticated Git commands after checkout. Disabling credential persistence prevents later project and dependency code from using `GITHUB_TOKEN` through Git.

## Verification

- parsed all four workflow files as YAML
- confirmed all 12 checkout steps set `persist-credentials: false`
