### PR TITLE
chore: restore analyzer plugin compatibility

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,8 +7,7 @@ analyzer:
     - ios/**
 
 plugins:
-  riverpod_lint: 3.1.2
-  prefer_shorthands: 0.4.7
+  riverpod_lint: 3.1.9
 
 formatter:
   trailing_commas: preserve


### PR DESCRIPTION
## 摘要

- 移除已無法搭配目前 Dart Analysis Server 載入的 `prefer_shorthands 0.4.7`
- 將 `riverpod_lint` 從 `3.1.2` 升級至 `3.1.9`
- 讓 analyzer plugin 環境恢復正常解析與執行

## 原因

`prefer_shorthands 0.4.7` 將 `analyzer` 限制在 `<10.0.0`，並依賴 `analyzer_plugin ^0.13.10`；目前 Flutter 3.47.2／Dart 3.13.2 的 plugin host 則需要 `analysis_server_plugin ^0.3.8` 與 `analyzer_plugin 0.14.x`。因此 plugin 環境無法完成 dependency resolution，`prefer_shorthands` 與既有的 `riverpod_lint 3.1.2` 實際上都不會執行。

移除 `prefer_shorthands` 後，`riverpod_lint 3.1.9` 可與目前工具鏈解析至相容版本：

- `analysis_server_plugin 0.3.22`
- `analyzer 14.3.0`
- `analyzer_plugin 0.14.16`

本次不加入另一個 shorthand linter。Dot shorthand 屬於程式碼風格，而目前替代方案的檢查範圍皆不完整，也會再次引入與 analyzer 版本緊密耦合的 dependency。另以 `shorthand_sanitizer 0.7.0` dry run 檢查時，會改寫 51 個檔案中的 303 處並移除 6 個 import；這類大範圍風格變更不應混入本次相容性修正。

Analyzer plugins 使用獨立於專案 `pubspec.lock` 的 dependency 環境，因此不需要修改 `pubspec.yaml` 或 `pubspec.lock`。

## 驗證

- `dart analyze`
- `flutter analyze --no-pub`
