### PR TITLE
fix: disable Firebase Analytics advertising ID collection

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
@@ -40,6 +41,9 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <meta-data
+            android:name="google_analytics_adid_collection_enabled"
+            android:value="false" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and


### PR DESCRIPTION
## Summary
- disable Firebase Analytics Advertising ID collection and remove related merged permissions
- keep Firebase Analytics app-instance identifier, device information, and usage events disclosure
- retain Crashlytics crash data disclosure in both privacy policies

Closes #401

Targeted verification: `:app:verifyReleaseManifest` could not be run because this checkout has no Gradle wrapper (`android/gradlew`) and `gradle` is not installed.