### PR TITLE
fix: hide redundant syllabus teacher chip

### DIFF
--- a/lib/screens/main/course_table/course_table_detail_sheet.dart
+++ b/lib/screens/main/course_table/course_table_detail_sheet.dart
@@ -601,21 +601,22 @@ class _SyllabusTabsState extends State<_SyllabusTabs>
 
     return Column(
       children: [
-        ChipTabSwitcher(
-          controller: _controller,
-          padding: const .symmetric(horizontal: 8),
-          tabs: [
-            for (final detail in widget.details)
-              (_normalizedText(
-                        localized(
-                          detail.teacher.nameZh,
-                          detail.teacher.nameEn,
-                        ),
-                      ) ??
-                      t.general.unknown)
-                  .spaced,
-          ],
-        ),
+        if (widget.details.length > 1)
+          ChipTabSwitcher(
+            controller: _controller,
+            padding: const .symmetric(horizontal: 8),
+            tabs: [
+              for (final detail in widget.details)
+                (_normalizedText(
+                          localized(
+                            detail.teacher.nameZh,
+                            detail.teacher.nameEn,
+                          ),
+                        ) ??
+                        t.general.unknown)
+                    .spaced,
+            ],
+          ),
         _SyllabusSections(detail: widget.details[_controller.index]),
       ],
     );


### PR DESCRIPTION
- Hide the syllabus teacher chip when only one teacher has submitted a syllabus
- Keep the teacher switcher available for courses with multiple submitted syllabuses
