### PR TITLE
fix: open organization websites externally

### DIFF
--- a/lib/screens/main/home/home_screen.dart
+++ b/lib/screens/main/home/home_screen.dart
@@ -88,7 +88,10 @@ class _MainHomeScreenState extends ConsumerState<MainHomeScreen> {
         actionIcon: .exitToApp,
         title: t.home.projectTattoo.title.spaced,
         description: t.home.projectTattoo.description,
-        onTap: () => launchUrl(.parse(t.home.projectTattoo.url)),
+        onTap: () => launchUrl(
+          .parse(t.home.projectTattoo.url),
+          inExternalApplication: true,
+        ),
       ),
       OptionEntryTile.icon(
         icon: Icons.explore_outlined,
@@ -104,7 +107,8 @@ class _MainHomeScreenState extends ConsumerState<MainHomeScreen> {
         actionIcon: .exitToApp,
         title: t.home.npcClub.title,
         description: t.home.npcClub.description,
-        onTap: () => launchUrl(.parse(t.home.npcClub.url)),
+        onTap: () =>
+            launchUrl(.parse(t.home.npcClub.url), inExternalApplication: true),
       ),
       if (ref.pref(PrefKey.showVoteButton))
         OptionEntryTile.icon(


### PR DESCRIPTION
## 摘要

- 將首頁的 Project Tattoo 與北科程式設計研究社網站改由系統瀏覽器開啟
- 避免網站內容在 App 內瀏覽器中顯示時，被誤認為 App binary 內的原生介面或內容

## 原因

App Store 審查依據 Guideline 2.3.10 回覆：

> The app or metadata includes information about third-party platforms that may not be relevant for App Store users, who are focused on experiences offered by the app itself.
>
> Revise the app's binary to remove Google Play references.

審查截圖中的 Google Play 按鈕實際位於我們的 `ntut.app` 跨平台網站；審查者從 App 首頁開啟網站後，網站顯示在 App 內瀏覽器，因此將網站內容誤認為 App binary 內的 Google Play reference。

這次改由系統瀏覽器開啟 Project Tattoo 與北科程式設計研究社網站，明確區隔 App 原生內容與外部網站內容，同時保留網站原本提供跨平台下載資訊的用途。

## 驗證

- `flutter analyze lib/screens/main/home/home_screen.dart`
