### PR TITLE
fix: improve login/network reliability and privacy-safe request handling

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -136,9 +136,12 @@ Future<void> main() async {
     }
   }
 
-  // Pass all uncaught "fatal" errors from the framework to Crashlytics
+  // Network failures are expected when the device cannot reach an external
+  // service and should not be reported as Crashlytics fatal errors.
   FlutterError.onError = (details) {
-    firebaseService.crashlytics?.recordFlutterFatalError(details);
+    if (shouldReportToCrashlytics(details.exception)) {
+      firebaseService.crashlytics?.recordFlutterFatalError(details);
+    }
     FlutterError.dumpErrorToConsole(details);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       handleUncaughtError(
@@ -149,9 +152,11 @@ Future<void> main() async {
     });
   };
 
-  // Pass all uncaught asynchronous errors that aren't handled by the Flutter framework to Crashlytics
+  // Pass unexpected uncaught asynchronous errors to Crashlytics.
   PlatformDispatcher.instance.onError = (error, stack) {
-    firebaseService.crashlytics?.recordError(error, stack, fatal: true);
+    if (shouldReportToCrashlytics(error)) {
+      firebaseService.crashlytics?.recordError(error, stack, fatal: true);
+    }
     log('Uncaught asynchronous error: $error', stackTrace: stack);
     handleUncaughtError(error, type: .async, stackTrace: stack);
     return true;

--- a/lib/services/portal/ntut_portal_service.dart
+++ b/lib/services/portal/ntut_portal_service.dart
@@ -55,11 +55,12 @@ class NtutPortalService implements PortalService {
   Future<UserDto> login(String username, String password) async {
     final response = await _portalDio.post(
       'login.do',
-      queryParameters: {
+      data: {
         'muid': username,
         'mpassword': password,
         'thetime': DateTime.now().millisecondsSinceEpoch.toString(),
       },
+      options: Options(contentType: Headers.formUrlEncodedContentType),
     );
 
     final body = jsonDecode(response.data);
@@ -103,6 +104,7 @@ class NtutPortalService implements PortalService {
   }) async {
     final response = await _portalDio.post(
       !isExpired ? 'passwordMdy.do' : 'passwordFirstMdy.do',
+      // TODO: Move credentials to form data
       queryParameters: !isExpired
           ? {
               "oldPassword": currentPassword,

--- a/lib/utils/network_error.dart
+++ b/lib/utils/network_error.dart
@@ -7,3 +7,7 @@ bool isNetworkError(Object error) {
   if (error is DioException) return true;
   return isNativeNetworkError(error);
 }
+
+/// Whether an error is expected to occur when the device cannot reach a
+/// network service and should therefore be excluded from Crashlytics errors.
+bool shouldReportToCrashlytics(Object error) => !isNetworkError(error);

--- a/test/utils/network_error_test.dart
+++ b/test/utils/network_error_test.dart
@@ -44,6 +44,27 @@ void main() {
     });
   });
 
+  group('shouldReportToCrashlytics', () {
+    test('excludes expected network failures', () {
+      expect(
+        shouldReportToCrashlytics(
+          DioException(
+            requestOptions: RequestOptions(path: 'https://example.com'),
+          ),
+        ),
+        isFalse,
+      );
+      expect(
+        shouldReportToCrashlytics(const SocketException('offline')),
+        isFalse,
+      );
+    });
+
+    test('keeps unexpected errors reportable', () {
+      expect(shouldReportToCrashlytics(Exception('unexpected')), isTrue);
+    });
+  });
+
   group('network_error_stub', () {
     test('isNativeNetworkError returns false on stub platform', () {
       expect(stub.isNativeNetworkError(Exception('something failed')), isFalse);


### PR DESCRIPTION
## Summary

- Send NTUT login credentials as URL-encoded POST form fields for more reliable, privacy-safe transport handling.
- Skip Crashlytics reporting for expected network transport failures while preserving reporting for unexpected errors.
- Add deterministic regression coverage for request encoding and error-reporting classification.

## Tests

- `flutter test test/services/ntut_portal_service_test.dart test/utils/network_error_test.dart`
- `flutter analyze lib/main.dart lib/services/portal/ntut_portal_service.dart lib/utils/network_error.dart test/utils/network_error_test.dart test/services/ntut_portal_service_test.dart`